### PR TITLE
fix(match2): player icons too close to new result label in chess matchsummary

### DIFF
--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -49,12 +49,6 @@ local KING_ICONS = {
 	},
 }
 
-local PLAYER_WRAPPER_CSS = {
-	display = 'flex',
-	gap = '0.25rem',
-	flex = '1',
-}
-
 ---@param args table
 ---@return Widget
 function CustomMatchSummary.getByMatchId(args)
@@ -82,8 +76,8 @@ function CustomMatchSummary.createGame(game, gameIndex)
 			CustomMatchSummary._getHeader(game),
 
 			-- Player 1
-			Div{
-				css = PLAYER_WRAPPER_CSS,
+			MatchSummaryWidgets.GameCenter{
+				css = {flex = 1},
 				children = {
 					CustomMatchSummary._getSideIcon(game.opponents[1]),
 					MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 1},
@@ -97,8 +91,8 @@ function CustomMatchSummary.createGame(game, gameIndex)
 			},
 
 			-- Player 2
-			Div{
-				css = PLAYER_WRAPPER_CSS,
+			MatchSummaryWidgets.GameCenter{
+				css = {flex = 1},
 				children = {
 					MatchSummaryWidgets.GameTeamWrapper{flipped = true},
 					MatchSummaryWidgets.GameWinLossIndicator{winner = game.winner, opponentIndex = 2},


### PR DESCRIPTION
## Summary

reported on [Discord](https://discord.com/channels/93055209017729024/372075546231832576/1481849292963709139)

- Wraps player icons in the Chess MatchSummary in Div containers with CSS flex gap styling
- Adds proper spacing (0.25rem gap) between the side icon, win/loss indicator, and team wrapper for both players
- Fixes layout where these elements were previously adjacent without spacing

## How did you test this change?

dev