### PR TITLE
feat(notability): remove open for discussion from marvelrivals

### DIFF
--- a/lua/wikis/marvelrivals/NotabilityChecker/config.lua
+++ b/lua/wikis/marvelrivals/NotabilityChecker/config.lua
@@ -19,7 +19,7 @@ Config.MAX_NUMBER_OF_COACHES = 6
 Config.PLACEMENT_LIMIT = 2000
 
 -- These are the notability thresholds needed by a team/player
-Config.NOTABILITY_THRESHOLD_MIN = 10
+Config.NOTABILITY_THRESHOLD_MIN = 22
 Config.NOTABILITY_THRESHOLD_NOTABLE = 22
 
 -- Weights used for tournaments


### PR DESCRIPTION
## Summary

"Open for Discussion" was never used on marvel rivals for notability and leads to confusion. Setting the min_threshold to the same as the actual value gets rid of that.
Was discussed with contributors in discord.

## How did you test this change?
trivial and same as #7061 