### PR TITLE
feat(BroadcastTalentTable): don't error on missing tournament data

### DIFF
--- a/lua/wikis/commons/BroadcastTalentTable.lua
+++ b/lua/wikis/commons/BroadcastTalentTable.lua
@@ -302,10 +302,14 @@ end
 
 ---@private
 ---@param broadcast EnrichedBroadcast
----@return Widget
+---@return Widget?
 function BroadcastTalentTable:_row(broadcast)
 	local tournament = Tournament.getTournament(broadcast.parent)
-	---@cast tournament -nil
+	if not tournament then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with invalid parent in queried broadcast events')
+		mw.logObject(broadcast, 'broadcasterEntryWithIssues')
+		return
+	end
 
 	local tierDisplay = Tier.display(tournament.liquipediaTier, tournament.liquipediaTierType, Table.merge(
 		tournament.tierOptions,


### PR DESCRIPTION
## Summary
currently BroadcastTalentTable just errors completely if a lpdb_broadcast object is found that does not have a valid parent

this PR makes it so that instead of throwing entirely it just logs the problematic object, sets a category and does not display the row

this allows for easier cleanup of such cases while at the same time not having the entire table error

## How did you test this change?
dev