### PR TITLE
ci: bump stefanzweifel/git-auto-commit-action to v7

### DIFF
--- a/.github/workflows/update visual snapshots.yml
+++ b/.github/workflows/update visual snapshots.yml
@@ -48,7 +48,7 @@ jobs:
           UPDATE_SNAPSHOTS: true
 
       - name: Commit and push if snapshots changed
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: update visual snapshots"
           file_pattern: 'lua/spec/snapshots/*.png'


### PR DESCRIPTION
## Summary

Context: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

Part of #7258
