### PR TITLE
fix(info): Update AoV logo to use newer logo

### DIFF
--- a/lua/wikis/honorofkings/Info.lua
+++ b/lua/wikis/honorofkings/Info.lua
@@ -17,12 +17,12 @@ return {
 			name = 'Arena of Valor',
 			link = 'Arena of Valor',
 			logo = {
-				darkMode = 'Arena of Valor 2022 lightmode.png',
-				lightMode = 'Arena of Valor 2022 darkmode.png',
+				darkMode = 'Arena of Valor 2022 darkmode.png',
+				lightMode = 'Arena of Valor 2022 lightmode.png',
 			},
 			defaultTeamLogo = {
-				darkMode = 'Arena of Valor 2022 lightmode.png',
-				lightMode = 'Arena of Valor 2022 darkmode.png',
+				darkMode = 'Arena of Valor 2022 darkmode.png',
+				lightMode = 'Arena of Valor 2022 lightmode.png',
 			},
 		},
 		aovas = {


### PR DESCRIPTION
## Summary
Not updated since 2022 and uncaught till recently

## How did you test this change?
Trivial