### PR TITLE
fix: build-js.js broken after recent javascript module changes

### DIFF
--- a/build-js.js
+++ b/build-js.js
@@ -54,7 +54,15 @@ async function build() {
 		const processedMainContent = removeOriginalCode( mainJsContent );
 
 		const warningMessage = "console.warn('Browser is using locally compiled JavaScript, and cannot be fully trusted to match the production counterpart.')";
-		const finalContent = warningMessage + processedMainContent + '\n\n' + concatenatedModules;
+		// Expose liquipedia on window so the dev proxy can detect and re-initialize modules.
+		// Core.js uses `const liquipedia` (correct for production), but `const` is not
+		// accessible as window.liquipedia, which the dev proxy requires.
+		const exposeOnWindow = 'window.liquipedia = liquipedia;';
+		const concatenatedModulesWithExpose = concatenatedModules.replace(
+			/(const liquipedia\s*=\s*(?:window\.liquipedia\s*\|\|\s*)?\{[^}]*\};)/,
+			`$1\n${ exposeOnWindow }`
+		);
+		const finalContent = warningMessage + processedMainContent + '\n\n' + concatenatedModulesWithExpose;
 
 		await fs.mkdir( path.dirname( outFile ), { recursive: true } );
 		await fs.writeFile( outFile, finalContent );


### PR DESCRIPTION
## Summary

#7233 broke the build-js.js implementation. This fixes that so the local setup continues to work.

context: #7201

## How did you test this change?

local setup