### PR TITLE
feat(InGameRoles): adjust role for Free Fire

### DIFF
--- a/lua/wikis/freefire/InGameRoles.lua
+++ b/lua/wikis/freefire/InGameRoles.lua
@@ -10,9 +10,11 @@ local inGameRoles = {
 	['support'] = {category = 'Support players', display = 'Support'},
 	['rusher'] = {category = 'Rusher', display = 'Rusher'},
 	['sniper'] = {category = 'Snipers', display = 'Snipers'},
-	['granader'] = {category = 'Granader', display = 'Granader'},
+	['bomber'] = {category = 'Bomber', display = 'Bomber'},
 	['igl'] = {category = 'In-game leaders', display = 'In-game leaders'},
 	['captain'] = {category = 'Captain', display = 'Captain'},
 }
+
+inGameRoles['granader'] = inGameRoles.bomber
 
 return inGameRoles


### PR DESCRIPTION
## Summary
Granader wasnt the actual role naming and I had no idea why it was that way, Bomber is the actual correct name

Redirect added to

## How did you test this change?
dev