### PR TITLE
feat: add a new Region in Filter Buttons of Valorant wiki

### DIFF
--- a/lua/wikis/valorant/FilterButtons/Config.lua
+++ b/lua/wikis/valorant/FilterButtons/Config.lua
@@ -22,6 +22,7 @@ local REGION_TO_SUPERREGION = {
 	['CIS'] = 'EMEA',
 	['Levant'] = 'EMEA',
 	['Africa'] = 'EMEA',
+	['North Africa'] = 'EMEA',
 	['Korea'] = 'Pacific',
 	['China'] = 'CN',
 	['North America'] = 'Americas',


### PR DESCRIPTION
## Summary

Some tournaments are located in North Africa but it doesn't appear in the matches ticker and so the matches are updated, this change will fix it.

## How did you test this change?

N/A
