### PR TITLE
fix(match2): broken team stats header alignment in lol/val matchpages

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -152,6 +152,7 @@ function MatchPage:renderOverallStats()
 							},
 							Div{
 								classes = {'match-bm-team-stats-list-cell'},
+								css = {flex = 1},
 								children = self:getTournamentIcon()
 							},
 							Div{
@@ -553,6 +554,7 @@ function MatchPage:_renderTeamStats(game)
 						},
 						Div{
 							classes = {'match-bm-team-stats-list-cell'},
+							css = {flex = 1},
 							children = self:isBestOfOne() and self:_buildGameResultSummary(game) or self:getTournamentIcon()
 						},
 						Div{

--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -324,6 +324,7 @@ function MatchPage:_renderTeamStats(game)
 						},
 						Div{
 							classes = {'match-bm-team-stats-list-cell'},
+							css = {flex = 1},
 							children = self:getTournamentIcon()
 						},
 						Div{


### PR DESCRIPTION
## Summary

regression from #7257

## How did you test this change?

browser dev tools