### PR TITLE
disable region cell in marvelrivals player infobox

### DIFF
--- a/lua/wikis/marvelrivals/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Person/Player/Custom.lua
@@ -60,8 +60,9 @@ function CustomInjector:parse(id, widgets)
 				children = {table.concat(heroIcons, '&nbsp;')},
 			}
 		)
+	elseif id == 'region' then
+		return {}
 	end
-
 	return widgets
 end
 


### PR DESCRIPTION
## Summary
Disabled region cell in player infobox, as it is redundant due to being wrong in many cases, and can cause limitations in ordering player nationalities. Most contributors have agreed with this change: https://discord.com/channels/93055209017729024/1316071697555914804/1483759173702258840

## How did you test this change?
dev
