### PR TITLE
fix(match2): missing no kill participation handling in lol matchpage

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -638,7 +638,7 @@ function MatchPage:_renderPlayerPerformance(game, teamIndex, player)
 					},
 					PlayerStat{
 						title = {KP_ICON, 'KP%'},
-						data = MathUtil.formatPercentage(player.killparticipation, 1)
+						data = player.killparticipation and MathUtil.formatPercentage(player.killparticipation, 1) or '-'
 					},
 					PlayerStat{
 						title = {


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/f973f303dce3e354f626775df0209ff299f3b080/lua/wikis/leagueoflegends/MatchGroup/Input/Custom/MatchPage.lua#L86-L89

LoL match2 parser skips calculation of kill participation if the team made 0 kills in total to avoid division by zero. This case is uncaught and matchpage attempts to perform `formatPercentage` with `nil`, resulting in an error.

This PR fixes the error described above by adding a nil check for `killparticipation`.

## How did you test this change?

live