### PR TITLE
feat(TeamParticipants): enable player team sync on fighters by default

### DIFF
--- a/lua/wikis/fighters/Info.lua
+++ b/lua/wikis/fighters/Info.lua
@@ -1967,5 +1967,8 @@ return {
 				storeFromWikiCode = true,
 			},
 		},
+		participants = {
+			syncPlayerTeam = true,
+		},
 	},
 }


### PR DESCRIPTION
## Summary
requested on discord: https://discord.com/channels/93055209017729024/268719633366777856/1484311297297350778

## How did you test this change?
N/A, just a setting change that already works on aoe