### PR TITLE
refactor(match2): move subgroup grouping logic to commons

### DIFF
--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -33,6 +33,7 @@ games, and etc in the new bracket framework.
 
 Display related functions go in Module:MatchGroup/Display/Helper.
 ]]
+---@class MatchGroupUtil
 local MatchGroupUtil = {types = {}}
 
 ---@class MatchGroupUtilLowerEdge

--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -777,7 +777,7 @@ end
 ---Group games on the subgroup field to form submatches
 ---@param matchGames MatchGroupUtilGame[]
 ---@return MatchGroupUtilSubgroup[]
-function MatchGroupUtil.groupBySubmatch(matchGames)
+function MatchGroupUtil.groupBySubgroup(matchGames)
 	local previousSubgroup = nil
 	---@type MatchGroupUtilGame[]?
 	local currentGames = nil

--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -325,6 +325,9 @@ MatchGroupUtil.types.Match = TypeUtil.struct({
 	extradata = 'table?',
 })
 
+---@class MatchGroupUtilSubgroup
+---@field games MatchGroupUtilGame[]
+---@field subgroup number
 
 ---@class FFAMatchGroupUtilMatch: MatchGroupUtilMatch
 ---@field games FFAMatchGroupUtilGame[]
@@ -769,6 +772,33 @@ function MatchGroupUtil.gameFromRecord(record, opponentCount)
 		walkover = nilIfEmpty(record.walkover) and record.walkover:lower() or nil,
 		winner = tonumber(record.winner),
 	}
+end
+
+---Group games on the subgroup field to form submatches
+---@param matchGames MatchGroupUtilGame[]
+---@return MatchGroupUtilSubgroup[]
+function MatchGroupUtil.groupBySubmatch(matchGames)
+	local previousSubgroup = nil
+	---@type MatchGroupUtilGame[]?
+	local currentGames = nil
+	---@type MatchGroupUtilGame[][]
+	local submatchGames = {}
+	Array.forEach(matchGames, function (game)
+		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
+			currentGames = {}
+			Array.appendWith(submatchGames, currentGames)
+			previousSubgroup = game.subgroup
+		end
+		---@cast currentGames -nil
+		Array.appendWith(currentGames, game)
+	end)
+	return Array.map(submatchGames, function (games, groupIndex)
+		---@type MatchGroupUtilSubgroup
+		return {
+			games = games,
+			subgroup = groupIndex
+		}
+	end)
 end
 
 ---@param data table

--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -329,6 +329,7 @@ MatchGroupUtil.types.Match = TypeUtil.struct({
 ---@class MatchGroupUtilSubgroup
 ---@field games MatchGroupUtilGame[]
 ---@field subgroup number
+---@field header string?
 
 ---@class FFAMatchGroupUtilMatch: MatchGroupUtilMatch
 ---@field games FFAMatchGroupUtilGame[]
@@ -776,15 +777,15 @@ function MatchGroupUtil.gameFromRecord(record, opponentCount)
 end
 
 ---Group games on the subgroup field to form submatches
----@param matchGames MatchGroupUtilGame[]
+---@param match MatchGroupUtilMatch
 ---@return MatchGroupUtilSubgroup[]
-function MatchGroupUtil.groupBySubgroup(matchGames)
+function MatchGroupUtil.groupBySubgroup(match)
 	local previousSubgroup = nil
 	---@type MatchGroupUtilGame[]?
 	local currentGames = nil
 	---@type MatchGroupUtilGame[][]
 	local submatchGames = {}
-	Array.forEach(matchGames, function (game)
+	Array.forEach(match.games, function (game)
 		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
 			currentGames = {}
 			Array.appendWith(submatchGames, currentGames)
@@ -797,7 +798,8 @@ function MatchGroupUtil.groupBySubgroup(matchGames)
 		---@type MatchGroupUtilSubgroup
 		return {
 			games = games,
-			subgroup = groupIndex
+			subgroup = groupIndex,
+			header = Table.extract(match.extradata or {}, 'subgroup' .. groupIndex .. 'header'),
 		}
 	end)
 end

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -23,6 +23,7 @@ local Opponent = Lua.import('Module:Opponent/Custom')
 local SCORE_STATUS = MatchGroupInputUtil.STATUS.SCORE
 
 --Utility functions for match group related things specific to the starcraft and starcraft2 wikis.
+---@class StarcraftMatchGroupUtil: MatchGroupUtil
 local StarcraftMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 
 ---@class StarcraftMatchGroupUtilGameOpponent:GameOpponent

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Faction = Lua.import('Module:Faction')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local String = Lua.import('Module:StringUtils')
@@ -40,12 +41,11 @@ local StarcraftMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@field map string
 ---@field displayName string?
 
----@class StarcraftMatchGroupUtilSubmatch
+---@class StarcraftMatchGroupUtilSubmatch: MatchGroupUtilSubgroup
 ---@field games StarcraftMatchGroupUtilGame[]
 ---@field mode string
 ---@field status string?
 ---@field opponents StarcraftMatchGroupUtilGameOpponent[]
----@field subgroup number
 ---@field winner number?
 ---@field header string?
 
@@ -83,7 +83,7 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 		-- Compute submatches
 		match.submatches = Array.map(
 			StarcraftMatchGroupUtil.groupBySubmatch(match.games),
-			function(games) return StarcraftMatchGroupUtil.constructSubmatch(games, match) end
+			FnUtil.curry(StarcraftMatchGroupUtil.constructSubmatch, match)
 		)
 	end
 
@@ -160,31 +160,12 @@ function StarcraftMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 	end)
 end
 
----Group games on the subgroup field to form submatches
----@param matchGames StarcraftMatchGroupUtilGame[]
----@return StarcraftMatchGroupUtilGame[][]
-function StarcraftMatchGroupUtil.groupBySubmatch(matchGames)
-	-- Group games on adjacent subgroups
-	local previousSubgroup = nil
-	local currentGames = nil
-	local submatchGames = {}
-	for _, game in ipairs(matchGames) do
-		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
-			currentGames = {}
-			table.insert(submatchGames, currentGames)
-			previousSubgroup = game.subgroup
-		end
-		---@cast currentGames -nil
-		table.insert(currentGames, game)
-	end
-	return submatchGames
-end
-
 ---Constructs a submatch object whose properties are aggregated from that of its games.
----@param games StarcraftMatchGroupUtilGame[]
 ---@param match StarcraftMatchGroupUtilMatch
+---@param subgroup MatchGroupUtilSubgroup
 ---@return StarcraftMatchGroupUtilSubmatch
-function StarcraftMatchGroupUtil.constructSubmatch(games, match)
+function StarcraftMatchGroupUtil.constructSubmatch(match, subgroup)
+	local games = subgroup.games
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
 	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
@@ -228,14 +209,12 @@ function StarcraftMatchGroupUtil.constructSubmatch(games, match)
 		opponent.placement = MatchGroupInputUtil.placementFromWinner('', winner, opponentIndex)
 	end)
 
-	return {
-		games = games,
+	return Table.mergeInto({
 		mode = firstGame.mode,
 		opponents = opponents,
-		subgroup = firstGame.subgroup,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. firstGame.subgroup .. 'header'),
-	}
+		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
+	}, subgroup)
 end
 
 ---Determine if a match has details that should be displayed via popup

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -82,7 +82,7 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 	if match.opponentMode == 'team' then
 		-- Compute submatches
 		match.submatches = Array.map(
-			StarcraftMatchGroupUtil.groupBySubmatch(match.games),
+			MatchGroupUtil.groupBySubgroup(match.games),
 			FnUtil.curry(StarcraftMatchGroupUtil.constructSubmatch, match)
 		)
 	end

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -48,7 +48,6 @@ local StarcraftMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@field status string?
 ---@field opponents StarcraftMatchGroupUtilGameOpponent[]
 ---@field winner number?
----@field header string?
 
 ---@class StarcraftMatchGroupUtilMatch: MatchGroupUtilMatch
 ---@field games StarcraftMatchGroupUtilGame[]
@@ -83,7 +82,7 @@ function StarcraftMatchGroupUtil.matchFromRecord(record)
 	if match.opponentMode == 'team' then
 		-- Compute submatches
 		match.submatches = Array.map(
-			MatchGroupUtil.groupBySubgroup(match.games),
+			MatchGroupUtil.groupBySubgroup(match),
 			FnUtil.curry(StarcraftMatchGroupUtil.constructSubmatch, match)
 		)
 	end
@@ -214,7 +213,6 @@ function StarcraftMatchGroupUtil.constructSubmatch(match, subgroup)
 		mode = firstGame.mode,
 		opponents = opponents,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
 	}, subgroup)
 end
 

--- a/lua/wikis/commons/MatchSummary/Starcraft.lua
+++ b/lua/wikis/commons/MatchSummary/Starcraft.lua
@@ -17,7 +17,7 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
-local MatchGroupUtilStarcraft = Lua.import('Module:MatchGroup/Util/Custom')
+local MatchGroupUtilStarcraft = Lua.import('Module:MatchGroup/Util/Custom') --[[@as StarcraftMatchGroupUtil]]
 local VetoLabel = Lua.import('Module:Widget/Match/Summary/VetoLabel')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
@@ -32,7 +32,7 @@ local TBD = 'TBD'
 local StarcraftMatchSummary = {}
 
 ---@param args {bracketId: string, matchId: string, config: table?}
----@return Html
+---@return Renderable
 function StarcraftMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(StarcraftMatchSummary, args, {width = '380px'})
 end
@@ -205,7 +205,7 @@ function StarcraftMatchSummary.TeamSubMatchOpponnetRow(submatch)
 		}
 	end
 
-	---@param opponentIndex any
+	---@param opponentIndex integer
 	---@param additionalClasses string[]?
 	---@return Widget
 	local createScore = function(opponentIndex, additionalClasses)

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -20,6 +20,7 @@ local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SCORE_STATUS = 'S'
 
+---@class HearthstoneMatchGroupUtil: MatchGroupUtil
 local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 
 ---@class HearthstoneMatchGroupUtilGameOpponent: GameOpponent

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local Table = Lua.import('Module:Table')
@@ -24,10 +25,8 @@ local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@class HearthstoneMatchGroupUtilGameOpponent: GameOpponent
 ---@field placement number?
 
----@class HearthstoneMatchGroupUtilSubmatch
----@field games MatchGroupUtilGame[]
+---@class HearthstoneMatchGroupUtilSubmatch: MatchGroupUtilSubgroup
 ---@field opponents HearthstoneMatchGroupUtilGameOpponent[]
----@field subgroup number
 ---@field winner number?
 ---@field header string?
 
@@ -35,7 +34,7 @@ local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@field submatches HearthstoneMatchGroupUtilSubmatch[]?
 ---@field isTeamMatch boolean
 
----@param record table
+---@param record match2
 ---@return HearthstoneMatchGroupUtilMatch
 function CustomMatchGroupUtil.matchFromRecord(record)
 	local match = MatchGroupUtil.matchFromRecord(record) --[[@as HearthstoneMatchGroupUtilMatch]]
@@ -55,15 +54,9 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 
 	-- Compute submatches
 	match.submatches = Array.map(
-		CustomMatchGroupUtil.groupBySubmatch(match.games),
-		function(games) return CustomMatchGroupUtil.constructSubmatch(games) end
+		MatchGroupUtil.groupBySubmatch(match.games),
+		FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 	)
-
-	local extradata = match.extradata
-	---@cast extradata table
-	Array.forEach(match.submatches, function (submatch)
-		submatch.header = Table.extract(extradata, 'subgroup' .. submatch.subgroup .. 'header')
-	end)
 
 	return match
 end
@@ -82,30 +75,12 @@ function CustomMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 	end)
 end
 
----Group games on the subgroup field to form submatches
----@param matchGames MatchGroupUtilGame[]
----@return MatchGroupUtilGame[][]
-function CustomMatchGroupUtil.groupBySubmatch(matchGames)
-	-- Group games on adjacent subgroups
-	local previousSubgroup = nil
-	local currentGames = nil
-	local submatchGames = {}
-	Array.forEach(matchGames, function (game)
-		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
-			currentGames = {}
-			table.insert(submatchGames, currentGames)
-			previousSubgroup = game.subgroup
-		end
-		---@cast currentGames -nil
-		table.insert(currentGames, game)
-	end)
-	return submatchGames
-end
-
 ---Constructs a submatch object whose properties are aggregated from that of its games.
----@param games MatchGroupUtilGame[]
+---@param match HearthstoneMatchGroupUtilMatch
+---@param subgroup MatchGroupUtilSubgroup
 ---@return HearthstoneMatchGroupUtilSubmatch
-function CustomMatchGroupUtil.constructSubmatch(games)
+function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
+	local games = subgroup.games
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
 	local isSubmatch = string.find(firstGame.map or '', '^[sS]ubmatch %d+$')
@@ -133,12 +108,13 @@ function CustomMatchGroupUtil.constructSubmatch(games)
 		opponent.placement = MatchGroupInputUtil.placementFromWinner('', winner, opponentIndex)
 	end)
 
-	return {
-		games = games,
+	local matchExtradata = match.extradata or {}
+
+	return Table.mergeInto({
+		header = Table.extract(matchExtradata, 'subgroup' .. subgroup.subgroup .. 'header'),
 		opponents = opponents,
-		subgroup = firstGame.subgroup,
 		winner = winner,
-	}
+	}, subgroup)
 end
 
 return CustomMatchGroupUtil

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -54,7 +54,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 
 	-- Compute submatches
 	match.submatches = Array.map(
-		MatchGroupUtil.groupBySubmatch(match.games),
+		MatchGroupUtil.groupBySubgroup(match.games),
 		FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 	)
 

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -108,8 +108,6 @@ function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
 		opponent.placement = MatchGroupInputUtil.placementFromWinner('', winner, opponentIndex)
 	end)
 
-	local matchExtradata = match.extradata or {}
-
 	return Table.mergeInto({
 		opponents = opponents,
 		winner = winner,

--- a/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/hearthstone/MatchGroup/Util/Custom.lua
@@ -29,7 +29,6 @@ local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@class HearthstoneMatchGroupUtilSubmatch: MatchGroupUtilSubgroup
 ---@field opponents HearthstoneMatchGroupUtilGameOpponent[]
 ---@field winner number?
----@field header string?
 
 ---@class HearthstoneMatchGroupUtilMatch: MatchGroupUtilMatch
 ---@field submatches HearthstoneMatchGroupUtilSubmatch[]?
@@ -55,7 +54,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 
 	-- Compute submatches
 	match.submatches = Array.map(
-		MatchGroupUtil.groupBySubgroup(match.games),
+		MatchGroupUtil.groupBySubgroup(match),
 		FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 	)
 
@@ -112,7 +111,6 @@ function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
 	local matchExtradata = match.extradata or {}
 
 	return Table.mergeInto({
-		header = Table.extract(matchExtradata, 'subgroup' .. subgroup.subgroup .. 'header'),
 		opponents = opponents,
 		winner = winner,
 	}, subgroup)

--- a/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Faction = Lua.import('Module:Faction')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local String = Lua.import('Module:StringUtils')
@@ -37,10 +38,11 @@ CustomMatchGroupUtil.types.Player = TypeUtil.extendStruct(MatchGroupUtil.types.P
 ---@field position integer
 ---@field random boolean
 
----@class StormgateMatchGroupUtilGameOpponent:GameOpponent
+---@class StormgateMatchGroupUtilGameOpponent: GameOpponent
 ---@field placement number?
 ---@field players StormgateMatchGroupUtilGamePlayer[]
 ---@field score number?
+
 CustomMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 	placement = 'number?',
 	players = TypeUtil.array(CustomMatchGroupUtil.types.Player),
@@ -55,12 +57,11 @@ CustomMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 ---@field by number?
 ---@field map string
 
----@class StormgateMatchGroupUtilSubmatch
+---@class StormgateMatchGroupUtilSubmatch: MatchGroupUtilSubgroup
 ---@field games StormgateMatchGroupUtilGame[]
 ---@field mode string
 ---@field opponents StormgateMatchGroupUtilGameOpponent[]
 ---@field status string?
----@field subgroup number
 ---@field winner number?
 ---@field header string?
 
@@ -91,8 +92,8 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if not match.isUniformMode then
 		-- Compute submatches
 		match.submatches = Array.map(
-			CustomMatchGroupUtil.groupBySubmatch(match.games),
-			function(games) return CustomMatchGroupUtil.constructSubmatch(games, match) end
+			MatchGroupUtil.groupBySubmatch(match.games),
+			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end
 
@@ -152,31 +153,12 @@ function CustomMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 	end)
 end
 
----Group games on the subgroup field to form submatches
----@param matchGames StormgateMatchGroupUtilGame[]
----@return StormgateMatchGroupUtilGame[][]
-function CustomMatchGroupUtil.groupBySubmatch(matchGames)
-	-- Group games on adjacent subgroups
-	local previousSubgroup = nil
-	local currentGames = nil
-	local submatchGames = {}
-	for _, game in ipairs(matchGames) do
-		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
-			currentGames = {}
-			table.insert(submatchGames, currentGames)
-			previousSubgroup = game.subgroup
-		end
-		---@cast currentGames -nil
-		table.insert(currentGames, game)
-	end
-	return submatchGames
-end
-
 ---Constructs a submatch object whose properties are aggregated from that of its games.
----@param games StormgateMatchGroupUtilGame[]
 ---@param match StormgateMatchGroupUtilMatch
+---@param subgroup MatchGroupUtilSubgroup
 ---@return StormgateMatchGroupUtilSubmatch
-function CustomMatchGroupUtil.constructSubmatch(games, match)
+function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
+	local games = subgroup.games
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
 	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
@@ -214,14 +196,12 @@ function CustomMatchGroupUtil.constructSubmatch(games, match)
 		CustomMatchGroupUtil._determineSubmatchPlayerFactions(match, games, opponents, opponentIndex)
 	end)
 
-	return {
-		games = games,
+	return Table.mergeInto({
 		mode = firstGame.mode,
 		opponents = opponents,
-		subgroup = firstGame.subgroup,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. firstGame.subgroup .. 'header'),
-	}
+		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
+	}, subgroup)
 end
 
 ---@param match StormgateMatchGroupUtilMatch

--- a/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
@@ -22,6 +22,7 @@ local Opponent = Lua.import('Module:Opponent/Custom')
 
 local SCORE_STATUS = 'S'
 
+---@class StormgateMatchGroupUtil: MatchGroupUtil
 local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 
 CustomMatchGroupUtil.types.Faction = TypeUtil.literalUnion(unpack(Faction.getFactions()))

--- a/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
@@ -92,7 +92,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if not match.isUniformMode then
 		-- Compute submatches
 		match.submatches = Array.map(
-			MatchGroupUtil.groupBySubmatch(match.games),
+			MatchGroupUtil.groupBySubgroup(match.games),
 			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end

--- a/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/stormgate/MatchGroup/Util/Custom.lua
@@ -64,7 +64,6 @@ CustomMatchGroupUtil.types.GameOpponent = TypeUtil.struct({
 ---@field opponents StormgateMatchGroupUtilGameOpponent[]
 ---@field status string?
 ---@field winner number?
----@field header string?
 
 ---@class StormgateMatchGroupUtilMatch: MatchGroupUtilMatch
 ---@field games StormgateMatchGroupUtilGame[]
@@ -93,7 +92,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if not match.isUniformMode then
 		-- Compute submatches
 		match.submatches = Array.map(
-			MatchGroupUtil.groupBySubgroup(match.games),
+			MatchGroupUtil.groupBySubgroup(match),
 			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end
@@ -201,7 +200,6 @@ function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
 		mode = firstGame.mode,
 		opponents = opponents,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
 	}, subgroup)
 end
 

--- a/lua/wikis/stormgate/MatchSummary.lua
+++ b/lua/wikis/stormgate/MatchSummary.lua
@@ -33,12 +33,12 @@ local DEFAULT_HERO = 'default'
 local CustomMatchSummary = {}
 
 ---@param args {bracketId: string, matchId: string, config: table?}
----@return Html
+---@return Renderable
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match table
+---@param match StormgateMatchGroupUtilMatch
 ---@return Widget[]
 function CustomMatchSummary.createBody(match)
 	CustomMatchSummary.computeOfffactions(match)
@@ -197,7 +197,7 @@ function CustomMatchSummary.DisplayHeroes(opponent, options)
 	}
 end
 
----@param submatch table
+---@param submatch StormgateMatchGroupUtilSubmatch
 ---@return MatchSummaryRow
 function CustomMatchSummary.TeamSubmatch(submatch)
 	return MatchSummaryWidgets.Row{
@@ -225,7 +225,7 @@ function CustomMatchSummary.TeamSubMatchOpponnetRow(submatch)
 		}
 	end
 
-	---@param opponentIndex any
+	---@param opponentIndex integer
 	---@param additionalClasses string[]?
 	---@return Widget
 	local createScore = function(opponentIndex, additionalClasses)
@@ -258,7 +258,7 @@ function CustomMatchSummary.TeamSubMatchOpponnetRow(submatch)
 	}
 end
 
----@param submatch StarcraftMatchGroupUtilSubmatch
+---@param submatch StormgateMatchGroupUtilSubmatch
 ---@return Widget?
 function CustomMatchSummary.TeamSubMatchGames(submatch)
 	if not CustomMatchSummary._submatchHasDetails(submatch) then return nil end
@@ -286,7 +286,7 @@ function CustomMatchSummary.TeamSubMatchGames(submatch)
 	}
 end
 
----@param submatch table
+---@param submatch StormgateMatchGroupUtilSubmatch
 ---@return boolean
 function CustomMatchSummary._submatchHasDetails(submatch)
 	return #submatch.games > 0 and Array.any(submatch.games, function(game)

--- a/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
@@ -83,7 +83,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if match.opponentMode == TEAM_DISPLAY_MODE then
 		-- Compute submatches
 		match.submatches = Array.map(
-			MatchGroupUtil.groupBySubmatch(match.games),
+			MatchGroupUtil.groupBySubgroup(match.games),
 			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end

--- a/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
@@ -24,6 +24,7 @@ local TEAM_DISPLAY_MODE = 'team'
 local UNIFORM_DISPLAY_MODE = 'uniform'
 local SCORE_STATUS = MatchGroupInputUtil.STATUS.SCORE
 
+---@class WarcraftMatchGroupUtil: MatchGroupUtil
 local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 
 ---@class WarcraftMatchGroupUtilGamePlayer: standardPlayer

--- a/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Faction = Lua.import('Module:Faction')
+local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local String = Lua.import('Module:StringUtils')
@@ -44,12 +45,11 @@ local CustomMatchGroupUtil = Table.deepCopy(MatchGroupUtil)
 ---@field by number?
 ---@field map string
 
----@class WarcraftMatchGroupUtilSubmatch
+---@class WarcraftMatchGroupUtilSubmatch: MatchGroupUtilSubgroup
 ---@field games WarcraftMatchGroupUtilGame[]
 ---@field mode string
 ---@field opponents WarcraftMatchGroupUtilGameOpponent[]
 ---@field status string?
----@field subgroup number
 ---@field winner number?
 ---@field header string?
 
@@ -83,8 +83,8 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if match.opponentMode == TEAM_DISPLAY_MODE then
 		-- Compute submatches
 		match.submatches = Array.map(
-			CustomMatchGroupUtil.groupBySubmatch(match.games),
-			function(games) return CustomMatchGroupUtil.constructSubmatch(games, match) end
+			MatchGroupUtil.groupBySubmatch(match.games),
+			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end
 
@@ -145,31 +145,12 @@ function CustomMatchGroupUtil.computeGameOpponents(game, matchOpponents)
 	end)
 end
 
----Group games on the subgroup field to form submatches
----@param matchGames WarcraftMatchGroupUtilGame[]
----@return WarcraftMatchGroupUtilGame[][]
-function CustomMatchGroupUtil.groupBySubmatch(matchGames)
-	-- Group games on adjacent subgroups
-	local previousSubgroup = nil
-	local currentGames = nil
-	local submatchGames = {}
-	for _, game in ipairs(matchGames) do
-		if previousSubgroup == nil or previousSubgroup ~= game.subgroup then
-			currentGames = {}
-			table.insert(submatchGames, currentGames)
-			previousSubgroup = game.subgroup
-		end
-		---@cast currentGames -nil
-		table.insert(currentGames, game)
-	end
-	return submatchGames
-end
-
 ---Constructs a submatch object whose properties are aggregated from that of its games.
----@param games WarcraftMatchGroupUtilGame[]
 ---@param match WarcraftMatchGroupUtilMatch
+---@param subgroup MatchGroupUtilSubgroup
 ---@return WarcraftMatchGroupUtilSubmatch
-function CustomMatchGroupUtil.constructSubmatch(games, match)
+function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
+	local games = subgroup.games
 	local firstGame = games[1]
 	local opponents = Table.deepCopy(firstGame.opponents)
 	local isSubmatch = String.startsWith(firstGame.map or '', 'Submatch')
@@ -204,14 +185,12 @@ function CustomMatchGroupUtil.constructSubmatch(games, match)
 		CustomMatchGroupUtil._determineSubmatchPlayerFactions(match, games, opponents, opponentIndex)
 	end)
 
-	return {
-		games = games,
+	return Table.mergeInto({
 		mode = firstGame.mode,
 		opponents = opponents,
-		subgroup = firstGame.subgroup,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. firstGame.subgroup .. 'header'),
-	}
+		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
+	}, subgroup)
 end
 
 ---@param match WarcraftMatchGroupUtilMatch

--- a/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Util/Custom.lua
@@ -84,7 +84,7 @@ function CustomMatchGroupUtil.matchFromRecord(record)
 	if match.opponentMode == TEAM_DISPLAY_MODE then
 		-- Compute submatches
 		match.submatches = Array.map(
-			MatchGroupUtil.groupBySubgroup(match.games),
+			MatchGroupUtil.groupBySubgroup(match),
 			FnUtil.curry(CustomMatchGroupUtil.constructSubmatch, match)
 		)
 	end
@@ -190,7 +190,6 @@ function CustomMatchGroupUtil.constructSubmatch(match, subgroup)
 		mode = firstGame.mode,
 		opponents = opponents,
 		winner = winner,
-		header = Table.extract(match.extradata or {}, 'subgroup' .. subgroup.subgroup .. 'header'),
 	}, subgroup)
 end
 

--- a/lua/wikis/warcraft/MatchSummary.lua
+++ b/lua/wikis/warcraft/MatchSummary.lua
@@ -34,12 +34,12 @@ local DEFAULT_HERO = 'default'
 local CustomMatchSummary = {}
 
 ---@param args {bracketId: string, matchId: string, config: table?}
----@return Html
+---@return Renderable
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
----@param match table
+---@param match WarcraftMatchGroupUtilMatch
 ---@return Widget[]
 function CustomMatchSummary.createBody(match)
 	CustomMatchSummary.computeOfffactions(match)
@@ -194,7 +194,7 @@ function CustomMatchSummary.DisplayHeroes(opponent, options)
 	}
 end
 
----@param submatch table
+---@param submatch WarcraftMatchGroupUtilSubmatch
 ---@return MatchSummaryRow
 function CustomMatchSummary.TeamSubmatch(submatch)
 	return MatchSummaryWidgets.Row{
@@ -222,7 +222,7 @@ function CustomMatchSummary.TeamSubMatchOpponnetRow(submatch)
 		}
 	end
 
-	---@param opponentIndex any
+	---@param opponentIndex integer
 	---@param additionalClasses string[]?
 	---@return Widget
 	local createScore = function(opponentIndex, additionalClasses)
@@ -255,7 +255,7 @@ function CustomMatchSummary.TeamSubMatchOpponnetRow(submatch)
 	}
 end
 
----@param submatch StarcraftMatchGroupUtilSubmatch
+---@param submatch WarcraftMatchGroupUtilSubmatch
 ---@return Widget?
 function CustomMatchSummary.TeamSubMatchGames(submatch)
 	if not CustomMatchSummary._submatchHasDetails(submatch) then return nil end
@@ -285,7 +285,7 @@ function CustomMatchSummary.TeamSubMatchGames(submatch)
 	}
 end
 
----@param submatch table
+---@param submatch WarcraftMatchGroupUtilSubmatch
 ---@return boolean
 function CustomMatchSummary._submatchHasDetails(submatch)
 	return #submatch.games > 0 and Array.any(submatch.games, function(game)


### PR DESCRIPTION
## How did you test this change?

preview with dev in sc2 (`dev=ElectricalBoy-match2-subgroups`)