### PR TITLE
fix: Remove 1px table row border spacing

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -132,12 +132,12 @@ $table2-cell-padding-x: 0.75rem;
 
 			.theme--light & {
 				background-color: var( --clr-semantic-gold-90 );
-				box-shadow: 0 1px 0 var( --clr-semantic-gold-80 );
+				box-shadow: inset 0 -1px 0 var( --clr-semantic-gold-80 );
 			}
 
 			.theme--dark & {
 				background-color: var( --clr-semantic-gold-16 );
-				box-shadow: 0 1px 0 var( --clr-semantic-gold-20 );
+				box-shadow: inset 0 -1px 0 var( --clr-semantic-gold-20 );
 			}
 
 			&::after {


### PR DESCRIPTION
## Summary
border-spacing interferes with the various means of background-colored cells, e.g. when hovering
https://discord.com/channels/93055209017729024/1474351702638460968/1481263081488384162

<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
browser devtools
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
