### PR TITLE
fix: array functions not working with non-array table elements

### DIFF
--- a/lua/spec/array_spec.lua
+++ b/lua/spec/array_spec.lua
@@ -81,6 +81,15 @@ describe('array', function()
 		it('check', function()
 			local a = {1, 2, 3, {5, 3}, {6, 4}}
 			assert.are_same({1, 2, 3, 5, 3, 6, 4}, Array.flatten(a))
+
+			local b = {
+				{
+					hello = 'world'
+				},
+				2,
+				3
+			}
+			assert.are_same(b, Array.flatten(b))
 		end)
 	end)
 
@@ -155,9 +164,11 @@ describe('array', function()
 
 	describe('ExtendWith', function()
 		it('check', function()
-			local a, b, c = {2, 3}, {5, 7, 11}, {13}
+			local a, b, c, d = {2, 3}, {5, 7, 11}, {13}, {hello = 'world'}
 			assert.are_same({2, 3, 5, 7, 11, 13}, Array.extendWith(a, b, c))
 			assert.are_same({2, 3, 5, 7, 11, 13}, a)
+			assert.are_same({2, 3, 5, 7, 11, 13, {hello = 'world'}}, Array.extendWith(a, d))
+			assert.are_same({2, 3, 5, 7, 11, 13, {hello = 'world'}}, a)
 		end)
 	end)
 

--- a/lua/wikis/commons/Array.lua
+++ b/lua/wikis/commons/Array.lua
@@ -138,13 +138,13 @@ end
 
 ---Flattens an array of arrays into an array.
 ---@generic T
----@param tbl T[]
+---@param tbl (T|T[])[]
 ---@return T[]
 ---@nodiscard
 function Array.flatten(tbl)
 	local flattenedArray = {}
 	for _, x in ipairs(tbl) do
-		if type(x) == 'table' then
+		if Array.isArray(x) then
 			for _, y in ipairs(x) do
 				table.insert(flattenedArray, y)
 			end
@@ -438,7 +438,7 @@ array is mutated in the process.
 function Array.extendWith(tbl, ...)
 	local arrays = Table.pack(...)
 	for index = 1, arrays.n do
-		if type(arrays[index]) == 'table' then
+		if Array.isArray(arrays[index]) then
 			for _, element in ipairs(arrays[index]) do
 				table.insert(tbl, element)
 			end


### PR DESCRIPTION
## Summary

```lua
local arr = {{hello = 'world'}, 2, 3}

local b = Array.flatten(arr) -- expected {{hello = 'world'}, 2, 3}, returned {2, 3}
```

```lua
local c = {3, 4, 5, 6}
local obj = {hello = 'world'}
local d = {8, 9}
local e = Array.extend(c, obj, d) -- expected {3, 4, 5, 6, {hello = 'world'}, 8, 9}, returned {3, 4, 5, 6, 8, 9}
```

## How did you test this change?

included tests