### PR TITLE
fix: Switch recent matches to player instead team

### DIFF
--- a/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
@@ -118,17 +118,14 @@ function CustomPlayer:adjustLPDB(lpdbData, args)
 	return lpdbData
 end
 
----@return string?
+---@return Widget?
 function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = TeamTemplate.getPageName(self.args.team)
-		---@cast teamPage -nil
-		return HtmlWidgets.Fragment{
-			children = {
-				MatchTicker.recent{team = teamPage},
-				UpcomingTournaments.team{name = teamPage}
-			}
-		}
+		return HtmlWidgets.Fragment{children = {
+			MatchTicker.player(),
+			UpcomingTournaments.team{name = teamPage}
+		}}
 	end
 end
 


### PR DESCRIPTION
## Summary

Changing to show the recent matches of the player not the team

## How did you test this change?

Dev module:https://liquipedia.net/rainbowsix/Module:Infobox/Person/Player/Custom/dev/Okidokie98
