### PR TITLE
refactor(match2): make side colors consistent between matchsummary and matchpage in valorant

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1331,9 +1331,6 @@ span.slash {
 	}
 }
 
-$valorant-atk: #b20110;
-$valorant-def: #01654c;
-
 .match-bm-rounds-overview {
 	$cell-height: 1.75rem;
 	$cell-radius: 0.25rem;
@@ -1388,13 +1385,13 @@ $valorant-def: #01654c;
 
 			&--atk {
 				.wiki-valorant & {
-					color: $valorant-atk;
+					color: var( --valorant-atk-score-color );
 				}
 			}
 
 			&--def {
 				.wiki-valorant & {
-					color: $valorant-def;
+					color: var( --valorant-def-score-color );
 				}
 			}
 		}
@@ -1457,14 +1454,14 @@ $valorant-def: #01654c;
 			&--atk {
 				.wiki-valorant & {
 					color: #ffffff;
-					background-color: $valorant-atk;
+					background-color: var( --valorant-atk-score-color );
 				}
 			}
 
 			&--def {
 				.wiki-valorant & {
 					color: #ffffff;
-					background-color: $valorant-def;
+					background-color: var( --valorant-def-score-color );
 				}
 			}
 		}
@@ -1483,13 +1480,13 @@ $valorant-def: #01654c;
 
 		&--atk {
 			.wiki-valorant & {
-				color: $valorant-atk;
+				color: var( --valorant-atk-score-color );
 			}
 		}
 
 		&--def {
 			.wiki-valorant & {
-				color: $valorant-def;
+				color: var( --valorant-def-score-color );
 			}
 		}
 	}
@@ -1515,14 +1512,14 @@ $valorant-def: #01654c;
 		&--atk {
 			.wiki-valorant & {
 				color: #ffffff;
-				background-color: $valorant-atk;
+				background-color: var( --valorant-atk-score-color );
 			}
 		}
 
 		&--def {
 			.wiki-valorant & {
 				color: #ffffff;
-				background-color: $valorant-def;
+				background-color: var( --valorant-def-score-color );
 			}
 		}
 	}

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -309,8 +309,13 @@
 }
 
 .wiki-valorant {
-	--valorant-def-score-color: #46b09c;
-	--valorant-atk-score-color: #c04845;
+	--valorant-def-score-color: #01654c;
+	--valorant-atk-score-color: #b20110;
+
+	.theme--dark & {
+		--valorant-def-score-color: #46b09c;
+		--valorant-atk-score-color: #c04845;
+	}
 
 	.brkts-valorant-score-color-def {
 		color: var( --valorant-def-score-color );

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -308,12 +308,17 @@
 	color: var( --clr-primary, #0000ff );
 }
 
-.brkts-valorant-score-color-def {
-	color: #46b09c;
-}
+.wiki-valorant {
+	--valorant-def-score-color: #46b09c;
+	--valorant-atk-score-color: #c04845;
 
-.brkts-valorant-score-color-atk {
-	color: #c04845;
+	.brkts-valorant-score-color-def {
+		color: var( --valorant-def-score-color );
+	}
+
+	.brkts-valorant-score-color-atk {
+		color: var( --valorant-atk-score-color );
+	}
 }
 
 .brkts-identityv-score-color-survivor {


### PR DESCRIPTION
## Summary

With this PR, light mode uses the colors from matchpage (darker shade) and dark mode uses colors from matchsummary (lighter shade).

## How did you test this change?

browser dev tools