### PR TITLE
fix: add null check for wikiMenu

### DIFF
--- a/javascript/commons/Liquipedia_links.js
+++ b/javascript/commons/Liquipedia_links.js
@@ -4,8 +4,15 @@
  ******************************************************************************/
 liquipedia.liquipedialinks = {
 	init: function() {
-		const countOtherWikis = parseInt( document.getElementById( 'ext-wikimenu' ).dataset.countOtherWikis );
-		if ( countOtherWikis > 0 ) {
+		const wikiMenu = document.getElementById( 'ext-wikimenu' );
+
+		if ( !wikiMenu ) {
+			return;
+		}
+
+		const countOtherWikis = parseInt( wikiMenu.dataset.countOtherWikis );
+
+		if ( countOtherWikis && countOtherWikis > 0 ) {
 			const badge = document.createElement( 'span' );
 			badge.classList.add(
 				'badge', 'badge-pill', 'wiki-backgroundcolor-navbar-badge', 'liquipedia-links-badge'


### PR DESCRIPTION
## Summary

To remove error in console on Lighthouse (Artifact). Because LH has it's own wikimenu.

`Uncaught TypeError: can't access property "dataset", document.getElementById(...) is null` 

## How did you test this change?

https://laura.wiki.tldev.eu/rocketleague/Main_Page
