### PR TITLE
refactor: transfer list to widget

### DIFF
--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -260,20 +260,18 @@ function TransferList:_buildDateCondition(date)
 	end
 
 	if config.startDate then
-		dateConditions:add(ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('date'), Comparator.gt, config.startDate),
-			ConditionNode(ColumnName('date'), Comparator.eq, config.startDate),
-		})
+		dateConditions:add(
+			ConditionNode(ColumnName('date'), Comparator.ge, config.startDate)
+		)
 	else
-		dateConditions:add{ConditionNode(ColumnName('date'), Comparator.gt, DateExt.defaultDate)}
+		dateConditions:add(ConditionNode(ColumnName('date'), Comparator.gt, DateExt.defaultDate))
 	end
 
 	if config.endDate then
 		local endDate = config.endDate .. ' 23:59:59'
-		dateConditions:add(ConditionTree(BooleanOperator.any):add{
-			ConditionNode(ColumnName('date'), Comparator.lt, endDate),
-			ConditionNode(ColumnName('date'), Comparator.eq, endDate),
-		})
+		dateConditions:add(
+			ConditionNode(ColumnName('date'), Comparator.le, endDate)
+		)
 	end
 
 	return dateConditions

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -208,6 +208,7 @@ function TransferList:fetch()
 	return self
 end
 
+---@private
 ---@param config {date: string, fromTeam: string, toTeam: string, roles1: string[]}?
 ---@return string
 function TransferList:_buildConditions(config)
@@ -221,6 +222,7 @@ function TransferList:_buildConditions(config)
 	return conditions:toString()
 end
 
+---@private
 ---@return ConditionTree
 function TransferList:_buildBaseConditions()
 	local config = self.config.conditions
@@ -242,6 +244,7 @@ function TransferList:_buildBaseConditions()
 	return self.baseConditions
 end
 
+---@private
 ---@param date string?
 ---@return ConditionTree?
 function TransferList:_buildDateCondition(date)
@@ -275,6 +278,7 @@ function TransferList:_buildDateCondition(date)
 	return dateConditions
 end
 
+---@private
 ---@param toTeam string?
 ---@param fromTeam string?
 ---@return ConditionTree?
@@ -333,6 +337,7 @@ function TransferList:create()
 	}
 end
 
+---@private
 ---@return Widget
 function TransferList:_buildHeader()
 	---@param props {classes: string[]?, children: Renderable|Renderable[]?}
@@ -376,6 +381,7 @@ function TransferList:_buildHeader()
 	}
 end
 
+---@private
 ---@param transfers transfer[]
 ---@return Widget?
 function TransferList:_buildRow(transfers)

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -337,26 +337,47 @@ function TransferList:create()
 	}
 end
 
----@return Html
+---@return Widget
 function TransferList:_buildHeader()
-	local headerRow = mw.html.create('div')
-		:addClass('divHeaderRow')
-		:tag('div'):addClass('divCell Date'):wikitext('Date'):allDone()
-
-	if HAS_PLATFORM_ICONS then
-		headerRow:tag('div'):addClass('divCell GameIcon')
+	---@param props {classes: string[]?, children: Renderable|Renderable[]?}
+	---@return Widget
+	local function createDivCell(props)
+		return HtmlWidgets.Div{
+			classes = Array.extend('divCell', props.classes),
+			children = props.children,
+		}
 	end
 
-	return headerRow
-		:tag('div'):addClass('divCell Name'):wikitext('Player'):done()
-		:tag('div'):addClass('divCell Team OldTeam'):wikitext('Old'):done()
-		:tag('div'):addClass('divCell Icon'):done()
-		:tag('div'):addClass('divCell Team NewTeam'):wikitext('New'):done()
-		:tag('div'):addClass('divCell Empty')
-			:tag('span')
-				:addClass('mobile-hide')
-				:wikitext(Abbreviation.make{text = 'Ref', title = 'Reference'})
-		:allDone()
+	return HtmlWidgets.Div{
+		classes = {'divHeaderRow'},
+		children = WidgetUtil.collect(
+			createDivCell{
+				classes = {'Date'},
+				children = 'Date'
+			},
+			HAS_PLATFORM_ICONS and createDivCell{classes = {'GameIcon'}} or nil,
+			createDivCell{
+				classes = {'Name'},
+				children = 'Player',
+			},
+			createDivCell{
+				classes = {'Team', 'OldTeam'},
+				children = 'Old',
+			},
+			createDivCell{classes = {'Icon'}},
+			createDivCell{
+				classes = {'Team', 'NewTeam'},
+				children = 'New',
+			},
+			createDivCell{
+				classes = {'Empty'},
+				children = HtmlWidgets.Span{
+					classes = {'mobile-hide'},
+					children = HtmlWidgets.Abbr{children = 'Ref', title = 'Reference'}
+				}
+			}
+		)
+	}
 end
 
 ---@param transfers transfer[]

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -73,7 +73,6 @@ local TransferList = Class.new(
 	---@return self
 	function(self, args)
 		self.config = self:parseArgs(args)
-		return self
 	end
 )
 

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -20,6 +20,7 @@ local TeamTemplate = Lua.import('Module:TeamTemplate')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
 
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local TransferRowWidget = Lua.import('Module:Widget/Transfer/Row')
 
 local Condition = Lua.import('Module:Condition')
@@ -301,9 +302,10 @@ end
 ---@return Html|string?
 function TransferList:create()
 	local config = self.config
-	if config.showMissingResultsMessage and Logic.isDeepEmpty(self.groupedTransfers) then
-		return mw.html.create('pre'):wikitext('No results for: ' .. mw.text.nowiki(self.conditions))
-	elseif Logic.isDeepEmpty(self.groupedTransfers) then
+	if Logic.isDeepEmpty(self.groupedTransfers) then
+		if config.showMissingResultsMessage then
+			return HtmlWidgets.Pre{children = 'No results for: ' .. mw.text.nowiki(self.conditions)}
+		end
 		return
 	end
 

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -7,7 +7,6 @@
 
 local Lua = require('Module:Lua')
 
-local Abbreviation = Lua.import('Module:Abbreviation')
 local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
@@ -15,10 +14,9 @@ local DateExt = Lua.import('Module:Date/Ext')
 local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
+local Opponent = Lua.import('Module:Opponent/Custom')
 local Table = Lua.import('Module:Table')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
-
-local Opponent = Lua.import('Module:Opponent/Custom')
 
 local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -20,8 +20,10 @@ local TeamTemplate = Lua.import('Module:TeamTemplate')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
 
+local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local TransferRowWidget = Lua.import('Module:Widget/Transfer/Row')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local Condition = Lua.import('Module:Condition')
 local ConditionTree = Condition.Tree
@@ -299,7 +301,7 @@ function TransferList:_buildTeamConditions(toTeam, fromTeam)
 	return self.teamConditions
 end
 
----@return Html|string?
+---@return Widget?
 function TransferList:create()
 	local config = self.config
 	if Logic.isDeepEmpty(self.groupedTransfers) then
@@ -309,31 +311,30 @@ function TransferList:create()
 		return
 	end
 
-	local display = mw.html.create('div')
-		:addClass('divTable mainpage-transfer Ref')
-		:css('text-align', 'center')
-		:css('width', '100%')
-		:node(self:_buildHeader())
-
-	Array.forEach(self.groupedTransfers, function(rowData)
-		display:node(self:_buildRow(rowData))
-	end)
+	local display = HtmlWidgets.Div{
+		classes = {'divTable', 'mainpage-transfer', 'Ref', config.class},
+		css = {
+			['text-align'] = 'center',
+			width = '100%',
+		},
+		children = WidgetUtil.collect(
+			self:_buildHeader(),
+			Array.map(self.groupedTransfers, function (rowData)
+				return self:_buildRow(rowData)
+			end)
+		)
+	}
 
 	if not config.title then
-		-- for whatever reason currently class is only applied in this case ...
-		if config.class then
-			display:addClass(config.class)
-		end
-		return mw.html.create('div')
-			:node(display)
+		return display
 	end
 
-	return mw.html.create('table')
-		:css('margin-top','0px')
-		:addClass('wikitable OffSeasonOverview')
-		:addClass(config.shown and 'collapsible collapsed' or nil)
-		:tag('tr'):tag('th'):attr('colspan', 7):wikitext(config.title):allDone()
-		:tag('tr'):tag('td'):css('padding', '0'):node(display):allDone()
+	return GeneralCollapsible{
+		title = config.title,
+		classes = {'OffSeasonOverview'},
+		shouldCollapse = not config.shown,
+		children = display,
+	}
 end
 
 ---@return Html

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -62,6 +62,7 @@ local DEFAULT_VALUES = {
 ---@field onlyNotableTransfers boolean
 
 ---@class TransferList: BaseClass
+---@operator call(table): TransferList
 ---@field config TransferListConfig
 ---@field groupedTransfers transfer[][]
 ---@field teamConditions ConditionTree?

--- a/lua/wikis/commons/TransferList.lua
+++ b/lua/wikis/commons/TransferList.lua
@@ -80,7 +80,7 @@ local TransferList = Class.new(
 )
 
 ---@param frame Frame
----@return Html
+---@return Widget?
 function TransferList.run(frame)
 	local args = Arguments.getArgs(frame)
 	return TransferList(args):fetch():create()

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -906,16 +906,16 @@ Template(s): OffSeasonOverview
 Author(s): Vogan
 *******************************************************************************/
 .OffSeasonOverview {
-	padding: 0;
-	margin: 0;
 	width: 70%;
-	margin-bottom: -1px;
+	border: 1px solid var( --table-border-color );
 
 	@media ( max-width: 560px ) {
-		padding: 0;
-		margin: 0;
 		width: 100%;
-		margin-bottom: -1px;
+	}
+
+	> .general-collapsible-default-header {
+		background-color: var( --table-header-variant-background-color );
+		padding: 0.3125rem;
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR:
- removes uses of `mw.html` in transfer list
- replaces table based collapsing with `GeneralCollapsible`
- cleans up condition builder
- updates type annotation accordingly 

## How did you test this change?

dev + browser dev tools