### PR TITLE
feat(notability): Increase B-Tier points in Overwatch

### DIFF
--- a/lua/wikis/overwatch/NotabilityChecker/config.lua
+++ b/lua/wikis/overwatch/NotabilityChecker/config.lua
@@ -107,7 +107,7 @@ Config.weights = {
 		tiertype = {
 			{
 				name = Config.TIER_TYPE_GENERAL,
-				points = 700,
+				points = 1000,
 			},
 			{
 				name = Config.TIER_TYPE_QUALIFIER,


### PR DESCRIPTION
## Summary

Increase the maximum gained notability points for B-Tier tournaments in the overwatch wiki to 1'000.
Discussed with wiki contributors, see [poll](https://discord.com/channels/93055209017729024/189387652745789440/1491107736530714674)

## How did you test this change?
none, simple value change
