### PR TITLE
feat(dropdown): add shared form variant

### DIFF
--- a/javascript/commons/Dropdown.js
+++ b/javascript/commons/Dropdown.js
@@ -2,22 +2,116 @@
  * Template(s): Dropdown
  ******************************************************************************/
 liquipedia.dropdown = {
-	init: function() {
-		document.addEventListener( 'click', ( e ) => {
-			const isDropdownButton = e.target.closest( '[data-dropdown-toggle]' );
-			const dropdownWidget = isDropdownButton ? isDropdownButton.closest( '.dropdown-widget' ) : null;
-			let currentMenu;
+	isInitialized: false,
 
-			if ( dropdownWidget ) {
-				currentMenu = dropdownWidget.querySelector( '.dropdown-widget__menu' );
-				currentMenu.classList.toggle( 'show' );
+	getDropdownWidget( target ) {
+		return target.closest( '.dropdown-widget' );
+	},
+
+	getToggle( dropdownWidget ) {
+		return dropdownWidget?.querySelector( '.dropdown-widget__toggle' ) ?? null;
+	},
+
+	getMenu( dropdownWidget ) {
+		return dropdownWidget?.querySelector( '.dropdown-widget__menu' ) ?? null;
+	},
+
+	setOpenState( dropdownWidget, isOpen, options = {} ) {
+		const menu = this.getMenu( dropdownWidget );
+		const toggle = this.getToggle( dropdownWidget );
+		if ( !menu || !toggle ) {
+			return;
+		}
+
+		const wasOpen = menu.classList.contains( 'show' );
+		if ( wasOpen === isOpen ) {
+			return;
+		}
+
+		const eventPrefix = isOpen ? 'dropdown:beforeopen' : 'dropdown:beforeclose';
+		dropdownWidget.dispatchEvent( new CustomEvent( eventPrefix, { bubbles: true } ) );
+
+		menu.classList.toggle( 'show', isOpen );
+		toggle.setAttribute( 'aria-expanded', String( isOpen ) );
+		menu.setAttribute( 'aria-hidden', String( !isOpen ) );
+
+		dropdownWidget.dispatchEvent( new CustomEvent( isOpen ? 'dropdown:open' : 'dropdown:close', { bubbles: true } ) );
+
+		if ( !isOpen && options.focusToggle ) {
+			toggle.focus();
+		}
+	},
+
+	closeOtherDropdowns( currentDropdownWidget ) {
+		document.querySelectorAll( '.dropdown-widget__menu.show' ).forEach( ( menu ) => {
+			const dropdownWidget = this.getDropdownWidget( menu );
+			if ( !dropdownWidget || dropdownWidget === currentDropdownWidget ) {
+				return;
 			}
 
-			document.querySelectorAll( '.dropdown-widget__menu.show' ).forEach( ( menu ) => {
-				if ( menu !== currentMenu ) {
-					menu.classList.remove( 'show' );
+			this.setOpenState( dropdownWidget, false );
+		} );
+	},
+
+	toggleDropdown( dropdownWidget ) {
+		const menu = this.getMenu( dropdownWidget );
+		if ( !menu ) {
+			return;
+		}
+
+		const isOpen = menu.classList.contains( 'show' );
+		if ( !isOpen ) {
+			this.closeOtherDropdowns( dropdownWidget );
+		}
+
+		this.setOpenState( dropdownWidget, !isOpen );
+	},
+
+	closeAllDropdowns( options = {} ) {
+		document.querySelectorAll( '.dropdown-widget__menu.show' ).forEach( ( menu ) => {
+			const dropdownWidget = this.getDropdownWidget( menu );
+			if ( dropdownWidget ) {
+				this.setOpenState( dropdownWidget, false, options );
+			}
+		} );
+	},
+
+	init: function() {
+		if ( this.isInitialized ) {
+			return;
+		}
+
+		this.isInitialized = true;
+
+		document.addEventListener( 'click', ( e ) => {
+			const toggle = e.target.closest( '[data-dropdown-toggle]' );
+			if ( toggle ) {
+				e.stopPropagation();
+				this.toggleDropdown( this.getDropdownWidget( toggle ) );
+				return;
+			}
+
+			this.closeAllDropdowns();
+		} );
+
+		document.addEventListener( 'keydown', ( event ) => {
+			const toggle = event.target.closest?.( '[data-dropdown-toggle]' ) ?? null;
+
+			if ( toggle && ( event.key === 'Enter' || event.key === ' ' ) ) {
+				event.preventDefault();
+				this.toggleDropdown( this.getDropdownWidget( toggle ) );
+				return;
+			}
+
+			if ( event.key === 'Escape' ) {
+				const openMenu = document.querySelector( '.dropdown-widget__menu.show' );
+				if ( openMenu ) {
+					const dropdownWidget = this.getDropdownWidget( openMenu );
+					if ( dropdownWidget ) {
+						this.setOpenState( dropdownWidget, false, { focusToggle: true } );
+					}
 				}
-			} );
+			}
 		} );
 	}
 };

--- a/javascript/tests/Dropdown.test.js
+++ b/javascript/tests/Dropdown.test.js
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { test, expect, beforeAll, beforeEach, describe } = require( '@jest/globals' );
+
+	describe( 'Dropdown module', () => {
+		beforeAll( () => {
+			globalThis.liquipedia = {
+				core: { modules: [] }
+			};
+
+			require( '../commons/Dropdown.js' );
+		} );
+
+		beforeEach( () => {
+			document.body.innerHTML = '';
+			liquipedia.dropdown.init();
+		} );
+
+	function createDropdownMarkup( label = 'Menu' ) {
+		return `
+			<div class="dropdown-widget dropdown-widget--form">
+				<div class="dropdown-widget__toggle" data-dropdown-toggle="true" role="button" tabindex="0" aria-expanded="false" aria-haspopup="menu">
+					<span>${ label }</span>
+				</div>
+				<div class="dropdown-widget__menu" aria-hidden="true">
+					<ul>
+						<li>Item</li>
+					</ul>
+				</div>
+			</div>
+		`;
+	}
+
+	test( 'should register itself as a module', () => {
+		expect( globalThis.liquipedia.core.modules ).toContain( 'dropdown' );
+	} );
+
+	test( 'should toggle the dropdown on click and sync aria state', () => {
+		document.body.innerHTML = createDropdownMarkup();
+
+		const toggle = document.querySelector( '.dropdown-widget__toggle' );
+		const menu = document.querySelector( '.dropdown-widget__menu' );
+
+		toggle.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		expect( menu.classList.contains( 'show' ) ).toBe( true );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		expect( menu.getAttribute( 'aria-hidden' ) ).toBe( 'false' );
+
+		toggle.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		expect( menu.classList.contains( 'show' ) ).toBe( false );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+		expect( menu.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+	} );
+
+	test( 'should close other dropdowns when opening a new one', () => {
+		document.body.innerHTML = `${ createDropdownMarkup( 'One' ) }${ createDropdownMarkup( 'Two' ) }`;
+
+		const toggles = document.querySelectorAll( '.dropdown-widget__toggle' );
+		const menus = document.querySelectorAll( '.dropdown-widget__menu' );
+
+		toggles[ 0 ].dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		expect( menus[ 0 ].classList.contains( 'show' ) ).toBe( true );
+
+		toggles[ 1 ].dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		expect( menus[ 0 ].classList.contains( 'show' ) ).toBe( false );
+		expect( menus[ 1 ].classList.contains( 'show' ) ).toBe( true );
+	} );
+
+	test( 'should support keyboard toggle and escape close', () => {
+		document.body.innerHTML = createDropdownMarkup();
+
+		const toggle = document.querySelector( '.dropdown-widget__toggle' );
+		const menu = document.querySelector( '.dropdown-widget__menu' );
+
+		toggle.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } ) );
+		expect( menu.classList.contains( 'show' ) ).toBe( true );
+
+		document.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ) );
+		expect( menu.classList.contains( 'show' ) ).toBe( false );
+		expect( document.activeElement ).toBe( toggle );
+	} );
+
+	test( 'should dispatch lifecycle events when opening and closing', () => {
+		document.body.innerHTML = createDropdownMarkup();
+
+		const dropdown = document.querySelector( '.dropdown-widget' );
+		const toggle = document.querySelector( '.dropdown-widget__toggle' );
+		const events = [];
+
+		dropdown.addEventListener( 'dropdown:beforeopen', () => events.push( 'beforeopen' ) );
+		dropdown.addEventListener( 'dropdown:open', () => events.push( 'open' ) );
+		dropdown.addEventListener( 'dropdown:beforeclose', () => events.push( 'beforeclose' ) );
+		dropdown.addEventListener( 'dropdown:close', () => events.push( 'close' ) );
+
+		toggle.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		toggle.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+
+		expect( events ).toEqual( [ 'beforeopen', 'open', 'beforeclose', 'close' ] );
+	} );
+} );

--- a/javascript/tests/Dropdown.test.js
+++ b/javascript/tests/Dropdown.test.js
@@ -22,7 +22,9 @@ const { test, expect, beforeAll, beforeEach, describe } = require( '@jest/global
 		return `
 			<div class="dropdown-widget dropdown-widget--form">
 				<div class="dropdown-widget__toggle" data-dropdown-toggle="true" role="button" tabindex="0" aria-expanded="false" aria-haspopup="menu">
-					<span>${ label }</span>
+					<span class="dropdown-widget__prefix">Icon</span>
+					<span class="dropdown-widget__label">${ label }</span>
+					<span class="dropdown-widget__indicator"><i class="far fa-chevron-down fa-xs"></i></span>
 				</div>
 				<div class="dropdown-widget__menu" aria-hidden="true">
 					<ul>

--- a/javascript/tests/Dropdown.test.js
+++ b/javascript/tests/Dropdown.test.js
@@ -4,19 +4,19 @@
 
 const { test, expect, beforeAll, beforeEach, describe } = require( '@jest/globals' );
 
-	describe( 'Dropdown module', () => {
-		beforeAll( () => {
-			globalThis.liquipedia = {
-				core: { modules: [] }
-			};
+describe( 'Dropdown module', () => {
+	beforeAll( () => {
+		globalThis.liquipedia = {
+			core: { modules: [] }
+		};
 
-			require( '../commons/Dropdown.js' );
-		} );
+		require( '../commons/Dropdown.js' );
+	} );
 
-		beforeEach( () => {
-			document.body.innerHTML = '';
-			liquipedia.dropdown.init();
-		} );
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		liquipedia.dropdown.init();
+	} );
 
 	function createDropdownMarkup( label = 'Menu' ) {
 		return `

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -33,6 +33,18 @@ describe('Dropdown', function()
 		assert.truthy(html:find('dropdown%-widget__item'))
 	end)
 
+	it('should not render a prefix wrapper when prefix is omitted', function()
+		local widget = Dropdown{
+			label = 'Actions',
+			children = {
+				DropdownItem{children = 'Option 1'},
+			}
+		}
+		local html = tostring(widget)
+		assert.falsy(html:find('dropdown%-widget__prefix'))
+		assert.truthy(html:find('dropdown%-widget__label'))
+	end)
+
 	it('should render the default form variant with built-in toggle structure', function()
 		local widget = Dropdown{
 			classes = {'custom-dropdown'},

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -15,7 +15,7 @@ describe('Dropdown', function()
 		assert.truthy(html:find('dropdown%-widget__menu'))
 	end)
 
-		it('should render dropdown items', function()
+	it('should render dropdown items', function()
 		local widget = Dropdown{
 			button = 'Actions',
 			children = {
@@ -26,6 +26,30 @@ describe('Dropdown', function()
 		local html = tostring(widget)
 		assert.truthy(html:find('Option 1'))
 		assert.truthy(html:find('Option 2'))
+		assert.truthy(html:find('dropdown%-widget__item'))
+	end)
+
+	it('should render the form variant with forwarded classes and attributes', function()
+		local widget = Dropdown{
+			button = 'Choose option',
+			variant = 'form',
+			classes = {'custom-dropdown'},
+			buttonClasses = {'custom-toggle'},
+			buttonAttributes = {['aria-haspopup'] = 'menu'},
+			menuClasses = {'custom-menu'},
+			menuAttributes = {['aria-hidden'] = 'true'},
+			buttonSize = 'md',
+			children = {
+				DropdownItem{children = 'Option 1'},
+			}
+		}
+		local html = tostring(widget)
+		assert.truthy(html:find('dropdown%-widget%-%-form'))
+		assert.truthy(html:find('custom%-dropdown'))
+		assert.truthy(html:find('custom%-toggle'))
+		assert.truthy(html:find('custom%-menu'))
+		assert.truthy(html:find('aria%-haspopup="menu"'))
+		assert.truthy(html:find('aria%-hidden="true"'))
 		assert.truthy(html:find('dropdown%-widget__item'))
 	end)
 

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -10,12 +10,13 @@ describe('Dropdown', function()
 		}
 		local html = tostring(widget)
 		assert.truthy(html:find('dropdown%-widget'))
-		assert.truthy(html:find('dropdown%-widget%-%-inline'))
+		assert.truthy(html:find('dropdown%-widget%-%-form'))
 		assert.truthy(html:find('dropdown%-widget__toggle'))
 		assert.truthy(html:find('data%-dropdown%-toggle="true"'))
 		assert.truthy(html:find('dropdown%-widget__menu'))
 		assert.truthy(html:find('dropdown%-widget__label'))
 		assert.truthy(html:find('dropdown%-widget__indicator'))
+		assert.truthy(html:find('btn%-secondary'))
 	end)
 
 	it('should render dropdown items', function()
@@ -32,9 +33,8 @@ describe('Dropdown', function()
 		assert.truthy(html:find('dropdown%-widget__item'))
 	end)
 
-	it('should render the form variant with built-in toggle structure', function()
+	it('should render the default form variant with built-in toggle structure', function()
 		local widget = Dropdown{
-			variant = 'form',
 			classes = {'custom-dropdown'},
 			prefix = 'Icon',
 			label = 'Choose option',
@@ -101,6 +101,7 @@ describe('Dropdown', function()
 
 	it('should render the inline variant with built-in toggle structure', function()
 		local widget = Dropdown{
+			variant = 'inline',
 			prefix = 'Icon',
 			label = 'Actions',
 			children = {

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -31,14 +31,15 @@ describe('Dropdown', function()
 
 	it('should render the form variant with forwarded classes and attributes', function()
 		local widget = Dropdown{
-			button = 'Choose option',
 			variant = 'form',
 			classes = {'custom-dropdown'},
 			buttonClasses = {'custom-toggle'},
-			buttonAttributes = {['aria-haspopup'] = 'menu'},
 			menuClasses = {'custom-menu'},
-			menuAttributes = {['aria-hidden'] = 'true'},
 			buttonSize = 'md',
+			prefix = 'Icon',
+			label = 'Choose option',
+			prefixClasses = {'custom-prefix'},
+			labelClasses = {'custom-label'},
 			children = {
 				DropdownItem{children = 'Option 1'},
 			}
@@ -47,9 +48,14 @@ describe('Dropdown', function()
 		assert.truthy(html:find('dropdown%-widget%-%-form'))
 		assert.truthy(html:find('custom%-dropdown'))
 		assert.truthy(html:find('custom%-toggle'))
+		assert.truthy(html:find('custom%-prefix'))
+		assert.truthy(html:find('custom%-label'))
 		assert.truthy(html:find('custom%-menu'))
 		assert.truthy(html:find('aria%-haspopup="menu"'))
 		assert.truthy(html:find('aria%-hidden="true"'))
+		assert.truthy(html:find('dropdown%-widget__prefix'))
+		assert.truthy(html:find('dropdown%-widget__label'))
+		assert.truthy(html:find('dropdown%-widget__indicator'))
 		assert.truthy(html:find('dropdown%-widget__item'))
 	end)
 

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -5,19 +5,22 @@ local DropdownItem = Lua.import('Module:Widget/Basic/Dropdown/Item')
 describe('Dropdown', function()
 	it('should render a basic dropdown wrapper', function()
 		local widget = Dropdown{
-			button = 'Click me',
+			label = 'Click me',
 			children = 'Menu children'
 		}
 		local html = tostring(widget)
 		assert.truthy(html:find('dropdown%-widget'))
+		assert.truthy(html:find('dropdown%-widget%-%-inline'))
 		assert.truthy(html:find('dropdown%-widget__toggle'))
 		assert.truthy(html:find('data%-dropdown%-toggle="true"'))
 		assert.truthy(html:find('dropdown%-widget__menu'))
+		assert.truthy(html:find('dropdown%-widget__label'))
+		assert.truthy(html:find('dropdown%-widget__indicator'))
 	end)
 
 	it('should render dropdown items', function()
 		local widget = Dropdown{
-			button = 'Actions',
+			label = 'Actions',
 			children = {
 				DropdownItem{children = 'Option 1'},
 				DropdownItem{children = 'Option 2', link = 'TargetPage'}
@@ -54,7 +57,7 @@ describe('Dropdown', function()
 
 	it('should render dropdown items with icons using fontawesome icon names', function()
 		local widget = Dropdown{
-			button = 'Menu',
+			label = 'Menu',
 			children = {
 				DropdownItem{
 					children = 'Home',
@@ -68,7 +71,7 @@ describe('Dropdown', function()
 
 	it('should render dropdown items with external links', function()
 		local widget = Dropdown{
-			button = 'External',
+			label = 'External',
 			children = {
 				DropdownItem{
 					children = 'External Link',
@@ -84,7 +87,7 @@ describe('Dropdown', function()
 
 	it('should render dropdown items with attributes', function()
 		local widget = Dropdown{
-			button = 'Actions',
+			label = 'Actions',
 			children = {
 				DropdownItem{
 					children = 'Action',
@@ -94,5 +97,23 @@ describe('Dropdown', function()
 		}
 		local html = tostring(widget)
 		assert.truthy(html:find('data%-action="test"'))
+	end)
+
+	it('should render the inline variant with built-in toggle structure', function()
+		local widget = Dropdown{
+			prefix = 'Icon',
+			label = 'Actions',
+			children = {
+				DropdownItem{children = 'Option 1'},
+			}
+		}
+		local html = tostring(widget)
+		assert.truthy(html:find('dropdown%-widget%-%-inline'))
+		assert.truthy(html:find('btn%-ghost'))
+		assert.truthy(html:find('dropdown%-widget__prefix'))
+		assert.truthy(html:find('dropdown%-widget__label'))
+		assert.truthy(html:find('dropdown%-widget__indicator'))
+		assert.truthy(html:find('aria%-haspopup="menu"'))
+		assert.truthy(html:find('aria%-hidden="true"'))
 	end)
 end)

--- a/lua/spec/dropdown_spec.lua
+++ b/lua/spec/dropdown_spec.lua
@@ -29,17 +29,12 @@ describe('Dropdown', function()
 		assert.truthy(html:find('dropdown%-widget__item'))
 	end)
 
-	it('should render the form variant with forwarded classes and attributes', function()
+	it('should render the form variant with built-in toggle structure', function()
 		local widget = Dropdown{
 			variant = 'form',
 			classes = {'custom-dropdown'},
-			buttonClasses = {'custom-toggle'},
-			menuClasses = {'custom-menu'},
-			buttonSize = 'md',
 			prefix = 'Icon',
 			label = 'Choose option',
-			prefixClasses = {'custom-prefix'},
-			labelClasses = {'custom-label'},
 			children = {
 				DropdownItem{children = 'Option 1'},
 			}
@@ -47,10 +42,8 @@ describe('Dropdown', function()
 		local html = tostring(widget)
 		assert.truthy(html:find('dropdown%-widget%-%-form'))
 		assert.truthy(html:find('custom%-dropdown'))
-		assert.truthy(html:find('custom%-toggle'))
-		assert.truthy(html:find('custom%-prefix'))
-		assert.truthy(html:find('custom%-label'))
-		assert.truthy(html:find('custom%-menu'))
+		assert.truthy(html:find('btn%-secondary'))
+		assert.truthy(html:find('Choose option'))
 		assert.truthy(html:find('aria%-haspopup="menu"'))
 		assert.truthy(html:find('aria%-hidden="true"'))
 		assert.truthy(html:find('dropdown%-widget__prefix'))

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -51,7 +51,8 @@ function DropdownContainer:render()
 		return nil
 	end
 
-	local variantConfig = assert(VARIANT_CONFIG[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
+	local variantConfig = assert(VARIANT_CONFIG[self.props.variant],
+		'Invalid Dropdown variant "' .. self.props.variant .. '"')
 
 	local toggleChildren = WidgetUtil.collect(
 		Logic.isNotEmpty(self.props.prefix) and Span{

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -20,8 +20,8 @@ local Div = HtmlWidgets.Div
 local Span = HtmlWidgets.Span
 
 local VALID_VARIANTS = {
-	inline = true,
 	form = true,
+	inline = true,
 }
 
 local VARIANT_CONFIG = {
@@ -37,7 +37,7 @@ local VARIANT_CONFIG = {
 
 ---@class DropdownContainerWidgetParameters
 ---@field children Renderable|Renderable[]
----@field variant 'inline'|'form'?
+---@field variant 'form'|'inline'?
 ---@field classes string[]?
 ---@field prefix Renderable|Renderable[]?
 ---@field label Renderable|Renderable[]?
@@ -47,7 +47,7 @@ local VARIANT_CONFIG = {
 ---@field props DropdownContainerWidgetParameters
 local DropdownContainer = Class.new(Widget)
 DropdownContainer.defaultProps = {
-	variant = 'inline',
+	variant = 'form',
 }
 
 ---@return Widget|nil

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -16,6 +16,7 @@ local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Button = Lua.import('Module:Widget/Basic/Button')
 local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 local Div = HtmlWidgets.Div
 local Span = HtmlWidgets.Span
 
@@ -65,11 +66,11 @@ function DropdownContainer:render()
 	}
 	local menuAttributes = {['aria-hidden'] = 'true'}
 
-	local toggleChildren = {
-		Logic.isEmpty(self.props.prefix) and nil or Span{
+	local toggleChildren = WidgetUtil.collect(
+		Logic.isNotEmpty(self.props.prefix) and Span{
 			classes = {'dropdown-widget__prefix'},
 			children = self.props.prefix,
-		},
+		} or nil,
 		Span{
 			classes = {'dropdown-widget__label'},
 			children = self.props.label,
@@ -77,8 +78,8 @@ function DropdownContainer:render()
 		Span{
 			classes = {'dropdown-widget__indicator'},
 			children = {Icon{iconName = 'expand', size = 'xs'}},
-		},
-	}
+		}
+	)
 
 	local toggleButton = Button{
 		size = variantConfig.buttonSize,

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -24,21 +24,24 @@ local VALID_VARIANTS = {
 	form = true,
 }
 
+local VARIANT_CONFIG = {
+	inline = {
+		buttonSize = 'xs',
+		buttonVariant = 'ghost',
+	},
+	form = {
+		buttonSize = 'md',
+		buttonVariant = 'secondary',
+	},
+}
+
 ---@class DropdownContainerWidgetParameters
 ---@field button string|Widget|(string|Widget)[]
 ---@field children Renderable|Renderable[]
 ---@field variant 'inline'|'form'?
 ---@field classes string[]?
----@field buttonClasses string[]?
----@field buttonAttributes table?
----@field menuClasses string[]?
----@field menuAttributes table?
----@field buttonSize 'xs'|'sm'|'md'|'lg'?
----@field buttonVariant string?
 ---@field prefix Renderable|Renderable[]?
----@field prefixClasses string[]?
 ---@field label Renderable|Renderable[]?
----@field labelClasses string[]?
 
 ---@class DropdownContainerWidget: Widget
 ---@operator call(DropdownContainerWidgetParameters): DropdownContainerWidget
@@ -46,8 +49,6 @@ local VALID_VARIANTS = {
 local DropdownContainer = Class.new(Widget)
 DropdownContainer.defaultProps = {
 	variant = 'inline',
-	buttonSize = 'xs',
-	buttonVariant = 'ghost',
 }
 
 ---@return Widget|nil
@@ -57,9 +58,10 @@ function DropdownContainer:render()
 	end
 
 	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
+	local variantConfig = VARIANT_CONFIG[self.props.variant]
 
-	local buttonAttributes = self.props.buttonAttributes or {}
-	local menuAttributes = self.props.menuAttributes or {}
+	local buttonAttributes = {}
+	local menuAttributes = {}
 
 	local toggleChildren = self.props.button
 	if self.props.variant == 'form' then
@@ -71,11 +73,11 @@ function DropdownContainer:render()
 
 		toggleChildren = {
 			Logic.isEmpty(self.props.prefix) and nil or Span{
-				classes = Array.extend('dropdown-widget__prefix', self.props.prefixClasses),
+				classes = {'dropdown-widget__prefix'},
 				children = self.props.prefix,
 			},
 			Span{
-				classes = Array.extend('dropdown-widget__label', self.props.labelClasses),
+				classes = {'dropdown-widget__label'},
 				children = self.props.label,
 			},
 			Span{
@@ -86,9 +88,9 @@ function DropdownContainer:render()
 	end
 
 	local toggleButton = Button{
-		size = self.props.buttonSize,
-		variant = self.props.buttonVariant,
-		classes = Array.extend('dropdown-widget__toggle', self.props.buttonClasses),
+		size = variantConfig.buttonSize,
+		variant = variantConfig.buttonVariant,
+		classes = {'dropdown-widget__toggle'},
 		attributes = Table.merge(buttonAttributes, {['data-dropdown-toggle'] = 'true'}),
 		children = toggleChildren
 	}
@@ -98,7 +100,7 @@ function DropdownContainer:render()
 		children = {
 			toggleButton,
 			Div{
-				classes = Array.extend('dropdown-widget__menu', self.props.menuClasses),
+				classes = {'dropdown-widget__menu'},
 				attributes = menuAttributes,
 				children = self.props.children
 			}

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -15,7 +15,9 @@ local Table = Lua.import('Module:Table')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Button = Lua.import('Module:Widget/Basic/Button')
+local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Div = HtmlWidgets.Div
+local Span = HtmlWidgets.Span
 
 local VALID_VARIANTS = {
 	inline = true,
@@ -33,6 +35,10 @@ local VALID_VARIANTS = {
 ---@field menuAttributes table?
 ---@field buttonSize 'xs'|'sm'|'md'|'lg'?
 ---@field buttonVariant string?
+---@field prefix Renderable|Renderable[]?
+---@field prefixClasses string[]?
+---@field label Renderable|Renderable[]?
+---@field labelClasses string[]?
 
 ---@class DropdownContainerWidget: Widget
 ---@operator call(DropdownContainerWidgetParameters): DropdownContainerWidget
@@ -52,12 +58,39 @@ function DropdownContainer:render()
 
 	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
 
+	local buttonAttributes = self.props.buttonAttributes or {}
+	local menuAttributes = self.props.menuAttributes or {}
+
+	local toggleChildren = self.props.button
+	if self.props.variant == 'form' then
+		buttonAttributes = Table.merge({
+			['aria-expanded'] = 'false',
+			['aria-haspopup'] = 'menu',
+		}, buttonAttributes)
+		menuAttributes = Table.merge({['aria-hidden'] = 'true'}, menuAttributes)
+
+		toggleChildren = {
+			Logic.isEmpty(self.props.prefix) and nil or Span{
+				classes = Array.extend('dropdown-widget__prefix', self.props.prefixClasses),
+				children = self.props.prefix,
+			},
+			Span{
+				classes = Array.extend('dropdown-widget__label', self.props.labelClasses),
+				children = self.props.label,
+			},
+			Span{
+				classes = {'dropdown-widget__indicator'},
+				children = {Icon{iconName = 'expand', size = 'xs'}},
+			},
+		}
+	end
+
 	local toggleButton = Button{
 		size = self.props.buttonSize,
 		variant = self.props.buttonVariant,
 		classes = Array.extend('dropdown-widget__toggle', self.props.buttonClasses),
-		attributes = Table.merge(self.props.buttonAttributes or {}, {['data-dropdown-toggle'] = 'true'}),
-		children = self.props.button
+		attributes = Table.merge(buttonAttributes, {['data-dropdown-toggle'] = 'true'}),
+		children = toggleChildren
 	}
 
 	return Div{
@@ -66,7 +99,7 @@ function DropdownContainer:render()
 			toggleButton,
 			Div{
 				classes = Array.extend('dropdown-widget__menu', self.props.menuClasses),
-				attributes = self.props.menuAttributes,
+				attributes = menuAttributes,
 				children = self.props.children
 			}
 		}

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -27,12 +27,12 @@ local VALID_VARIANTS = {
 
 local VARIANT_CONFIG = {
 	inline = {
-		buttonSize = 'xs',
-		buttonVariant = 'ghost',
+		size = 'xs',
+		variant = 'ghost',
 	},
 	form = {
-		buttonSize = 'md',
-		buttonVariant = 'secondary',
+		size = 'md',
+		variant = 'secondary',
 	},
 }
 
@@ -60,12 +60,6 @@ function DropdownContainer:render()
 	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
 	local variantConfig = VARIANT_CONFIG[self.props.variant]
 
-	local buttonAttributes = {
-		['aria-expanded'] = 'false',
-		['aria-haspopup'] = 'menu',
-	}
-	local menuAttributes = {['aria-hidden'] = 'true'}
-
 	local toggleChildren = WidgetUtil.collect(
 		Logic.isNotEmpty(self.props.prefix) and Span{
 			classes = {'dropdown-widget__prefix'},
@@ -82,10 +76,14 @@ function DropdownContainer:render()
 	)
 
 	local toggleButton = Button{
-		size = variantConfig.buttonSize,
-		variant = variantConfig.buttonVariant,
+		size = variantConfig.size,
+		variant = variantConfig.variant,
 		classes = {'dropdown-widget__toggle'},
-		attributes = Table.merge(buttonAttributes, {['data-dropdown-toggle'] = 'true'}),
+		attributes = {
+			['data-dropdown-toggle'] = 'true',
+			['aria-expanded'] = 'false',
+			['aria-haspopup'] = 'menu',
+		},
 		children = toggleChildren
 	}
 
@@ -95,7 +93,7 @@ function DropdownContainer:render()
 			toggleButton,
 			Div{
 				classes = {'dropdown-widget__menu'},
-				attributes = menuAttributes,
+				attributes = {['aria-hidden'] = 'true'},
 				children = self.props.children
 			}
 		}

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -36,7 +36,6 @@ local VARIANT_CONFIG = {
 }
 
 ---@class DropdownContainerWidgetParameters
----@field button string|Widget|(string|Widget)[]
 ---@field children Renderable|Renderable[]
 ---@field variant 'inline'|'form'?
 ---@field classes string[]?
@@ -60,32 +59,26 @@ function DropdownContainer:render()
 	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
 	local variantConfig = VARIANT_CONFIG[self.props.variant]
 
-	local buttonAttributes = {}
-	local menuAttributes = {}
+	local buttonAttributes = {
+		['aria-expanded'] = 'false',
+		['aria-haspopup'] = 'menu',
+	}
+	local menuAttributes = {['aria-hidden'] = 'true'}
 
-	local toggleChildren = self.props.button
-	if self.props.variant == 'form' then
-		buttonAttributes = Table.merge({
-			['aria-expanded'] = 'false',
-			['aria-haspopup'] = 'menu',
-		}, buttonAttributes)
-		menuAttributes = Table.merge({['aria-hidden'] = 'true'}, menuAttributes)
-
-		toggleChildren = {
-			Logic.isEmpty(self.props.prefix) and nil or Span{
-				classes = {'dropdown-widget__prefix'},
-				children = self.props.prefix,
-			},
-			Span{
-				classes = {'dropdown-widget__label'},
-				children = self.props.label,
-			},
-			Span{
-				classes = {'dropdown-widget__indicator'},
-				children = {Icon{iconName = 'expand', size = 'xs'}},
-			},
-		}
-	end
+	local toggleChildren = {
+		Logic.isEmpty(self.props.prefix) and nil or Span{
+			classes = {'dropdown-widget__prefix'},
+			children = self.props.prefix,
+		},
+		Span{
+			classes = {'dropdown-widget__label'},
+			children = self.props.label,
+		},
+		Span{
+			classes = {'dropdown-widget__indicator'},
+			children = {Icon{iconName = 'expand', size = 'xs'}},
+		},
+	}
 
 	local toggleButton = Button{
 		size = variantConfig.buttonSize,

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -19,11 +19,6 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local Div = HtmlWidgets.Div
 local Span = HtmlWidgets.Span
 
-local VALID_VARIANTS = {
-	form = true,
-	inline = true,
-}
-
 local VARIANT_CONFIG = {
 	inline = {
 		size = 'xs',
@@ -56,8 +51,7 @@ function DropdownContainer:render()
 		return nil
 	end
 
-	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
-	local variantConfig = VARIANT_CONFIG[self.props.variant]
+	local variantConfig = assert(VARIANT_CONFIG[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
 
 	local toggleChildren = WidgetUtil.collect(
 		Logic.isNotEmpty(self.props.prefix) and Span{

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -10,21 +10,39 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
+local Table = Lua.import('Module:Table')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Button = Lua.import('Module:Widget/Basic/Button')
 local Div = HtmlWidgets.Div
 
+local VALID_VARIANTS = {
+	inline = true,
+	form = true,
+}
+
 ---@class DropdownContainerWidgetParameters
 ---@field button string|Widget|(string|Widget)[]
 ---@field children Renderable|Renderable[]
+---@field variant 'inline'|'form'?
 ---@field classes string[]?
+---@field buttonClasses string[]?
+---@field buttonAttributes table?
+---@field menuClasses string[]?
+---@field menuAttributes table?
+---@field buttonSize 'xs'|'sm'|'md'|'lg'?
+---@field buttonVariant string?
 
 ---@class DropdownContainerWidget: Widget
 ---@operator call(DropdownContainerWidgetParameters): DropdownContainerWidget
 ---@field props DropdownContainerWidgetParameters
 local DropdownContainer = Class.new(Widget)
+DropdownContainer.defaultProps = {
+	variant = 'inline',
+	buttonSize = 'xs',
+	buttonVariant = 'ghost',
+}
 
 ---@return Widget|nil
 function DropdownContainer:render()
@@ -32,20 +50,23 @@ function DropdownContainer:render()
 		return nil
 	end
 
+	assert(VALID_VARIANTS[self.props.variant], 'Invalid Dropdown variant "' .. self.props.variant .. '"')
+
 	local toggleButton = Button{
-		size = 'xs',
-		variant = 'ghost',
-		classes = {'dropdown-widget__toggle'},
-		attributes = {['data-dropdown-toggle'] = 'true'},
+		size = self.props.buttonSize,
+		variant = self.props.buttonVariant,
+		classes = Array.extend('dropdown-widget__toggle', self.props.buttonClasses),
+		attributes = Table.merge(self.props.buttonAttributes or {}, {['data-dropdown-toggle'] = 'true'}),
 		children = self.props.button
 	}
 
 	return Div{
-		classes = Array.extend('dropdown-widget', self.props.classes),
+		classes = Array.extend({'dropdown-widget', 'dropdown-widget--' .. self.props.variant}, self.props.classes),
 		children = {
 			toggleButton,
 			Div{
-				classes = {'dropdown-widget__menu'},
+				classes = Array.extend('dropdown-widget__menu', self.props.menuClasses),
+				attributes = self.props.menuAttributes,
 				children = self.props.children
 			}
 		}

--- a/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
+++ b/lua/wikis/commons/Widget/Basic/Dropdown/Container.lua
@@ -10,7 +10,6 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
-local Table = Lua.import('Module:Table')
 
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -47,12 +47,9 @@ Template(s): Dropdown Widget
 		border: 1px solid;
 		border-radius: 0.25rem;
 		z-index: 10;
-
-		.theme--light & {
-			background-color: var( --clr-secondary-100 );
-			border-color: var( --clr-on-surface-light-primary-12 );
-			box-shadow: 0 1px 4px var( --clr-on-surface-light-primary-12 );
-		}
+		background-color: var( --clr-secondary-100 );
+		border-color: var( --clr-on-surface-light-primary-12 );
+		box-shadow: 0 1px 4px var( --clr-on-surface-light-primary-12 );
 
 		.theme--dark & {
 			background-color: var( --clr-secondary-9 );
@@ -107,10 +104,7 @@ Template(s): Dropdown Widget
 		border-radius: 0.25rem;
 		cursor: pointer;
 		gap: 0.25rem;
-
-		.theme--light & {
-			color: var( --clr-secondary-25 );
-		}
+		color: var( --clr-secondary-25 );
 
 		.theme--dark & {
 			color: var( --clr-secondary-90 );
@@ -118,10 +112,7 @@ Template(s): Dropdown Widget
 
 		&.active {
 			font-weight: bold;
-
-			.theme--light & {
-				color: var( --clr-secondary-25 ) !important;
-			}
+			color: var( --clr-secondary-25 ) !important;
 
 			.theme--dark & {
 				color: var( --clr-secondary-100 ) !important;
@@ -129,9 +120,7 @@ Template(s): Dropdown Widget
 		}
 
 		&:hover {
-			.theme--light & {
-				background-color: var( --clr-on-surface-light-primary-4 );
-			}
+			background-color: var( --clr-on-surface-light-primary-4 );
 
 			.theme--dark & {
 				background-color: var( --clr-on-surface-dark-primary-4 );
@@ -141,21 +130,19 @@ Template(s): Dropdown Widget
 
 	&--form {
 		width: 100%;
-
-		.theme--light & {
-			--dropdown-toggle-border: var( --clr-secondary-90 );
-			--dropdown-toggle-text: var( --clr-secondary-16 );
-			--dropdown-menu-border: rgba( 0, 0, 0, 0.16 );
-			--dropdown-menu-shadow: 0 1px 4px rgba( 0, 0, 0, 0.12 );
-			--dropdown-item-color: var( --clr-secondary-25 );
-			--dropdown-item-bg: var( --clr-on-surface-light-primary-4 );
-		}
+		--dropdown-menu-shadow: 0 1px 4px var( --dropdown-menu-shadow-color );
+		--dropdown-toggle-border: var( --clr-secondary-90 );
+		--dropdown-toggle-text: var( --clr-secondary-16 );
+		--dropdown-menu-border: var( --clr-on-surface-light-primary-16 );
+		--dropdown-menu-shadow-color: var( --clr-on-surface-light-primary-12 );
+		--dropdown-item-color: var( --clr-secondary-25 );
+		--dropdown-item-bg: var( --clr-on-surface-light-primary-4 );
 
 		.theme--dark & {
 			--dropdown-toggle-border: var( --clr-secondary-25 );
 			--dropdown-toggle-text: var( --clr-secondary-100 );
 			--dropdown-menu-border: var( --clr-secondary-25 );
-			--dropdown-menu-shadow: 0 1px 4px var( --clr-on-surface-dark-primary-4 );
+			--dropdown-menu-shadow-color: var( --clr-on-surface-dark-primary-4 );
 			--dropdown-item-color: var( --clr-secondary-100 );
 			--dropdown-item-bg: var( --clr-on-surface-dark-primary-8 );
 		}

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -89,6 +89,31 @@ Template(s): Dropdown Widget
 		}
 	}
 
+	&__prefix {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+	}
+
+	&__label {
+		flex: 1;
+	}
+
+	&__indicator {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+		transition: transform 0.2s ease;
+	}
+
+	&__toggle[aria-expanded="true"] &__indicator {
+		transform: rotate(180deg);
+	}
+
 	&--form &__menu {
 		min-width: 100%;
 		padding: 0.25rem 0;

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -118,6 +118,14 @@ Template(s): Dropdown Widget
 
 		&.active {
 			font-weight: bold;
+
+			.theme--light & {
+				color: var( --clr-secondary-25 );
+			}
+
+			.theme--dark & {
+				color: var( --clr-secondary-100 );
+			}
 		}
 
 		&:hover {

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -171,7 +171,7 @@ Template(s): Dropdown Widget
 
 		.dropdown-widget__menu {
 			min-width: 100%;
-			padding: 0.25rem 0;
+			padding: 0 0;
 			margin-top: 0.25rem;
 			z-index: 20;
 			background-color: var( --clr-background );

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -129,6 +129,21 @@ Template(s): Dropdown Widget
 				background-color: var( --clr-on-surface-dark-primary-4 );
 			}
 		}
+
+		a {
+			color: inherit;
+		}
+
+		&.new,
+		.new {
+			.theme--light & {
+				color: var( --clr-semantic-negative-40 ) !important;
+			}
+
+			.theme--dark & {
+				color: var( --clr-semantic-negative-80 ) !important;
+			}
+		}
 	}
 
 	&--form {

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -120,11 +120,11 @@ Template(s): Dropdown Widget
 			font-weight: bold;
 
 			.theme--light & {
-				color: var( --clr-secondary-25 );
+				color: var( --clr-secondary-25 ) !important;
 			}
 
 			.theme--dark & {
-				color: var( --clr-secondary-100 );
+				color: var( --clr-secondary-100 ) !important;
 			}
 		}
 
@@ -135,21 +135,6 @@ Template(s): Dropdown Widget
 
 			.theme--dark & {
 				background-color: var( --clr-on-surface-dark-primary-4 );
-			}
-		}
-
-		a {
-			color: inherit;
-		}
-
-		&.new,
-		.new {
-			.theme--light & {
-				color: var( --clr-semantic-negative-40 ) !important;
-			}
-
-			.theme--dark & {
-				color: var( --clr-semantic-negative-80 ) !important;
 			}
 		}
 	}

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -100,6 +100,13 @@ Template(s): Dropdown Widget
 		flex: 1;
 	}
 
+	&--form &__label {
+		font-size: 0.875rem;
+		font-weight: normal;
+		line-height: 1.25rem;
+		text-align: left;
+	}
+
 	&__indicator {
 		display: inline-flex;
 		align-items: center;
@@ -110,14 +117,15 @@ Template(s): Dropdown Widget
 		transition: transform 0.2s ease;
 	}
 
-	&__toggle[aria-expanded="true"] &__indicator {
-		transform: rotate(180deg);
+	&__toggle[ aria-expanded="true" ] &__indicator {
+		transform: rotate( 180deg );
 	}
 
 	&--form &__menu {
 		min-width: 100%;
 		padding: 0.25rem 0;
 		margin-top: 0.25rem;
+		z-index: 20;
 
 		.theme--light & {
 			background-color: var( --clr-background );
@@ -130,6 +138,12 @@ Template(s): Dropdown Widget
 			border-color: var( --clr-secondary-25 );
 			box-shadow: 0 1px 4px var( --clr-on-surface-dark-primary-4 );
 		}
+	}
+
+	& &__menu > ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
 	}
 
 	&__item {
@@ -175,6 +189,16 @@ Template(s): Dropdown Widget
 		}
 
 		&:hover {
+			.theme--light & {
+				background-color: var( --clr-on-surface-light-primary-4 );
+			}
+
+			.theme--dark & {
+				background-color: var( --clr-on-surface-dark-primary-8 );
+			}
+		}
+
+		&.active {
 			.theme--light & {
 				background-color: var( --clr-on-surface-light-primary-4 );
 			}

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -187,11 +187,11 @@ Template(s): Dropdown Widget
 		font-size: 0.875rem;
 
 		.theme--light & {
-			color: var( --clr-secondary-39 );
+			color: var( --clr-secondary-25 );
 		}
 
 		.theme--dark & {
-			color: var( --clr-secondary-80 );
+			color: var( --clr-secondary-100 );
 		}
 
 		&:hover {
@@ -213,5 +213,9 @@ Template(s): Dropdown Widget
 				background-color: var( --clr-on-surface-dark-primary-8 );
 			}
 		}
+	}
+
+	&__menu .dropdown-widget__item > a {
+		color: inherit !important;
 	}
 }

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -103,7 +103,7 @@ Template(s): Dropdown Widget
 		align-items: center;
 		padding: 0.25rem 0.5rem;
 		font-size: 0.6875rem;
-		font-weight: bold;
+		font-weight: normal;
 		border-radius: 0.25rem;
 		cursor: pointer;
 		gap: 0.25rem;
@@ -114,6 +114,10 @@ Template(s): Dropdown Widget
 
 		.theme--dark & {
 			color: var( --clr-secondary-90 );
+		}
+
+		&.active {
+			font-weight: bold;
 		}
 
 		&:hover {
@@ -190,9 +194,5 @@ Template(s): Dropdown Widget
 				background-color: var( --dropdown-item-bg );
 			}
 		}
-	}
-
-	&__menu .dropdown-widget__item > a {
-		color: inherit !important;
 	}
 }

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -32,6 +32,10 @@ Template(s): Dropdown Widget
 		text-decoration: none;
 	}
 
+	&--form {
+		width: 100%;
+	}
+
 	&__menu {
 		display: none;
 		position: absolute;
@@ -61,6 +65,48 @@ Template(s): Dropdown Widget
 		}
 	}
 
+	&--form &__toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		min-height: 2.75rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.25rem;
+		border: 1px solid;
+		cursor: pointer;
+
+		.theme--light & {
+			border-color: var( --clr-secondary-90 );
+			background-color: var( --clr-background );
+			color: var( --clr-secondary-16 ) !important;
+		}
+
+		.theme--dark & {
+			border-color: var( --clr-secondary-25 );
+			background-color: var( --clr-background );
+			color: var( --clr-secondary-100 ) !important;
+		}
+	}
+
+	&--form &__menu {
+		min-width: 100%;
+		padding: 0.25rem 0;
+		margin-top: 0.25rem;
+
+		.theme--light & {
+			background-color: var( --clr-background );
+			border-color: rgba( 0, 0, 0, 0.16 );
+			box-shadow: 0 1px 4px rgba( 0, 0, 0, 0.12 );
+		}
+
+		.theme--dark & {
+			background-color: var( --clr-background );
+			border-color: var( --clr-secondary-25 );
+			box-shadow: 0 1px 4px var( --clr-on-surface-dark-primary-4 );
+		}
+	}
+
 	&__item {
 		display: flex;
 		align-items: center;
@@ -86,6 +132,30 @@ Template(s): Dropdown Widget
 
 			.theme--dark & {
 				background-color: var( --clr-on-surface-dark-primary-4 );
+			}
+		}
+	}
+
+	&--form &__item {
+		padding: 0.5rem 0.75rem;
+		margin: 0.25rem;
+		font-size: 0.875rem;
+
+		.theme--light & {
+			color: var( --clr-secondary-39 );
+		}
+
+		.theme--dark & {
+			color: var( --clr-secondary-80 );
+		}
+
+		&:hover {
+			.theme--light & {
+				background-color: var( --clr-on-surface-light-primary-4 );
+			}
+
+			.theme--dark & {
+				background-color: var( --clr-on-surface-dark-primary-8 );
 			}
 		}
 	}

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -32,10 +32,6 @@ Template(s): Dropdown Widget
 		text-decoration: none;
 	}
 
-	&--form {
-		width: 100%;
-	}
-
 	&__toggle {
 		display: inline-flex;
 		align-items: center;
@@ -71,30 +67,6 @@ Template(s): Dropdown Widget
 		}
 	}
 
-	&--form &__toggle {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		width: 100%;
-		min-height: 2.75rem;
-		padding: 0.5rem 0.75rem;
-		border-radius: 0.25rem;
-		border: 1px solid;
-		cursor: pointer;
-
-		.theme--light & {
-			border-color: var( --clr-secondary-90 );
-			background-color: var( --clr-background );
-			color: var( --clr-secondary-16 ) !important;
-		}
-
-		.theme--dark & {
-			border-color: var( --clr-secondary-25 );
-			background-color: var( --clr-background );
-			color: var( --clr-secondary-100 ) !important;
-		}
-	}
-
 	&__prefix {
 		display: inline-flex;
 		align-items: center;
@@ -104,13 +76,6 @@ Template(s): Dropdown Widget
 
 	&__label {
 		flex: 1;
-	}
-
-	&--form &__label {
-		font-size: 0.875rem;
-		font-weight: normal;
-		line-height: 1.25rem;
-		text-align: left;
 	}
 
 	&__indicator {
@@ -123,30 +88,11 @@ Template(s): Dropdown Widget
 		transition: transform 0.2s ease;
 	}
 
-	&__toggle[ aria-expanded="true" ] &__indicator {
+	&__toggle[ aria-expanded="true" ] .dropdown-widget__indicator {
 		transform: rotate( 180deg );
 	}
 
-	&--form &__menu {
-		min-width: 100%;
-		padding: 0.25rem 0;
-		margin-top: 0.25rem;
-		z-index: 20;
-
-		.theme--light & {
-			background-color: var( --clr-background );
-			border-color: rgba( 0, 0, 0, 0.16 );
-			box-shadow: 0 1px 4px rgba( 0, 0, 0, 0.12 );
-		}
-
-		.theme--dark & {
-			background-color: var( --clr-background );
-			border-color: var( --clr-secondary-25 );
-			box-shadow: 0 1px 4px var( --clr-on-surface-dark-primary-4 );
-		}
-	}
-
-	& &__menu > ul {
+	&__menu > ul {
 		list-style: none;
 		margin: 0;
 		padding: 0;
@@ -181,36 +127,67 @@ Template(s): Dropdown Widget
 		}
 	}
 
-	&--form &__item {
-		padding: 0.5rem 0.75rem;
-		margin: 0.25rem;
-		font-size: 0.875rem;
+	&--form {
+		width: 100%;
 
 		.theme--light & {
-			color: var( --clr-secondary-25 );
+			--dropdown-toggle-border: var( --clr-secondary-90 );
+			--dropdown-toggle-text: var( --clr-secondary-16 );
+			--dropdown-menu-border: rgba( 0, 0, 0, 0.16 );
+			--dropdown-menu-shadow: 0 1px 4px rgba( 0, 0, 0, 0.12 );
+			--dropdown-item-color: var( --clr-secondary-25 );
+			--dropdown-item-bg: var( --clr-on-surface-light-primary-4 );
 		}
 
 		.theme--dark & {
-			color: var( --clr-secondary-100 );
+			--dropdown-toggle-border: var( --clr-secondary-25 );
+			--dropdown-toggle-text: var( --clr-secondary-100 );
+			--dropdown-menu-border: var( --clr-secondary-25 );
+			--dropdown-menu-shadow: 0 1px 4px var( --clr-on-surface-dark-primary-4 );
+			--dropdown-item-color: var( --clr-secondary-100 );
+			--dropdown-item-bg: var( --clr-on-surface-dark-primary-8 );
 		}
 
-		&:hover {
-			.theme--light & {
-				background-color: var( --clr-on-surface-light-primary-4 );
-			}
-
-			.theme--dark & {
-				background-color: var( --clr-on-surface-dark-primary-8 );
-			}
+		.dropdown-widget__toggle {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			width: 100%;
+			min-height: 2.75rem;
+			padding: 0.5rem 0.75rem;
+			border-radius: 0.25rem;
+			border: 1px solid var( --dropdown-toggle-border );
+			cursor: pointer;
+			background-color: var( --clr-background );
+			color: var( --dropdown-toggle-text ) !important;
 		}
 
-		&.active {
-			.theme--light & {
-				background-color: var( --clr-on-surface-light-primary-4 );
-			}
+		.dropdown-widget__label {
+			font-size: 0.875rem;
+			font-weight: normal;
+			line-height: 1.25rem;
+			text-align: left;
+		}
 
-			.theme--dark & {
-				background-color: var( --clr-on-surface-dark-primary-8 );
+		.dropdown-widget__menu {
+			min-width: 100%;
+			padding: 0.25rem 0;
+			margin-top: 0.25rem;
+			z-index: 20;
+			background-color: var( --clr-background );
+			border-color: var( --dropdown-menu-border );
+			box-shadow: var( --dropdown-menu-shadow );
+		}
+
+		.dropdown-widget__item {
+			padding: 0.5rem 0.75rem;
+			margin: 0.25rem;
+			font-size: 0.875rem;
+			color: var( --dropdown-item-color );
+
+			&:hover,
+			&.active {
+				background-color: var( --dropdown-item-bg );
 			}
 		}
 	}

--- a/stylesheets/commons/Dropdown.scss
+++ b/stylesheets/commons/Dropdown.scss
@@ -36,6 +36,12 @@ Template(s): Dropdown Widget
 		width: 100%;
 	}
 
+	&__toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
 	&__menu {
 		display: none;
 		position: absolute;


### PR DESCRIPTION
## Summary

- Static tabs needed a reusable dropdown primitive instead with the new `form` style variant
- Add a shared `form` dropdown variant with built-in prefix/label/indicator markup, generic open/close and keyboard handling, lifecycle events, and shared form item styling for linked and non-linked items.
- Tighten the dropdown container API by removing the old custom toggle prop path, making `form` the default variant, and covering the shared Lua and JS behavior with focused tests.

## How did you test this change?

dev + devtools
https://liquipedia.net/rocketleague/User:Eetwalt#Dropdown_Dev_Test