### PR TITLE
fix: Add R6 default tiertype 'General' to conditions

### DIFF
--- a/lua/wikis/commons/TournamentsListing/Conditions.lua
+++ b/lua/wikis/commons/TournamentsListing/Conditions.lua
@@ -158,7 +158,7 @@ function TournamentsListingConditions.placeConditions(tournamentData, config)
 			-- Condition on tier/tiertype is here to exclude on-page showmatch prizepools used on some wikis
 			ConditionNode(ColumnName('liquipediatier'), Comparator.eq, tier),
 			-- Tiertype 'General' is the default (instead of empty) on R6. Unused on other wikis, so can just add it here.
-			Condition.Util.anyof(ColumnName('liquipediatiertype'), {tierType or '', 'General'}),
+			Condition.Util.anyOf(ColumnName('liquipediatiertype'), {tierType or '', 'General'}),
 			ConditionNode(ColumnName(config.useParent and 'parent' or 'pagename'), Comparator.eq, tournamentData.pageName),
 			ConditionNode(ColumnName('placement'), Comparator.neq, '')
 		}

--- a/lua/wikis/commons/TournamentsListing/Conditions.lua
+++ b/lua/wikis/commons/TournamentsListing/Conditions.lua
@@ -155,8 +155,10 @@ function TournamentsListingConditions.placeConditions(tournamentData, config)
 	local tier, tierType = Tier.toValue(tournamentData.liquipediaTier, tournamentData.liquipediaTierType)
 	local conditions = ConditionTree(BooleanOperator.all)
 		:add{
+			-- Condition on tier/tiertype is here to exclude on-page showmatch prizepools used on some wikis
 			ConditionNode(ColumnName('liquipediatier'), Comparator.eq, tier),
-			ConditionNode(ColumnName('liquipediatiertype'), Comparator.eq, tierType or ''),
+			-- Tiertype 'General' is the default (instead of empty) on R6. Unused on other wikis, so can just add it here.
+			Condition.Util.anyof(ColumnName('liquipediatiertype'), {tierType or '', 'General'}),
 			ConditionNode(ColumnName(config.useParent and 'parent' or 'pagename'), Comparator.eq, tournamentData.pageName),
 			ConditionNode(ColumnName('placement'), Comparator.neq, '')
 		}


### PR DESCRIPTION
## Summary
R6 uses the default tiertype 'General', which is not setup as regular tiertype and thus does not survive Tournament.fromRecord construction.

Add it directly to the condition to circumvent this issue for now.
According to @Rathoz it should be removed entirely in the future.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
