### PR TITLE
feat: automate proxy setup for local testing

### DIFF
--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -1,0 +1,61 @@
+import logging
+import subprocess
+
+from http import HTTPStatus
+from mitmproxy import http
+
+
+class LiquipediaMapper:
+    def request(self, flow: http.HTTPFlow) -> None:
+        if "://liquipedia.net/" not in flow.request.pretty_url:
+            return
+
+        if (
+            "only=styles" in flow.request.pretty_url
+            and "skin=lakesideview" not in flow.request.pretty_url
+        ):
+            self.__build_css_resource(flow)
+        elif "only=scripts" in flow.request.pretty_url:
+            self.__build_js_resource(flow)
+
+    def __build_css_resource(self, flow: http.HTTPFlow):
+        try:
+            logging.info(
+                subprocess.check_output(
+                    ["npm", "run", "build:css"], stderr=subprocess.STDOUT
+                ).decode()
+            )
+            logging.info("Successfully compiled stylesheet")
+        except subprocess.SubprocessError as e:
+            logging.exception(e)
+            return
+        with open("lua/output/css/main.css", "rb") as f:
+            flow.response = http.Response.make(
+                HTTPStatus.OK,
+                f.read(),
+                {"Content-Type": "text/css; charset=utf-8", "Via": "LiquipediaMapper"},
+            )
+
+    def __build_js_resource(self, flow: http.HTTPFlow):
+        try:
+            logging.info(
+                subprocess.check_output(
+                    ["node", "build-js.js"], stderr=subprocess.STDOUT
+                ).decode()
+            )
+            logging.info("Successfully compiled javascript")
+        except subprocess.SubprocessError as e:
+            logging.exception(e)
+            return
+        with open("lua/output/js/main.js", "rb") as f:
+            flow.response = http.Response.make(
+                HTTPStatus.OK,
+                f.read(),
+                {
+                    "Content-Type": "text/javascript; charset=utf-8",
+                    "Via": "LiquipediaMapper",
+                },
+            )
+
+
+addons = [LiquipediaMapper()]

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -23,7 +23,10 @@ class LiquipediaMapper:
             flow.response = http.Response.make(
                 HTTPStatus.OK,
                 f.read(),
-                {"Content-Type": "text/css; charset=utf-8", "Via": "LiquipediaMapper"},
+                {"Content-Type": "text/css; charset=utf-8"},
+            )
+            flow.response.headers["Via"] = (
+                f"{flow.response.http_version} LiquipediaMapper"
             )
 
     def __serve_local_js_resource(self, flow: http.HTTPFlow):
@@ -31,10 +34,10 @@ class LiquipediaMapper:
             flow.response = http.Response.make(
                 HTTPStatus.OK,
                 f.read(),
-                {
-                    "Content-Type": "text/javascript; charset=utf-8",
-                    "Via": "LiquipediaMapper",
-                },
+                {"Content-Type": "text/css; charset=utf-8"},
+            )
+            flow.response.headers["Via"] = (
+                f"{flow.response.http_version} LiquipediaMapper"
             )
 
 

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -12,7 +12,10 @@ class LiquipediaMapper:
             and "skin=lakesideview" not in flow.request.pretty_url
         ):
             self.__serve_local_css_resource(flow)
-        elif "only=scripts" in flow.request.pretty_url:
+        elif (
+            "only=scripts" in flow.request.pretty_url
+            and "skin=lakesideview" not in flow.request.pretty_url
+        ):
             self.__serve_local_js_resource(flow)
 
     def __serve_local_css_resource(self, flow: http.HTTPFlow):

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -34,7 +34,7 @@ class LiquipediaMapper:
             flow.response = http.Response.make(
                 HTTPStatus.OK,
                 f.read(),
-                {"Content-Type": "text/css; charset=utf-8"},
+                {"Content-Type": "text/javascript; charset=utf-8"},
             )
             flow.response.headers["Via"] = (
                 f"{flow.response.http_version} LiquipediaMapper"

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -11,11 +11,11 @@ class LiquipediaMapper:
             "only=styles" in flow.request.pretty_url
             and "skin=lakesideview" not in flow.request.pretty_url
         ):
-            self.__build_css_resource(flow)
+            self.__serve_local_css_resource(flow)
         elif "only=scripts" in flow.request.pretty_url:
-            self.__build_js_resource(flow)
+            self.__serve_local_js_resource(flow)
 
-    def __build_css_resource(self, flow: http.HTTPFlow):
+    def __serve_local_css_resource(self, flow: http.HTTPFlow):
         with open("lua/output/css/main.css", "rb") as f:
             flow.response = http.Response.make(
                 HTTPStatus.OK,
@@ -23,7 +23,7 @@ class LiquipediaMapper:
                 {"Content-Type": "text/css; charset=utf-8", "Via": "LiquipediaMapper"},
             )
 
-    def __build_js_resource(self, flow: http.HTTPFlow):
+    def __serve_local_js_resource(self, flow: http.HTTPFlow):
         with open("lua/output/js/main.js", "rb") as f:
             flow.response = http.Response.make(
                 HTTPStatus.OK,

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -1,6 +1,3 @@
-import logging
-import subprocess
-
 from http import HTTPStatus
 from mitmproxy import http
 
@@ -19,16 +16,6 @@ class LiquipediaMapper:
             self.__build_js_resource(flow)
 
     def __build_css_resource(self, flow: http.HTTPFlow):
-        try:
-            logging.info(
-                subprocess.check_output(
-                    ["npm", "run", "build:css"], stderr=subprocess.STDOUT
-                ).decode()
-            )
-            logging.info("Successfully compiled stylesheet")
-        except subprocess.SubprocessError as e:
-            logging.exception(e)
-            return
         with open("lua/output/css/main.css", "rb") as f:
             flow.response = http.Response.make(
                 HTTPStatus.OK,
@@ -37,16 +24,6 @@ class LiquipediaMapper:
             )
 
     def __build_js_resource(self, flow: http.HTTPFlow):
-        try:
-            logging.info(
-                subprocess.check_output(
-                    ["node", "build-js.js"], stderr=subprocess.STDOUT
-                ).decode()
-            )
-            logging.info("Successfully compiled javascript")
-        except subprocess.SubprocessError as e:
-            logging.exception(e)
-            return
         with open("lua/output/js/main.js", "rb") as f:
             flow.response = http.Response.make(
                 HTTPStatus.OK,


### PR DESCRIPTION
## Summary

This PR adds (semi-)automated python script version of #7201.

To use: `mitmproxy -s scripts/proxy_lp.py`, and the script automates the rest.

## How did you test this change?

local test run