### PR TITLE
feat(filter_buttons): Update pokemon filter buttons

### DIFF
--- a/lua/wikis/pokemon/FilterButtons/Config.lua
+++ b/lua/wikis/pokemon/FilterButtons/Config.lua
@@ -33,7 +33,7 @@ Config.categories = {
 		name = 'game',
 		property = 'game',
 		expandable = true,
-		items = {'sv', 'tcg', 'go', 'unite'},
+		items = {'champions', 'sv', 'tcg', 'go', 'unite'},
 		transform = function(game)
 			return Game.icon({game = game, noSpan = true, noLink = true, size = '36x36px'})
 		end


### PR DESCRIPTION
## Summary
Pokemon Champions will be used as competitive title this year, but will be a transition period where some events will still run the old game (`sv` in the module) and gradually phased out at a later date 

so this will contain all 5 titles for now then sometime later SV will be completely excluded

## How did you test this change?
live