### PR TITLE
feat(match2): fix IDV width

### DIFF
--- a/lua/wikis/identityv/MatchSummary.lua
+++ b/lua/wikis/identityv/MatchSummary.lua
@@ -19,7 +19,7 @@ local CustomMatchSummary = {}
 ---@param args table
 ---@return Widget
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '500px'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '540px'})
 end
 
 ---@param match MatchGroupUtilMatch


### PR DESCRIPTION
## Summary
Apparently this happens: 
<img width="545" height="344" alt="image" src="https://github.com/user-attachments/assets/a24c9060-7a0a-4043-8928-38eb0240a7af" />

So I extend the width a bit further to solve, this is mostly just web-version only issue as on phone the characters arent displayed by default so they have plenty of space normally fine

<img width="578" height="319" alt="image" src="https://github.com/user-attachments/assets/451d4ea5-e0cb-489b-b07d-94f23524985c" />
