### PR TITLE
chore: rename variable in Class.new

### DIFF
--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -59,7 +59,7 @@ function Class.new(base, init)
 
 		classTable.init(instance, ...)
 
-		return object
+		return instance
 	end
 
 	classTable.init = function(instance, ...)

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -54,20 +54,20 @@ function Class.new(base, init)
 	local metatable = {}
 
 	metatable.__call = function(class_tbl, ...)
-		local object = {}
-		setmetatable(object, classTable)
+		local instance = {}
+		setmetatable(instance, classTable)
 
-		classTable.init(object, ...)
+		classTable.init(instance, ...)
 
 		return object
 	end
 
-	classTable.init = function(object, ...)
+	classTable.init = function(instance, ...)
 		if base then
-			base.init(object, ...)
+			base.init(instance, ...)
 		end
 		if init then
-			init(object, ...)
+			init(instance, ...)
 		end
 	end
 

--- a/lua/wikis/commons/Class.lua
+++ b/lua/wikis/commons/Class.lua
@@ -37,32 +37,32 @@ Class.PRIVATE_FUNCTION_SPECIFIER = '_'
 ---@overload fun(init: fun(self, ...)): table
 ---@nodiscard
 function Class.new(base, init)
-	local instance = {}
+	local classTable = {}
 
 	if not init and type(base) == 'function' then
 		init = base
 		base = nil
 	elseif type(base) == 'table' then
 		for index, value in pairs(base) do
-			instance[index] = value
+			classTable[index] = value
 		end
-		instance._base = base
+		classTable._base = base
 	end
 
-	instance.__index = instance
+	classTable.__index = classTable
 
 	local metatable = {}
 
 	metatable.__call = function(class_tbl, ...)
 		local object = {}
-		setmetatable(object, instance)
+		setmetatable(object, classTable)
 
-		instance.init(object, ...)
+		classTable.init(object, ...)
 
 		return object
 	end
 
-	instance.init = function(object, ...)
+	classTable.init = function(object, ...)
 		if base then
 			base.init(object, ...)
 		end
@@ -71,12 +71,12 @@ function Class.new(base, init)
 		end
 	end
 
-	instance.export = function(options)
-		return Class.export(instance, options)
+	classTable.export = function(options)
+		return Class.export(classTable, options)
 	end
 
-	setmetatable(instance, metatable)
-	return instance
+	setmetatable(classTable, metatable)
+	return classTable
 end
 
 ---@generic T:table


### PR DESCRIPTION
## Summary

This PR renames `instance` in `Class.new` to `classTable` for clarity.

## How did you test this change?

N/A, simple variable name change