### PR TITLE
fix(standings): position change column header always shown

### DIFF
--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -123,7 +123,7 @@ function StandingsFfaWidget:_headerRow()
 	return TableWidgets.TableHeader{children = {
 		TableWidgets.Row{children = WidgetUtil.collect(
 			makeHeaderCell('#'),
-			makeHeaderCell(),
+			self:_showRoundColumns() and makeHeaderCell() or nil,
 			makeHeaderCell('Participant'),
 			Array.map(standings.tiebreakers, function(tiebreaker)
 				if not tiebreaker.title then


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1494087526762151936

## How did you test this change?

preview with dev