### PR TITLE
feat(match2): make grid layout container optionally collapsible

### DIFF
--- a/lua/wikis/commons/Widget/GeneralCollapsible/Default.lua
+++ b/lua/wikis/commons/Widget/GeneralCollapsible/Default.lua
@@ -25,6 +25,7 @@ local Widget = Lua.import('Module:Widget')
 ---@field titleClasses string[]?
 ---@field titleWidget Renderable?
 ---@field collapseAreaClasses string[]?
+---@field collapseAreaCss table<string, string|number>?
 ---@field children Renderable|Renderable[]?
 
 ---@class DefaultCollapsible: Widget
@@ -53,6 +54,7 @@ function DefaultCollapsible:render()
 			},
 			Div{
 				children = props.children,
+				css = props.collapseAreaCss,
 				classes = Array.extend({},
 					'should-collapse',
 					props.collapseAreaClasses

--- a/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
@@ -23,8 +23,7 @@ local MatchSummaryGamesContainer = Class.new(Widget)
 function MatchSummaryGamesContainer:render()
 	if Logic.isEmpty(self.props.children) then
 		return
-	end
-	if not Logic.readBool(self.props.collapsible) then
+	elseif Logic.isEmpty(self.props.gamesSectionName) and Logic.isEmpty(self.props.gamesSectionResult) then
 		return HtmlWidgets.Div{
 			classes = {'brkts-popup-body-grid'},
 			css = self.props.css,

--- a/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
@@ -28,13 +28,15 @@ local MatchSummaryGamesContainer = Class.new(Widget)
 
 ---@return Widget?
 function MatchSummaryGamesContainer:render()
-	if Logic.isEmpty(self.props.children) then
+	local props = self.props
+
+	if Logic.isEmpty(props.children) then
 		return
-	elseif Logic.isEmpty(self.props.gamesSectionName) and Logic.isEmpty(self.props.gamesSectionResult) then
+	elseif Logic.isEmpty(props.gamesSectionName) and Logic.isEmpty(props.gamesSectionResult) then
 		return HtmlWidgets.Div{
 			classes = {'brkts-popup-body-grid'},
-			css = self.props.css,
-			children = self.props.children,
+			css = props.css,
+			children = props.children,
 		}
 	end
 	return GeneralCollapsible{
@@ -44,14 +46,14 @@ function MatchSummaryGamesContainer:render()
 				'brkts-popup-body-grid-header'
 			},
 			children = {
-				HtmlWidgets.Div{children = self.props.gamesSectionName},
-				HtmlWidgets.Div{children = self.props.gamesSectionResult},
+				HtmlWidgets.Div{children = props.gamesSectionName},
+				HtmlWidgets.Div{children = props.gamesSectionResult},
 				CollapsibleToggle{},
 			}
 		},
-		collapseAreaCss = self.props.css,
+		collapseAreaCss = props.css,
 		collapseAreaClasses = {'brkts-popup-body-grid'},
-		children = self.props.children,
+		children = props.children,
 		shouldCollapse = true,
 	}
 end

--- a/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
@@ -15,8 +15,15 @@ local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default'
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
+---@class MatchSummaryGamesContainerProps
+---@field children? Renderable|Renderable[]
+---@field css? table<string, string|number>
+---@field gamesSectionName? Renderable|Renderable[]
+---@field gamesSectionResult? Renderable|Renderable[]
+
 ---@class MatchSummaryGamesContainer: Widget
----@operator call(table): MatchSummaryGamesContainer
+---@operator call(MatchSummaryGamesContainerProps): MatchSummaryGamesContainer
+---@field props MatchSummaryGamesContainerProps
 local MatchSummaryGamesContainer = Class.new(Widget)
 
 ---@return Widget?

--- a/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GamesContainer.lua
@@ -10,6 +10,8 @@ local Lua = require('Module:Lua')
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
 
+local CollapsibleToggle = Lua.import('Module:Widget/GeneralCollapsible/Toggle')
+local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local Widget = Lua.import('Module:Widget')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 
@@ -22,10 +24,29 @@ function MatchSummaryGamesContainer:render()
 	if Logic.isEmpty(self.props.children) then
 		return
 	end
-	return HtmlWidgets.Div{
-		classes = {'brkts-popup-body-grid'},
-		css = self.props.css,
+	if not Logic.readBool(self.props.collapsible) then
+		return HtmlWidgets.Div{
+			classes = {'brkts-popup-body-grid'},
+			css = self.props.css,
+			children = self.props.children,
+		}
+	end
+	return GeneralCollapsible{
+		titleWidget = HtmlWidgets.Div{
+			classes = {
+				'general-collapsible-default-header',
+				'brkts-popup-body-grid-header'
+			},
+			children = {
+				HtmlWidgets.Div{children = self.props.gamesSectionName},
+				HtmlWidgets.Div{children = self.props.gamesSectionResult},
+				CollapsibleToggle{},
+			}
+		},
+		collapseAreaCss = self.props.css,
+		collapseAreaClasses = {'brkts-popup-body-grid'},
 		children = self.props.children,
+		shouldCollapse = true,
 	}
 end
 

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -692,6 +692,23 @@ div.brkts-popup-body-element-thumbs {
 			}
 		}
 	}
+
+	&-header {
+		padding: unset;
+		grid-template-columns: 1fr 2fr 1fr;
+
+		> div {
+			display: flex;
+
+			&:first-child {
+				justify-content: flex-start;
+			}
+
+			&:nth-child( 2 ) {
+				justify-content: center;
+			}
+		}
+	}
 }
 
 .brkts-champion-icon {


### PR DESCRIPTION
## Summary

This PR adds optional collapsing capability for grid layout container, in preparation of migration for games that involves sets/subseries.

## How did you test this change?

dev