### PR TITLE
feat(MapPoolTable): Set category instead of erroring for unfound maps

### DIFF
--- a/lua/wikis/commons/MapPoolTable.lua
+++ b/lua/wikis/commons/MapPoolTable.lua
@@ -192,6 +192,7 @@ function MapPoolTable:_backFillMap(map)
 
 	local mapData = Map.getMapByPageName(Page.pageifyLink(map.pageName)) or getMapDataFromLookup(map.pageName)
 	if not mapData then
+		mapData = mapData or {}
 		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown map in MapPoolTable')
 	end
 

--- a/lua/wikis/commons/MapPoolTable.lua
+++ b/lua/wikis/commons/MapPoolTable.lua
@@ -191,7 +191,9 @@ function MapPoolTable:_backFillMap(map)
 	end
 
 	local mapData = Map.getMapByPageName(Page.pageifyLink(map.pageName)) or getMapDataFromLookup(map.pageName)
-	assert(mapData, 'No data found for "' .. map.pageName .. '"')
+	if not mapData then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with unknown map in MapPoolTable')
+	end
 
 	-- can not use Table.merge nor Table.deepMerge due to creators/creatorDisplayNames
 	map.displayName = map.displayName or mapData.displayName


### PR DESCRIPTION
## Summary
some usages of the old modules had that edge case so catching it without error seems a good idea to me

## How did you test this change?
live