### PR TITLE
feat(infobox): Additional parameter in overwatch for Character/Custom

### DIFF
--- a/lua/wikis/overwatch/Infobox/Character/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/Character/Custom.lua
@@ -37,10 +37,10 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'role' then
-		return {
+		Array.appendWith(
 			Cell{name = 'Role', children = {args.role}},
-			Cell{name = 'Subrole', children = {args.subrole}},
-		}
+			Cell{name = 'Subrole', children = {args.subrole}}
+		)
 	elseif id == 'custom' then
 		Array.appendWith(
 			widgets,

--- a/lua/wikis/overwatch/Infobox/Character/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/Character/Custom.lua
@@ -38,7 +38,6 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'role' then
 		Array.appendWith(
-			Cell{name = 'Role', children = {args.role}},
 			Cell{name = 'Subrole', children = {args.subrole}}
 		)
 	elseif id == 'custom' then

--- a/lua/wikis/overwatch/Infobox/Character/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/Character/Custom.lua
@@ -36,7 +36,12 @@ end
 ---@return Widget[]
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
-	if id == 'custom' then
+	if id == 'role' then
+		return {
+			Cell{name = 'Role', children = {args.role}},
+			Cell{name = 'Subrole', children = {args.subrole}},
+		}
+	elseif id == 'custom' then
 		Array.appendWith(
 			widgets,
 			Cell{name = 'Age', children = {args.age}},
@@ -56,7 +61,8 @@ end
 function CustomCharacter:getWikiCategories(args)
 	if not Namespace.isMain() then return {} end
 	return Array.append({'Heroes'},
-		String.isNotEmpty(args.role) and (args.role .. ' Heroes') or nil
+		String.isNotEmpty(args.role) and (args.role .. ' Heroes') or nil,
+		String.isNotEmpty(args.subrole) and (args.subrole .. ' Heroes') or nil
 	)
 end
 

--- a/lua/wikis/overwatch/Infobox/Character/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/Character/Custom.lua
@@ -38,6 +38,7 @@ function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 	if id == 'role' then
 		Array.appendWith(
+			widgets,
 			Cell{name = 'Subrole', children = {args.subrole}}
 		)
 	elseif id == 'custom' then


### PR DESCRIPTION
## Summary

Blizzard introduced "subroles" for their heroes with an update a month ago. Each subrole has different passive effects and should be displayed on the respective hero pages. Displaywise it should go directly below the existing "role" parameter, otherwise it looks very bad.

## How did you test this change?

[dev ](https://liquipedia.net/overwatch/Module:Infobox/Character/Custom/dev/iGeneral) on [userpage](https://liquipedia.net/overwatch/User:IGeneral/test9)