### PR TITLE
feat(filterbuttons): Remove default items for the Deadlock

### DIFF
--- a/lua/wikis/deadlock/FilterButtons/Config.lua
+++ b/lua/wikis/deadlock/FilterButtons/Config.lua
@@ -21,7 +21,6 @@ Config.categories = {
 				table.insert(category.items, tier.value)
 			end
 		end,
-		defaultItems = {'1', '2', '3'},
 		transform = function(tier)
 			return Tier.toName(tier)
 		end,


### PR DESCRIPTION
Requested on the Discord:
https://discord.com/channels/93055209017729024/1278051336889438218/1494636860474003520

Context: There is minimum of tournaments happening so they just wanna show all filters by default.
This is happening for months already. :) 

## Summary

quick test in live