### PR TITLE
feat: store maps on broodwar like on other faction wikis

### DIFF
--- a/lua/wikis/starcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/League/Custom.lua
@@ -263,13 +263,4 @@ function CustomLeague:getWikiCategories(args)
 	return {Logic.readBool(args.female) and 'Female Tournaments' or nil}
 end
 
----@param base string
----@return string
-function CustomLeague:_concatArgs(base)
-	return table.concat(
-		Array.map(self:getAllArgsForBase(self.args, base), mw.ext.TeamLiquidIntegration.resolve_redirect),
-		';'
-	)
-end
-
 return CustomLeague

--- a/lua/wikis/starcraft/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/League/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Opponent = Lua.import('Module:Opponent/Custom')
 local Page = Lua.import('Module:Page')
@@ -244,7 +245,7 @@ end
 ---@return table
 function CustomLeague:addToLpdb(lpdbData, args)
 	lpdbData.tickername = lpdbData.tickername or lpdbData.name
-	lpdbData.maps = self:_concatArgs('map')
+	lpdbData.maps = Json.stringify(self.data.maps)
 	-- do not resolve redirect on the series input
 	-- BW wiki has several series that are displayed on the same page
 	-- hence they need to not RR them


### PR DESCRIPTION
## Summary
needed to be able to use `Module:MapPoolTable` instead of the very old very outdated spaghetti code module broodwar currently uses ...
(adjusted the old module to map the json data to the old shit data format so we do not get any errors from this change)

## How did you test this change?
dev