### PR TITLE
fix(tabs): handle span-wrapped tab links

### DIFF
--- a/stylesheets/commons/Tabs.scss
+++ b/stylesheets/commons/Tabs.scss
@@ -91,7 +91,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 			background-color: unset !important;
 
 			> a,
-			> span,
+			> span:not( :has( > a ) ),
+			> span > a,
 			> strong {
 				display: flex;
 				align-items: center;
@@ -141,7 +142,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 			}
 
 			&.active > a,
-			&.active > span,
+			&.active > span:not( :has( > a ) ),
+			&.active > span > a,
 			&.active > strong {
 				background-color: $tabs-bg-active-light !important;
 				color: $tabs-text-active-light !important;
@@ -171,7 +173,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 			}
 
 			&.hover > a,
-			&.hover > span,
+			&.hover > span:not( :has( > a ) ),
+			&.hover > span > a,
 			&.hover > strong {
 				background-color: $tabs-bg-hover-light !important;
 
@@ -429,7 +432,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 		.nav-tabs li {
 			min-height: 2.25rem;
 
-			a {
+			> a,
+			> span > a {
 				padding: $tabs-nav-padding-nested;
 				min-height: 2.25rem;
 			}
@@ -444,7 +448,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 		.nav-tabs li {
 			min-height: 2.25rem;
 
-			a {
+			> a,
+			> span > a {
 				padding: $tabs-nav-padding-nested;
 				min-height: 2.25rem;
 			}
@@ -541,7 +546,8 @@ html.client-nojs .tabs-content > div:not( .active ) {
 		.tabs-nav-wrapper .nav-tabs li {
 			min-height: 2.25rem;
 
-			a {
+			> a,
+			> span > a {
 				padding: $tabs-nav-padding-nested;
 				min-height: 2.25rem;
 			}


### PR DESCRIPTION
## Summary

Span-wrapped tab links receive the tab padding and state styles twice, which makes affected tab rows taller than intended.
- apply tab styling to the nested link instead of the wrapper span when a tab renders as <span><a>...</a></span>
- keep nested tab padding consistent for wrapped links in normal, hover, and active states

## How did you test this change?

devtools

Page:
https://liquipedia.net/leagueoflegends/LCK_CL/2026/Rounds_1-2

Before:
<img width="847" height="90" alt="image" src="https://github.com/user-attachments/assets/f418dca5-743b-4c11-b5fc-98c636006c2b" />

After:
<img width="823" height="159" alt="image" src="https://github.com/user-attachments/assets/e81ca006-866b-49aa-bc03-6fa3786969c6" />

Template use:
<img width="1620" height="478" alt="image" src="https://github.com/user-attachments/assets/0c7425da-91b6-4641-b808-4eb029735260" />