### PR TITLE
feat(infobox): use `Infobox/Extension/PatchAuto` on sc2

### DIFF
--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -9,7 +9,7 @@ local Lua = require('Module:Lua')
 
 local AllowedServers = Lua.import('Module:Server')
 local Array = Lua.import('Module:Array')
-local Autopatch = Lua.import('Module:Automated Patch')
+local PatchAuto = Lua.import('Module:Infobox/Extension/PatchAuto')
 local Class = Lua.import('Module:Class')
 local Countdown = Lua.import('Module:Countdown')
 local DateExt = Lua.import('Module:Date/Ext')
@@ -29,6 +29,7 @@ local Injector = Lua.import('Module:Widget/Injector')
 local League = Lua.import('Module:Infobox/League')
 local RaceBreakdown = Lua.import('Module:Infobox/Extension/RaceBreakdown')
 
+local Link = Lua.import('Module:Widget/Basic/Link')
 local Widgets = Lua.import('Module:Widget/All')
 local Breakdown = Widgets.Breakdown
 local Cell = Widgets.Cell
@@ -102,20 +103,19 @@ end
 function CustomLeague:_computePatch(args)
 	local prefixPatch = function(patch)
 		if not patch then return end
-		return 'Patch ' .. patch
+		return 'Patch ' .. patch:gsub(' ', '_')
+	end
+	self.data.patch = prefixPatch(args.patch)
+	self.data.endPatch = prefixPatch(args.epatch)
+
+	if self.data.game ~= GAME_LOTV or not Logic.nilOr(Logic.readBoolOrNil(args.autopatch), true) then
+		return
 	end
 
-	local shouldFetchPatch = Logic.nilOr(Logic.readBoolOrNil(args.autopatch), true)
-	local fetchPatch = function(date)
-		if not shouldFetchPatch or self.data.game ~= GAME_LOTV then return end
-		return Autopatch._main{date}
-	end
-
-	local patch = args.patch or fetchPatch(self.data.startDate or TODAY)
-	local endPatch = args.epatch or fetchPatch(self.data.endDate or TODAY) or patch
-
-	self.data.patch = prefixPatch(patch)
-	self.data.endPatch = prefixPatch(endPatch)
+	self.data = PatchAuto.run(self.data, {
+		patch_display = prefixPatch(args.patch),
+		epatch_display = prefixPatch(args.epatch),
+	})
 end
 
 ---@param args table
@@ -201,7 +201,7 @@ function CustomInjector:parse(id, widgets)
 
 	if id == 'gamesettings' then
 		return {
-			Cell{name = 'Game Version', children = {caller:_getGameVersion(args)}},
+			Cell{name = 'Game Version', children = caller:_getGameVersion(args)},
 			Cell{name = 'Server', children = {caller:_getServer(args)}}
 		}
 	elseif id == 'dates' and data.startTime.display then
@@ -311,22 +311,24 @@ function CustomLeague._removePlus(inputValue, alreadyHasPlus)
 end
 
 ---@param args table
----@return string
+---@return Renderable[]
 function CustomLeague:_getGameVersion(args)
 	local betaPrefix = String.isNotEmpty(args.beta) and 'Beta ' or ''
 
 	local gameDisplay = self.data.game == GAME_MOD and (args.modname or 'Mod')
-		or Page.makeInternalLink(Game.name{game = self.data.game})
+		or Link{link = Game.name{game = self.data.game}}
 
 	local patch = self.data.patch
 	local endPatch = self.data.endPatch
 
-	local patchDisplay = betaPrefix .. table.concat({
-		Page.makeInternalLink(patch),
-		Page.makeInternalLink(endPatch ~= patch and patch and endPatch or nil)
-	}, ' &ndash; ')
+	local patches = Array.map(Array.map({
+		Link{link = patch, children = self.data.patchDisplay},
+		Link{link = endPatch ~= patch and patch and endPatch or nil, children = self.data.endPatchDisplay}
+	}, tostring), Logic.nilIfEmpty)
 
-	return table.concat({gameDisplay, patchDisplay}, '<br>')
+	local patchDisplay = betaPrefix .. table.concat(patches, ' &ndash; ')
+
+	return {gameDisplay, patchDisplay}
 end
 
 ---@param args table

--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -45,7 +45,6 @@ local FINISHED = 'finished'
 local DEFAULT_MODE = '1v1'
 local GREATER_EQUAL = '&#8805;'
 local PRIZE_POOL_ROUND_PRECISION = 2
-local TODAY = os.date('%Y-%m-%d', os.time())
 
 local GAME_MOD = 'mod'
 local GAME_LOTV = Game.toIdentifier{game = 'lotv'}

--- a/lua/wikis/starcraft2/Infobox/Series/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Series/Custom.lua
@@ -154,15 +154,6 @@ function CustomSeries:_getGameVersion()
 	return {gameDisplay, patchDisplay}
 end
 
----@param dateEntry string?
----@return string|osdate
-function CustomSeries._retrievePatchDate(dateEntry)
-	return String.isNotEmpty(dateEntry) ---@cast dateEntry -nil
-		and dateEntry:lower() ~= 'tbd'
-		and dateEntry:lower() ~= 'tba'
-		and dateEntry or TODAY
-end
-
 function CustomSeries:_addCustomVariables()
 	local args = self.args
 

--- a/lua/wikis/starcraft2/Infobox/Series/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Series/Custom.lua
@@ -8,7 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
-local Autopatch = Lua.import('Module:Automated Patch')
+local PatchAuto = Lua.import('Module:Infobox/Extension/PatchAuto')
 local Class = Lua.import('Module:Class')
 local Game = Lua.import('Module:Game')
 local Json = Lua.import('Module:Json')
@@ -23,6 +23,7 @@ local Variables = Lua.import('Module:Variables')
 local Injector = Lua.import('Module:Widget/Injector')
 local Series = Lua.import('Module:Infobox/Series')
 
+local Link = Lua.import('Module:Widget/Basic/Link')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
@@ -36,6 +37,7 @@ local CustomInjector = Class.new(Injector)
 
 ---@class Starcraft2SeriesInfobox: SeriesInfobox
 ---@operator call(Frame): Starcraft2SeriesInfobox
+---@field patchData {patch: string?, endPatch: string?, patchDisplay: string?, endPatchDisplay: string?}
 local CustomSeries = Class.new(Series)
 
 ---@param frame Frame
@@ -48,12 +50,47 @@ function CustomSeries.run(frame)
 
 	args.game = (args.game or ''):lower() == GAME_MOD and GAME_MOD or Game.toIdentifier{game = args.game}
 
+	series.patchData = series:_computePatch()
+
 	args.liquipediatiertype = args.liquipediatiertype or args.tiertype
 	args.liquipediatier = args.liquipediatier or args.tier
 
 	series:_addCustomVariables()
 
 	return series:createInfobox()
+end
+
+---@private
+---@return {patch: string?, endPatch: string?, patchDisplay: string?, endPatchDisplay: string?}
+function CustomSeries:_computePatch()
+	local args = self.args
+
+	local prefixPatch = function(patch)
+		if not patch then return end
+		return 'Patch ' .. patch:gsub(' ', '_')
+	end
+	local patch = prefixPatch(args.patch)
+	local endPatch = prefixPatch(args.epatch)
+
+	if args.game ~= GAME_LOTV or not Logic.nilOr(Logic.readBoolOrNil(args.autopatch), true) then
+		return {
+			patch = patch,
+			endPatch = endPatch,
+		}
+	end
+
+	return PatchAuto.run(
+		{
+			patch = patch,
+			endPatch = endPatch,
+			startDate = CustomSeries._validDateOr(args.date, args.sdate),
+			endDate = CustomSeries._validDateOr(args.date, args.edate)
+		},
+		{
+			patch_display = patch,
+			epatch_display = endPatch,
+		}
+	)
 end
 
 ---@param id string
@@ -69,7 +106,7 @@ function CustomInjector:parse(id, widgets)
 		}
 	elseif id == 'custom' then
 		Array.appendWith(widgets,
-			Cell{name = 'Game version', children = {self.caller:_getGameVersion(args.game, args.patch)}},
+			Cell{name = 'Game version', children = self.caller:_getGameVersion()},
 			Cell{name = 'Server', children = {args.server}},
 			Cell{name = 'Type', children = {args.type}},
 			Cell{name = 'Format', children = {args.format}}
@@ -94,52 +131,27 @@ function CustomSeries:_displaySeriesPrizepools()
 	}
 end
 
----@param game string?
----@param patch string?
----@return string
-function CustomSeries:_getGameVersion(game, patch)
+---@return Renderable[]
+function CustomSeries:_getGameVersion()
 	local args = self.args
 
-	local shouldUseAutoPatch = Logic.readBool(args.autopatch or true)
-	local modName = args.modname
 	local betaPrefix = String.isNotEmpty(args.beta) and 'Beta ' or ''
-	local endPatch = args.epatch
-	local startDate = args.sdate
-	local endDate = args.edate
 
-	local gameVersion
-	if game == GAME_MOD then
-		gameVersion = modName or 'Mod'
-	else
-		gameVersion = '[[' .. Game.name{game = game} .. ']]' ..
-			'[[Category:' .. betaPrefix .. Game.abbreviation{game = game} .. ' Competitions]]'
-	end
+	local gameDisplay = args.game == GAME_MOD and (args.modname or 'Mod')
+		or Link{link = Game.name{game = args.game}}
 
-	if game == GAME_LOTV and shouldUseAutoPatch then
-		if String.isEmpty(patch) then
-			patch = 'Patch ' .. (Autopatch._main({CustomSeries._retrievePatchDate(startDate)}) or '')
-		end
-		if String.isEmpty(endPatch) then
-			endPatch = 'Patch ' .. (Autopatch._main({CustomSeries._retrievePatchDate(endDate)}) or '')
-		end
-	elseif String.isEmpty(endPatch) then
-		endPatch = patch
-	end
+	local patchData = self.patchData
+	local patch = patchData.patch
+	local endPatch = patchData.endPatch
 
-	local patchDisplay = betaPrefix
+	local patches = Array.map(Array.map({
+		Link{link = patch, children = patchData.patchDisplay},
+		Link{link = endPatch ~= patch and patch and endPatch or nil, children = patchData.endPatchDisplay}
+	}, tostring), Logic.nilIfEmpty)
 
-	if String.isNotEmpty(patch) then
-		patchDisplay = patchDisplay .. '<br/>[[' .. patch .. ']]'
-		if patch ~= endPatch then
-			patchDisplay = patchDisplay .. ' &ndash; [[' .. endPatch .. ']]'
-		end
-	end
+	local patchDisplay = betaPrefix .. table.concat(patches, ' &ndash; ')
 
-	--set patch variables
-	Variables.varDefine('patch', patch)
-	Variables.varDefine('epatch', endPatch)
-
-	return gameVersion .. patchDisplay
+	return {gameDisplay, patchDisplay}
 end
 
 ---@param dateEntry string?
@@ -176,6 +188,9 @@ function CustomSeries:_addCustomVariables()
 		Variables.varDefine('tournament_parent', (args.parent or self.pagename):gsub(' ', '_'))
 		Variables.varDefine('tournament_game', args.game)
 		Variables.varDefine('tournament_type', args.type or '')
+		--set patch variables
+		Variables.varDefine('patch', self.patchData.patch)
+		Variables.varDefine('epatch', self.patchData.endPatch)
 		CustomSeries._setDateMatchVar(args.date, args.edate, args.sdate)
 	end
 end

--- a/lua/wikis/starcraft2/Infobox/Series/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Series/Custom.lua
@@ -29,7 +29,6 @@ local Cell = Widgets.Cell
 
 local GAME_MOD = 'mod'
 local GAME_LOTV = Game.toIdentifier{game = 'lotv'}
-local TODAY = os.date('%Y-%m-%d', os.time())
 
 ---@class Starcraft2SeriesInfoboxWidgetInjector: WidgetInjector
 ---@field caller Starcraft2SeriesInfobox


### PR DESCRIPTION
## Summary
use `Infobox/Extension/PatchAuto` in sc2 infoboxes league & series so we can kick `Module:Automated Patch`

## How did you test this change?
dev