### PR TITLE
fix: use pagename from data instead of input for mappools

### DIFF
--- a/lua/wikis/commons/MapPoolTable.lua
+++ b/lua/wikis/commons/MapPoolTable.lua
@@ -197,6 +197,7 @@ function MapPoolTable:_backFillMap(map)
 	end
 
 	-- can not use Table.merge nor Table.deepMerge due to creators/creatorDisplayNames
+	map.pageName = mapData.pageName or map.pageName
 	map.displayName = map.displayName or mapData.displayName
 	map.image = map.image or mapData.image
 	map.imageDark = map.imageDark or mapData.imageDark


### PR DESCRIPTION
## Summary
warcraft has several aliases in the data module
if such an alias is inputted the generated display currently links to the alias instead of the intended page
this pr makes it so that if data (lpdb or data module) for a map is found the pagename is retrieved from that so that the display links to that

## How did you test this change?
dev