### PR TITLE
feat(tabs): support wrapping for static tabs on fighters

### DIFF
--- a/lua/wikis/commons/Tabs.lua
+++ b/lua/wikis/commons/Tabs.lua
@@ -42,9 +42,7 @@ function Tabs.static(args)
 	Tabs._setThis(tabArgs)
 
 	-- Temporary solution for fighters
-	mw.log('Tabs.static: args.wrapping=' .. tostring(args.wrapping) .. ' wikiName=' .. tostring(Info.wikiName))
 	local wrapsClass = Logic.readBool(args.wrapping) and Info.wikiName == 'fighters' and 'wraps' or nil
-	mw.log('Tabs.static: wrapsClass=' .. tostring(wrapsClass))
 
 	local function buildTabLiItems(additionalClasses)
 		return Array.map(tabArgs, function(tab)

--- a/lua/wikis/commons/Tabs.lua
+++ b/lua/wikis/commons/Tabs.lua
@@ -41,6 +41,11 @@ function Tabs.static(args)
 
 	Tabs._setThis(tabArgs)
 
+	-- Temporary solution for fighters
+	mw.log('Tabs.static: args.wrapping=' .. tostring(args.wrapping) .. ' wikiName=' .. tostring(Info.wikiName))
+	local wrapsClass = Logic.readBool(args.wrapping) and Info.wikiName == 'fighters' and 'wraps' or nil
+	mw.log('Tabs.static: wrapsClass=' .. tostring(wrapsClass))
+
 	local function buildTabLiItems(additionalClasses)
 		return Array.map(tabArgs, function(tab)
 			--if tab.name is unset tab.link is set as per `Tabs._readArguments`
@@ -77,7 +82,7 @@ function Tabs.static(args)
 		analyticsName = 'Navigation tab',
 		children = {
 			HtmlWidgets.Div{
-				classes = {'tabs-static'},
+				classes = {'tabs-static', wrapsClass},
 				attributes = {['data-nosnippet'] = '', ['data-tabs-static'] = ''},
 				children = WidgetUtil.collect(
 					Tabs._buildNavWrapper(navTabs),

--- a/stylesheets/commons/Tabs.scss
+++ b/stylesheets/commons/Tabs.scss
@@ -185,6 +185,27 @@ html.client-nojs .tabs-content > div:not( .active ) {
 		}
 	}
 
+	/* Temporary solution for fighters */
+	&.wraps {
+		.tabs-nav-wrapper {
+			flex-wrap: wrap;
+		}
+
+		.tabs-nav-wrapper .nav-tabs {
+			flex-wrap: wrap;
+			overflow-x: visible;
+			scrollbar-width: auto;
+		}
+
+		.tabs-nav-wrapper .nav-tabs::-webkit-scrollbar {
+			display: initial;
+		}
+
+		.tabs-scroll-arrow-wrapper {
+			display: none !important;
+		}
+	}
+
 	/* Scroll Arrows */
 	.tabs-scroll-arrow-wrapper {
 		position: absolute;
@@ -477,27 +498,6 @@ html.client-nojs .tabs-content > div:not( .active ) {
 	& > .tabs-content {
 		border: unset !important;
 		padding: 0.5rem 0 0 0.5rem;
-	}
-
-	/* Temporary solution for fighters */
-	&.wraps {
-		.tabs-nav-wrapper {
-			flex-wrap: wrap;
-		}
-
-		.tabs-nav-wrapper .nav-tabs {
-			flex-wrap: wrap;
-			overflow-x: visible;
-			scrollbar-width: auto;
-		}
-
-		.tabs-nav-wrapper .nav-tabs::-webkit-scrollbar {
-			display: initial;
-		}
-
-		.tabs-scroll-arrow-wrapper {
-			display: none !important;
-		}
 	}
 
 	&.tabs-variant-vertical {


### PR DESCRIPTION
## Summary

Static tabs lacked the `wrapping` arg support that dynamic tabs had.

Adds `wraps` class to static tabs and moves the shared `&.wraps` SCSS block from `.tabs-dynamic` into the shared `.tabs-static, .tabs-dynamic` block so both tab types benefit.

## How did you test this change?

dev + devtools