### PR TITLE
feat: additional icons for Hero tabber to use on dota2 and dota2gameru

### DIFF
--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -278,7 +278,7 @@ return {
 	dota2_ht_relics = 'fad fa-diamond',
 	dota2_ht_old_abilties = 'fad fa-book-spells',
 	dota2_ht_calc = 'fas fa-function',
-	dota2_ht_old_abilties = 'fad fa-archive',
+	dota2_ht_unreleased = 'fad fa-archive',
 
 	-- Usage: Info button
 	['general-info'] = 'fas fa-info-circle',

--- a/lua/wikis/commons/Icon/Data.lua
+++ b/lua/wikis/commons/Icon/Data.lua
@@ -266,6 +266,20 @@ return {
 	dota2_spl_status = 'fas fa-hourglass-half',
 	dota2_spl_misc = 'fad fa-list-ul',
 
+	-- Usage: Dota2 Hero tabbber tabs
+	dota2_ht_overview = 'fas fa-id-badge',
+	dota2_ht_matches = 'fas fa-trophy',
+	dota2_ht_changelogs = 'fas fa-file-alt',
+	dota2_ht_responses = 'fas fa-microphone-alt',
+	dota2_ht_sounds = 'fas fa-volume',
+	dota2_ht_animations = 'far fa-running',
+	dota2_ht_lore = 'fas fa-scroll-old',
+	dota2_ht_equipment = 'fas fa-helmet-battle',
+	dota2_ht_relics = 'fad fa-diamond',
+	dota2_ht_old_abilties = 'fad fa-book-spells',
+	dota2_ht_calc = 'fas fa-function',
+	dota2_ht_old_abilties = 'fad fa-archive',
+
 	-- Usage: Info button
 	['general-info'] = 'fas fa-info-circle',
 }


### PR DESCRIPTION
## Summary
Tab icon definitions to use as some fluff for the previously empty tabber on Dota 2 hero pages.
The proposed icons are shown here: https://liquipedia.net/dota2/User:Le_Mur/Sandbox#Tabber_Icons
