### PR TITLE
feat: Automated Documentation for icon data

### DIFF
--- a/lua/wikis/commons/Icon/Data/Documentation.lua
+++ b/lua/wikis/commons/Icon/Data/Documentation.lua
@@ -1,0 +1,51 @@
+---
+-- @Liquipedia
+-- page=Module:Icon/Data/Documentation
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local FnUtil = Lua.import('Module:FnUtil')
+local IconData = Lua.import('Module:Icon/Data', {loadData = true})
+local Table = Lua.import('Module:Table')
+
+local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
+local UnorderedList = Lua.import('Module:Widget/List/Unordered')
+
+local IconDataDoc = {}
+
+---@return Widget
+function IconDataDoc.generate()
+	local iconNames = Array.extractKeys(IconData)
+	local groupedIcons
+	_, groupedIconNames = Array.groupBy(iconNames, function(iconName)
+		return iconName:sub(1,1):upper()
+	end)
+
+	local children = {}
+	for letter, group in Table.iter.spairs(groupedIconNames) do
+		Array.sortInPlaceBy(group, FnUtil.identity)
+
+		Array.appendWith(children,
+			HtmlWidgets.H3{children = letter},
+			UnorderedList{children = Array.map(group, IconDataDoc._displayIcon)}
+		)
+	end
+
+	return HtmlWidgets.Fragment{children = children}
+end
+
+---@param iconName string
+---@return Renderable[]
+function IconDataDoc._displayIcon(iconName)
+	return {
+		iconName,
+		': ',
+		Icon{iconName = iconName, size = '1rem'},
+	}
+end
+
+return IconDataDoc

--- a/lua/wikis/commons/Icon/Data/Documentation.lua
+++ b/lua/wikis/commons/Icon/Data/Documentation.lua
@@ -20,8 +20,7 @@ local IconDataDoc = {}
 ---@return Widget
 function IconDataDoc.generate()
 	local iconNames = Array.extractKeys(IconData)
-	local groupedIcons
-	_, groupedIconNames = Array.groupBy(iconNames, function(iconName)
+	local _, groupedIconNames = Array.groupBy(iconNames, function(iconName)
 		return iconName:sub(1,1):upper()
 	end)
 


### PR DESCRIPTION
## Summary
based on conversations on discord contributors would like a list available that shows all available icons (if Module:Icon/Data) and their names.
They want to be able to check what they can use e.g. in Tabs.

This PR adds a small module that generates such a list automatically so we do not have to update the docs everytime a new icon is added or an existing icon is changed ...

## How did you test this change?
live