### PR TITLE
fix(match2): missing nil catch for overall kill participation display in leagueoflegends matchpage

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -209,7 +209,9 @@ function MatchPage:renderOverallStats()
 						},
 						PlayerStat{
 							title = {KP_ICON, 'KP%'},
-							data = MathUtil.formatPercentage(player.extradata.killparticipation, 1)
+							data = player.extradata.killparticipation and MathUtil.formatPercentage(
+								player.extradata.killparticipation, 1
+							) or '-'
 						},
 						PlayerStat{
 							title = {


### PR DESCRIPTION
## How did you test this change?

live