### PR TITLE
fix(TeamParticipantCard): correct dark mode hover tooltip background

### DIFF
--- a/stylesheets/commons/TeamParticipantCard.scss
+++ b/stylesheets/commons/TeamParticipantCard.scss
@@ -604,7 +604,7 @@ body:has( .switch-toggle-active#{ $compact-selector } ) {
 				}
 
 				.theme--dark & {
-					background-color: var( --clr-on-surface-dark-primary-4 );
+					background-color: var( --clr-secondary-16 );
 					border-color: var( --clr-on-surface-dark-primary-8 );
 					box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.3 );
 				}


### PR DESCRIPTION
## Summary

Fixes the hover roster tooltip rendering with a transparent background in dark mode.

- Changes the dark mode tooltip background from `--clr-on-surface-dark-primary-4`
  (nearly transparent) to `--clr-secondary-16`

## How did you test this change?

devtools