### PR TITLE
fix: Array.mapIndexes stops on false literal

### DIFF
--- a/lua/spec/array_spec.lua
+++ b/lua/spec/array_spec.lua
@@ -228,6 +228,16 @@ describe('array', function()
 				return a[prefix] ~= 'cake' and (prefix .. a[prefix]) or nil
 			end))
 		end)
+
+		it('accept literal \'false\'', function()
+			local a = Array.mapIndexes(function (index)
+				if index > 10 then
+					return
+				end
+				return index % 2 == 0
+			end)
+			assert.are_same(Array.flatten(Array.rep({false, true}, 5)), a)
+		end)
 	end)
 
 	describe('Range', function()

--- a/lua/spec/array_spec.lua
+++ b/lua/spec/array_spec.lua
@@ -229,7 +229,7 @@ describe('array', function()
 			end))
 		end)
 
-		it('accept literal \'false\'', function()
+		it('accept \'false\' literal', function()
 			local a = Array.mapIndexes(function (index)
 				if index > 10 then
 					return

--- a/lua/wikis/commons/Array.lua
+++ b/lua/wikis/commons/Array.lua
@@ -489,7 +489,7 @@ function Array.mapIndexes(funct)
 	local arr = {}
 	for index = 1, math.huge do
 		local y = funct(index)
-		if y then
+		if y ~= nil then
 			table.insert(arr, y)
 		else
 			break


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/0958de27365dd9014ae8c686b5a744d44d2b657d/lua/wikis/commons/Array.lua#L478-L484

The documentation for `Array.mapIndexes` specifies that it stops before the first `nil` returned by `funct`. This is not true as the current implementation could also stop on a `false` literal being returned.

This fixes the forementioned problem by explicitly checking for non-`nil` return from `funct`.

## How did you test this change?

included test