### PR TITLE
feat(infobox): add official device display to freefire league infobox

### DIFF
--- a/lua/wikis/freefire/Infobox/League/Custom.lua
+++ b/lua/wikis/freefire/Infobox/League/Custom.lua
@@ -49,7 +49,9 @@ end
 function CustomInjector:parse(id, widgets)
 	local args = self.caller.args
 
-	if id == 'custom' then
+	if id == 'sponsors' then
+		table.insert(widgets, Cell{name = 'Official Device', children = {args.device}})
+	elseif id == 'custom' then
 		Array.appendWith(widgets,
 			Cell{name = 'Number of Players', children = {args.player_number}},
 			Cell{name = 'Number of Teams', children = {args.team_number}}


### PR DESCRIPTION
Added the "Official Device" field to the sponsors section of the infobox to allow for hardware sponsorship display, mirroring functionality from the PUBG Mobile module.