### PR TITLE
fix(match2): handle missing first side in identityv matchsummary

### DIFF
--- a/lua/wikis/identityv/MatchSummary.lua
+++ b/lua/wikis/identityv/MatchSummary.lua
@@ -74,10 +74,14 @@ function IdentityVMatchSummaryGameRow:createGameOpponentView(opponentIndex)
 	local firstSide = getFirstSide()
 	local secondSide = CustomMatchSummary._getOppositeSide(firstSide)
 	local halfs = extradata['t' .. opponentIndex .. 'halfs'] or {}
-	local scoreDetails = {
-		{score = halfs[firstSide], style = 'brkts-identityv-score-color-' .. firstSide},
-		{score = halfs[secondSide], style = 'brkts-identityv-score-color-' .. secondSide},
-	}
+	local scoreDetails
+
+	if firstSide and firstSide ~= '' then
+		scoreDetails = {
+			{score = halfs[firstSide], style = 'brkts-identityv-score-color-' .. firstSide},
+			{score = halfs[secondSide], style = 'brkts-identityv-score-color-' .. secondSide},
+		}
+	end
 
 	local characters = extradata['t' .. opponentIndex .. 'picks'] or {}
 	return {

--- a/lua/wikis/identityv/MatchSummary.lua
+++ b/lua/wikis/identityv/MatchSummary.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
@@ -74,9 +75,9 @@ function IdentityVMatchSummaryGameRow:createGameOpponentView(opponentIndex)
 	local firstSide = getFirstSide()
 	local secondSide = CustomMatchSummary._getOppositeSide(firstSide)
 	local halfs = extradata['t' .. opponentIndex .. 'halfs'] or {}
-	local scoreDetails
+	local scoreDetails = {}
 
-	if firstSide and firstSide ~= '' then
+	if Logic.isNotEmpty(firstSide) then
 		scoreDetails = {
 			{score = halfs[firstSide], style = 'brkts-identityv-score-color-' .. firstSide},
 			{score = halfs[secondSide], style = 'brkts-identityv-score-color-' .. secondSide},


### PR DESCRIPTION
## Summary

Reported on discord:
https://discord.com/channels/93055209017729024/268719633366777856/1499690194662850752
<img width="558" height="263" alt="image" src="https://github.com/user-attachments/assets/2297c482-035d-44ca-b060-87b3b43ad788" />


## How did you test this change?

Firstly tested in dev then applied hot fix live