### PR TITLE
ci: bump actions

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v13
+        uses: Liquipedia/gh-actions-lua@7615c1c345af98bd9898fa5b53c488c5f58246cf
         with:
           luaVersion: '5.1'
 
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v13
+        uses: Liquipedia/gh-actions-lua@7615c1c345af98bd9898fa5b53c488c5f58246cf
         with:
           luaVersion: '5.1'
 

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -11,12 +11,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup lua
-        uses: Liquipedia/gh-actions-lua@316cadd2e8345ee977caa64ac0d192e15d932f73
+        uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: '5.1'
 
       - name: Setup luarock
-        uses: leafo/gh-actions-luarocks@v5
+        uses: leafo/gh-actions-luarocks@v6
 
       - name: Setup dependencies
         run: |
@@ -43,12 +43,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup lua
-        uses: Liquipedia/gh-actions-lua@316cadd2e8345ee977caa64ac0d192e15d932f73
+        uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: '5.1'
 
       - name: Setup luarocks
-        uses: leafo/gh-actions-luarocks@v5
+        uses: leafo/gh-actions-luarocks@v6
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/pythoncheck.yml
+++ b/.github/workflows/pythoncheck.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run linter
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
         with:
           src: scripts/
       - name: Check styling

--- a/.github/workflows/update visual snapshots.yml
+++ b/.github/workflows/update visual snapshots.yml
@@ -28,7 +28,7 @@ jobs:
         run: apt-get update && apt-get install -y -q gcc make unzip
 
       - name: Setup lua
-        uses: leafo/gh-actions-lua@v13
+        uses: Liquipedia/gh-actions-lua@7615c1c345af98bd9898fa5b53c488c5f58246cf
         env:
           DEBIAN_FRONTEND: noninteractive
         with:

--- a/.github/workflows/update visual snapshots.yml
+++ b/.github/workflows/update visual snapshots.yml
@@ -28,7 +28,7 @@ jobs:
         run: apt-get update && apt-get install -y -q gcc make unzip
 
       - name: Setup lua
-        uses: Liquipedia/gh-actions-lua@316cadd2e8345ee977caa64ac0d192e15d932f73
+        uses: leafo/gh-actions-lua@v13
         env:
           DEBIAN_FRONTEND: noninteractive
         with:


### PR DESCRIPTION
## Summary

Resolves #7258

This PR:
- bumps `astral-sh/ruff-action` from `v3` to `v4.0.0`
- bumps `Liquipedia/gh-actions-lua` from Liquipedia/gh-actions-lua@316cadd2e8345ee977caa64ac0d192e15d932f73 to Liquipedia/gh-actions-lua@7615c1c345af98bd9898fa5b53c488c5f58246cf (rebased using `v13` from upstream)
- bumps `leafo/gh-actions-luarocks` from `v5` to `v6`

## How did you test this change?

