### PR TITLE
feat: new game for chess wiki

### DIFF
--- a/lua/wikis/chess/Info.lua
+++ b/lua/wikis/chess/Info.lua
@@ -37,6 +37,19 @@ return {
 				lightMode = 'Chess default lightmode.png',
 			},
 		},
+		bughouse = {
+			abbreviation = 'Bughouse',
+			name = 'Bughouse',
+			link = 'Bughouse',
+			logo = {
+				darkMode = 'Chess default darkmode.png',
+				lightMode = 'Chess default lightmode.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Chess default darkmode.png',
+				lightMode = 'Chess default lightmode.png',
+			},
+		},
 	},
 	config = {
 		squads = {


### PR DESCRIPTION
## Summary

Adding bughouse chess variant, because of [recently announced championship](https://liquipedia.net/chess/WR_Bughouse_Championship/2026) 

There are other events which we can cover - annual Chess.com Bughouse Championship (2020-2026)

## How did you test this change?

Just data
