### PR TITLE
feat: enable THA storage and default to using it in infobox on ow

### DIFF
--- a/lua/wikis/overwatch/Info.lua
+++ b/lua/wikis/overwatch/Info.lua
@@ -51,7 +51,8 @@ return {
 		defaultMaxPlayersPerPlacement = 12,
 		infoboxPlayer = {
 			automatedHistory = {
-				mode = 'manual',
+				mode = 'manualPrio',
+				storeFromWikiCode =true,
 			},
 		},
 		participants = {

--- a/lua/wikis/overwatch/Info.lua
+++ b/lua/wikis/overwatch/Info.lua
@@ -52,7 +52,7 @@ return {
 		infoboxPlayer = {
 			automatedHistory = {
 				mode = 'manualPrio',
-				storeFromWikiCode =true,
+				storeFromWikiCode = true,
 			},
 		},
 		participants = {


### PR DESCRIPTION
## Summary

I noticed syncPlayerTeam for the new TeamParticipantsis not working on the overwatch wiki.
See https://discord.com/channels/93055209017729024/268719633366777856/1500901538804273336 and https://discord.com/channels/93055209017729024/268719633366777856/1500903876436693042

Adjusting the automatedHistory in Module:Info to manualPrio and storeFromWikiCode = true according to [hjpas guidance](https://discord.com/channels/93055209017729024/268719633366777856/1501241673739534356) seems to be working. Tested it on a few pages and does not seem to generate funny data.

manualPrio seems to be the best option as we still have quite a few (older) player/team pages with manual transfers that were not added yet to the Transfer:Portal. 

## How did you test this change?

[dev module](https://liquipedia.net/overwatch/Module:Info/dev/iGeneral)
[Tournament page using the syncPlayerTeam](https://liquipedia.net/overwatch/User:IGeneral/test9)
[Player page with dev and automated history](https://liquipedia.net/overwatch/Dip)
[Player page with dev and manual/automated history combined](https://liquipedia.net/overwatch/CH0R0NG)
[Player page with dev and manual history](https://liquipedia.net/overwatch/Harbleu)