### PR TITLE
feat(standings): update color scheme and add background to standings table

### DIFF
--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -71,7 +71,8 @@ function StandingsFfaWidget:render()
 				end
 				return self:_createRoundBody(round)
 			end)
-		)
+		),
+		striped = false
 	}
 
 	if activeRounds == 0 then

--- a/lua/wikis/commons/Widget/Standings/Swiss.lua
+++ b/lua/wikis/commons/Widget/Standings/Swiss.lua
@@ -48,7 +48,8 @@ function StandingsSwissWidget:render()
 			TableWidgets.TableBody{children = Array.map(lastRound.opponents, function(slot)
 				return self:_createRow(slot)
 			end)}
-		)
+		),
+		striped = false
 	}
 end
 

--- a/stylesheets/commons/Colours.scss
+++ b/stylesheets/commons/Colours.scss
@@ -759,7 +759,7 @@ ul.nav-tabs li.game-wiiu,
 html {
 	--position-byeup-color: #9641c9;
 	--position-seedup-color: #0572dd;
-	--position-up-color: #00ba00;
+	--position-up-color: #008a00;
 	--position-stayup-color: #005a00;
 	--position-stay-color: #966f00;
 	--position-staydown-color: #c85000;

--- a/stylesheets/commons/Colours.scss
+++ b/stylesheets/commons/Colours.scss
@@ -756,22 +756,12 @@ ul.nav-tabs li.game-wiiu,
 
 /* Standings position / placement colors */
 
-.theme--light {
-	--position-byeup-color: #8046a3;
-	--position-seedup-color: #006bd4;
-	--position-up-color: var( --clr-semantic-positive-30 );
-	--position-stayup-color: #094e09;
+html {
+	--position-byeup-color: #9641c9;
+	--position-seedup-color: #0572dd;
+	--position-up-color: #00ba00;
+	--position-stayup-color: #005a00;
 	--position-stay-color: #966f00;
-	--position-staydown-color: #d4400f;
-	--position-down-color: var( --clr-semantic-negative-40 );
-}
-
-.theme--dark {
-	--position-byeup-color: #cc9fe7;
-	--position-seedup-color: #a9caeb;
-	--position-up-color: #65a765;
-	--position-stayup-color: #b6f8b6;
-	--position-stay-color: #e5c976;
-	--position-staydown-color: #f2a288;
-	--position-down-color: #fc6868;
+	--position-staydown-color: #c85000;
+	--position-down-color: #d02626;
 }

--- a/stylesheets/commons/Colours.scss
+++ b/stylesheets/commons/Colours.scss
@@ -765,3 +765,23 @@ html {
 	--position-staydown-color: #c85000;
 	--position-down-color: #d02626;
 }
+
+.theme--light {
+	--position-byeup-background-color: #f7e9ff;
+	--position-seedup-background-color: #d9ecff;
+	--position-up-background-color: #d5f7d5;
+	--position-stayup-background-color: #ebffeb;
+	--position-stay-background-color: #fff7df;
+	--position-staydown-background-color: #ffe7d9;
+	--position-down-background-color: #ffe9e9;
+}
+
+.theme--dark {
+	--position-byeup-background-color: #3a1f4b;
+	--position-seedup-background-color: #15385b;
+	--position-up-background-color: #053b05;
+	--position-stayup-background-color: #052f05;
+	--position-stay-background-color: #413106;
+	--position-staydown-background-color: #441e05;
+	--position-down-background-color: #3f1212;
+}

--- a/stylesheets/commons/Colours.scss
+++ b/stylesheets/commons/Colours.scss
@@ -756,7 +756,7 @@ ul.nav-tabs li.game-wiiu,
 
 /* Standings position / placement colors */
 
-html {
+:root {
 	--position-byeup-color: #9641c9;
 	--position-seedup-color: #0572dd;
 	--position-up-color: #008a00;

--- a/stylesheets/commons/Label.scss
+++ b/stylesheets/commons/Label.scss
@@ -128,7 +128,7 @@
 		&[ data-label-type="placement-minimum" ] {
 			color: var( --placement-solid-color );
 			background-color: hsl( from var( --placement-solid-color ) h s l / 0.08 );
-			box-shadow: 0 0 0 calc( var( --label-scale ) * 0.0125rem ) var( --placement-solid-color ) inset;
+			box-shadow: 0 0 0 calc( var( --label-scale ) * 0.0625rem ) var( --placement-solid-color ) inset;
 
 			.theme--dark & {
 				color: var( --placement-text-color );

--- a/stylesheets/commons/Label.scss
+++ b/stylesheets/commons/Label.scss
@@ -115,10 +115,6 @@
 
 		--placement-text-color: var( --clr-secondary-100 );
 
-		.theme--dark & {
-			--placement-text-color: var( --clr-secondary-9 );
-		}
-
 		&:not( [ data-placement-type ] ) {
 			--placement-solid-color: var( --clr-on-surface-light-primary-4 );
 			--placement-text-color: var( --clr-secondary-25 );
@@ -133,6 +129,10 @@
 			color: var( --placement-solid-color );
 			background-color: hsl( from var( --placement-solid-color ) h s l / 0.08 );
 			box-shadow: 0 0 0 calc( var( --label-scale ) * 0.0125rem ) var( --placement-solid-color ) inset;
+
+			.theme--dark & {
+				color: var( --placement-text-color );
+			}
 		}
 
 		&[ data-placement-type="byeup" ] {

--- a/stylesheets/commons/Standings.scss
+++ b/stylesheets/commons/Standings.scss
@@ -5,6 +5,14 @@
 	tr[ data-position-status ] {
 		position: relative;
 
+		&:not( :last-child ) {
+			border-bottom: 1px solid var( --clr-on-surface-light-primary-8 );
+
+			.theme--dark & {
+				border-bottom: 1px solid var( --clr-on-surface-dark-primary-8 );
+			}
+		}
+
 		&::after {
 			content: "";
 			position: absolute;

--- a/stylesheets/commons/Standings.scss
+++ b/stylesheets/commons/Standings.scss
@@ -1,5 +1,7 @@
 .standings-ffa,
 .standings-swiss {
+	--confirmed-placement-background-opacity: 0.25;
+
 	tr[ data-position-status ] {
 		position: relative;
 
@@ -39,6 +41,41 @@
 
 		&[ data-position-status="down" ] {
 			--placement-row-color: var( --position-down-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type ] ) {
+			> :nth-child( -n + 2 ),
+			&:has( > :nth-child( 2 ) > .standings-position-indicator ) > :nth-child( 3 ) {
+				background-color: var( --placement-confirmed-color );
+			}
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="byeup" ] ) {
+			--placement-confirmed-color: var( --position-byeup-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="seedup" ] ) {
+			--placement-confirmed-color: var( --position-seedup-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="up" ] ) {
+			--placement-confirmed-color: var( --position-up-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="stayup" ] ) {
+			--placement-confirmed-color: var( --position-stayup-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="stay" ] ) {
+			--placement-confirmed-color: var( --position-stay-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="staydown" ] ) {
+			--placement-confirmed-color: var( --position-staydown-background-color );
+		}
+
+		&:has( > :first-child > .label--placement[ data-placement-type="down" ] ) {
+			--placement-confirmed-color: var( --position-down-background-color );
 		}
 	}
 }

--- a/stylesheets/commons/Standings.scss
+++ b/stylesheets/commons/Standings.scss
@@ -1,7 +1,5 @@
 .standings-ffa,
 .standings-swiss {
-	--confirmed-placement-background-opacity: 0.25;
-
 	tr[ data-position-status ] {
 		position: relative;
 

--- a/stylesheets/commons/Standings.scss
+++ b/stylesheets/commons/Standings.scss
@@ -4,10 +4,12 @@
 		position: relative;
 
 		&:not( :last-child ) {
-			border-bottom: 1px solid var( --clr-on-surface-light-primary-8 );
+			box-shadow: inset 0 -1px var( --border-color );
+
+			--border-color: var( --clr-on-surface-light-primary-8 );
 
 			.theme--dark & {
-				border-bottom: 1px solid var( --clr-on-surface-dark-primary-8 );
+				--border-color: var( --clr-on-surface-dark-primary-8 );
 			}
 		}
 
@@ -53,6 +55,7 @@
 			> :nth-child( -n + 2 ),
 			&:has( > :nth-child( 2 ) > .standings-position-indicator ) > :nth-child( 3 ) {
 				background-color: var( --placement-confirmed-color );
+				box-shadow: inset 0 -1px var( --border-color );
 			}
 
 			&:hover {

--- a/stylesheets/commons/Standings.scss
+++ b/stylesheets/commons/Standings.scss
@@ -48,6 +48,17 @@
 			&:has( > :nth-child( 2 ) > .standings-position-indicator ) > :nth-child( 3 ) {
 				background-color: var( --placement-confirmed-color );
 			}
+
+			&:hover {
+				> :nth-child( -n + 2 ),
+				&:has( > :nth-child( 2 ) > .standings-position-indicator ) > :nth-child( 3 ) {
+					background-color: hsl( from var( --placement-confirmed-color ) h s calc( l * 0.9 ) );
+
+					.theme--dark & {
+						background-color: hsl( from var( --placement-confirmed-color ) h s calc( l * 1.25 ) );
+					}
+				}
+			}
 		}
 
 		&:has( > :first-child > .label--placement[ data-placement-type="byeup" ] ) {


### PR DESCRIPTION
## Summary

This PR:
- updates position color scheme
- adds background colors to standings table  
  no lua change; 100% (s)css

## How did you test this change?

preview with dev + browser dev tools

### Screenshots
<img width="391" height="544" alt="image" src="https://github.com/user-attachments/assets/d7628c80-4fe6-41dc-a4c3-31a4fa39d76e" /><img width="394" height="546" alt="image" src="https://github.com/user-attachments/assets/e413f8dd-0971-4612-be27-60ba7916e460" />

