### PR TITLE
Move placement styles

### DIFF
--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -1326,72 +1326,42 @@ Author(s): spazer, Lafungo
 	line-height: 1.25;
 }
 
-.placement-1 {
-	background-color: var( --achievement-placement-1, #ffd739 ); //rgb( 255, 221, 60 );
-}
+$placement-colors: (
+	"1": ( var( --clr-semantic-gold-40 ), var( --clr-semantic-gold-30 ) ),
+	"2": ( var( --clr-semantic-silver-40 ) ),
+	"3": ( var( --clr-semantic-bronze-40 ), var( --clr-semantic-bronze-30 ) ),
+	"4": ( var( --clr-semantic-copper-40 ), var( --clr-semantic-copper-30 ) ),
+	"5": ( var( --clr-elm-40 ), var( --clr-elm-30 ) ),
+	"6": ( var( --clr-elm-30 ), var( --clr-elm-20 ) ),
+	"lightblue": ( var( --clr-elm-40 ), color-mix( in srgb, #000000 20%, var( --clr-elm-40 ) ) ),
+	"blue": ( var( --clr-elm-30 ), color-mix( in srgb, #000000 20%, var( --clr-elm-30 ) ) ),
+	"darkblue": ( var( --clr-elm-20 ), color-mix( in srgb, #000000 20%, var( --clr-elm-20 ) ) ),
+	"darkgrey": ( var( --clr-elm-10 ) ),
+	"win": ( var( --clr-semantic-positive-40 ), var( --clr-semantic-positive-20 ) ),
+	"draw": ( var( --clr-tuliptree-80 ), var( --clr-tuliptree-40 ) ),
+	"lose": ( var( --clr-secondary-70 ), var( --clr-secondary-25 ) ),
+	"up": ( var( --clr-atlantis-40 ), var( --clr-atlantis-30 ) ),
+	"stay": ( var( --clr-sun-40 ), var( --clr-sun-30 ) ),
+	"down": ( color-mix( in srgb, #ffffff 30%, var( --clr-semantic-negative-40 ) ), var( --clr-semantic-negative-30 ) ),
+	"dnp": ( var( --clr-moon-80 ), color-mix( in srgb, #000000 20%, var( --clr-moon-80 ) ) ),
+);
 
-.placement-2 {
-	background-color: var( --achievement-placement-2, #bebebe ); //rgb( 154, 154, 154 );
-}
+@each $name, $colors in $placement-colors {
+	.placement-#{$name} {
+		@if length( $colors ) == 2 {
+			.theme--light & {
+				background-color: nth( $colors, 1 );
+			}
 
-.placement-3 {
-	background-color: var( --achievement-placement-3, #bb8644 ); //rgb( 177, 132, 42 );
-}
+			.theme--dark & {
+				background-color: nth( $colors, 2 );
+			}
+		}
 
-.placement-4 {
-	background-color: var( --achievement-placement-4, #f8996b );
-}
-
-.placement-5 {
-	background-color: var( --achievement-placement-5, #27a4a4 );
-}
-
-.placement-6 {
-	background-color: var( --achievement-placement-6, #1e7d7d );
-}
-
-.placement-lightblue {
-	background-color: var( --achievement-placement-lightblue, #007f99 );
-}
-
-.placement-blue {
-	background-color: var( --achievement-placement-blue, #166f82 );
-}
-
-.placement-darkblue {
-	background-color: var( --achievement-placement-darkblue, #2d606b );
-}
-
-.placement-darkgrey {
-	background-color: var( --achievement-placement-darkgrey, #445154 );
-}
-
-.placement-win {
-	background-color: var( --achievement-placement-win, #009e60 );
-}
-
-.placement-draw {
-	background-color: var( --achievement-placement-draw, #d2b48c );
-}
-
-.placement-lose {
-	background-color: var( --achievement-placement-lose, #dddddd );
-}
-
-.placement-up {
-	background-color: var( --achievement-placement-up, #89e069 );
-}
-
-.placement-stay {
-	background-color: var( --achievement-placement-stay, #fede68 );
-}
-
-.placement-down {
-	background-color: var( --achievement-placement-down, #ff6f6f );
-}
-
-.placement-dnp {
-	background-color: var( --achievement-placement-dnp, #d0d0d0 );
+		@else {
+			background-color: nth( $colors, 1 );
+		}
+	}
 }
 
 .green-check {


### PR DESCRIPTION
## Summary

Moving the placement colors logic from the Lakesideview rep to the Lua-Modules repo. 
I don't think Lighthouse should own this because it's only used inside wiki content.

As a reference, these were the colors from Lakesideview:
```
$achievement-placement-1--light: var( --clr-semantic-gold-40 );
$achievement-placement-1--dark: var( --clr-semantic-gold-30 );
$achievement-placement-2--light: var( --clr-semantic-silver-40 );
$achievement-placement-2--dark: var( --clr-semantic-silver-40 );
$achievement-placement-3--light: var( --clr-semantic-bronze-40 );
$achievement-placement-3--dark: var( --clr-semantic-bronze-30 );
$achievement-placement-4--light: var( --clr-semantic-copper-40 );
$achievement-placement-4--dark: var( --clr-semantic-copper-30 );
$achievement-placement-5--light: wikiColorFromMap( elm, 40 );
$achievement-placement-5--dark: wikiColorFromMap( elm, 30 );
$achievement-placement-6--light: wikiColorFromMap( elm, 30 );
$achievement-placement-6--dark: wikiColorFromMap( elm, 20 );
$achievement-placement-lose--light: var( --clr-secondary-70 );
$achievement-placement-lose--dark: var( --clr-secondary-25 );
$achievement-placement-draw--light: var( --clr-tuliptree-80 );
$achievement-placement-draw--dark: var( --clr-tuliptree-40 );
$achievement-placement-lightblue--light: var( --clr-elm-40 );
$achievement-placement-lightblue--dark: mix( #000000, wikiColorFromMap( elm, 40 ), 20% );
$achievement-placement-blue--light: var( --clr-elm-30 );
$achievement-placement-blue--dark: mix( #000000, wikiColorFromMap( elm, 30 ), 20% );
$achievement-placement-darkblue--light: var( --clr-elm-20 );
$achievement-placement-darkblue--dark: mix( #000000, wikiColorFromMap( elm, 20 ), 20% );
$achievement-placement-darkgrey--light: var( --clr-elm-10 );
$achievement-placement-darkgrey--dark: var( --clr-elm-10 );
$achievement-placement-win--light: var( --clr-semantic-positive-40 );
$achievement-placement-win--dark: var( --clr-semantic-positive-20 );
$achievement-placement-dnp--light: var( --clr-moon-80 );
$achievement-placement-dnp--dark: mix( #000000, wikiColorFromMap( moon, 80 ), 20% );
$achievement-placement-stay--light: var( --clr-sun-40 );
$achievement-placement-stay--dark: var( --clr-sun-30 );
$achievement-placement-up--light: var( --clr-atlantis-40 );
$achievement-placement-up--dark: var( --clr-atlantis-30 );
$achievement-placement-down--light: mix( #ffffff, semanticColorFromMap( negative, 40 ), 30% );
$achievement-placement-down--dark: var( --clr-semantic-negative-30 );
```

I also made the code a little shorter and removed the fallback, because always either `theme--light` or `theme--dark` is applied.

## Related MR
https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/merge_requests/192

## How did you test this change?

I tested it on https://laura.wiki.tldev.eu/rocketleague/Rocket_League_Championship_Series/2021-22/Fall#Interregional_Matchups
CSS changed here https://laura.wiki.tldev.eu/commons/MediaWiki:Common.css/Miscellaneous.scss
