### PR TITLE
feat: Add apac region mapping to val filterbuttons

### DIFF
--- a/lua/wikis/valorant/FilterButtons/Config.lua
+++ b/lua/wikis/valorant/FilterButtons/Config.lua
@@ -29,6 +29,7 @@ local REGION_TO_SUPERREGION = {
 	['Latin America North'] = 'Americas',
 	['Latin America South'] = 'Americas',
 	['Brazil'] = 'Americas',
+	['Asia-Pacific'] = 'Pacific',
 	['Taiwan'] = 'Pacific',
 	['Hong Kong'] = 'Pacific',
 	['Thailand'] = 'Pacific',


### PR DESCRIPTION
## Summary
We have some tournaments that are online with region being Asia-Pacific, not appearing in match ticker, important with EWC qualifiers ongoing and ENC

## How did you test this change?

N/A