### PR TITLE
feat(TeamParticipants): improve ingame role display for roles without icon

### DIFF
--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -69,8 +69,8 @@ local function getRoleDisplays(player)
 			return firstRole.icon
 		end
 		for _, role in ipairs(roles) do
-			if role.type == RoleUtil.ROLE_TYPE.INGAME then
-				return role.icon or role.display
+			if role.type == RoleUtil.ROLE_TYPE.INGAME and role.icon then
+				return role.icon
 			end
 		end
 	end
@@ -84,7 +84,7 @@ local function getRoleDisplays(player)
 		end
 		-- Add non-ingame role if present
 		for _, role in ipairs(roles) do
-			if role.type ~= RoleUtil.ROLE_TYPE.INGAME then
+			if role.type ~= RoleUtil.ROLE_TYPE.INGAME or not role.icon then
 				table.insert(rightRoles, role.display)
 				break
 			end
@@ -138,6 +138,7 @@ function ParticipantsTeamRoster:render()
 	end
 
 	---@param groups {label: string?, players: table[]}[]
+	---@return Widget
 	local makeRostersDisplay = function(groups)
 		local children = {}
 		for _, group in ipairs(groups) do

--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -53,10 +53,11 @@ end
 -- * Right-role:
 --   * If the person has a specific status (did not play/former), display it first
 --   * If there's a non-ingame role assigned, display it after the status
+--   * Displays the remianing ingame roles (which are not displayed on the left) also.
 --   * Returns an array of labels to display (can be multiple)
 -- * Left-role:
 --   * If the first role has an icon, we use that to render the left-role
---   * If not then we instead display the icon or text of the first ingame role
+--   * If not then we instead display the icon of the first ingame role with icon
 ---@param player table
 ---@return string?, string[]?
 local function getRoleDisplays(player)

--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -53,7 +53,7 @@ end
 -- * Right-role:
 --   * If the person has a specific status (did not play/former), display it first
 --   * If there's a non-ingame role assigned, display it after the status
---   * Displays the remianing ingame roles (which are not displayed on the left) also.
+--   * Displays the remaining ingame roles (which are not displayed on the left) also.
 --   * Returns an array of labels to display (can be multiple)
 -- * Left-role:
 --   * If the first role has an icon, we use that to render the left-role


### PR DESCRIPTION
## Summary
resolves #7491
also adds a missing return anno

before:
<img width="353" height="353" alt="image" src="https://github.com/user-attachments/assets/ca01436e-b7a6-4392-b42d-a49e8ac1c952" />

with this:
<img width="332" height="365" alt="image" src="https://github.com/user-attachments/assets/6c547603-70a8-457e-a92e-99a70951ae42" />


## How did you test this change?
dev