### PR TITLE
feat(TeamParticipants): Add option to disable enrichPlayerDates

### DIFF
--- a/lua/wikis/commons/TeamParticipants/Controller.lua
+++ b/lua/wikis/commons/TeamParticipants/Controller.lua
@@ -42,7 +42,9 @@ function TeamParticipantsController.fromTemplate(frame)
 	local parsedData = TeamParticipantsWikiParser.parseWikiInput(parsedArgs)
 	TeamParticipantsController.importParticipants(parsedData)
 	TeamParticipantsController.fillIncompleteRosters(parsedData)
-	TeamParticipantsController.enrichPlayerDates(parsedData)
+	if Logic.nilOr(Logic.readBoolOrNil(parsedArgs.enrichPlayerDates), true) then
+		TeamParticipantsController.enrichPlayerDates(parsedData)
+	end
 
 	local shouldStore = Logic.readBoolOrNil(args.store) ~= false and Lpdb.isStorageEnabled()
 


### PR DESCRIPTION
## Summary
as already mentioned in #7466 `enrichPlayerDates` is pointless on some wikis/tournaments, but it increases the runtime
hence add an option to at least be able to suppress it

## How did you test this change?
untested, but trivial