### PR TITLE
fix(TeamParticipants): add missing results field to setPageVars test data

### DIFF
--- a/lua/spec/team_participant_spec.lua
+++ b/lua/spec/team_participant_spec.lua
@@ -896,6 +896,7 @@ describe('Team Participant', function()
 							apiId = nil,
 							extradata = {
 								type = 'player',
+								results = true,
 								joinDate = '2024-03-15',
 								leaveDate = nil,
 							},
@@ -924,6 +925,7 @@ describe('Team Participant', function()
 							apiId = nil,
 							extradata = {
 								type = 'player',
+								results = true,
 								status = 'former',
 								joinDate = '2024-02-01',
 								leaveDate = '2024-08-15',


### PR DESCRIPTION
## Summary

Fixes #7496

- Two `setPageVars` tests from #7466 were failing because the manually-constructed test players had no `extradata.results` field, which `shouldStorePlayer` (added by #7483) requires before writing page vars
- `parsePlayer` defaults `results` to `true`, so real players always pass the check — the tests just didn't reflect that; adding `results = true` to both test players fixes them

## How did you test this change?

Running the tests