### PR TITLE
feat(mainpage): adjust size for EA FC

### DIFF
--- a/lua/wikis/easportsfc/MainPageLayout/data.lua
+++ b/lua/wikis/easportsfc/MainPageLayout/data.lua
@@ -183,7 +183,7 @@ return {
 								},
 							},
 							{
-								size = 7,
+								size = 6,
 								children = {
 									{
 										noPanel = true,
@@ -192,7 +192,7 @@ return {
 								},
 							},
 							{
-								size = 5,
+								size = 6,
 								children = {
 									{
 										noPanel = true,


### PR DESCRIPTION
## Summary
Matches is a bit too wide, can be made smaller without having the name eclipsing issues

<img width="936" height="592" alt="image" src="https://github.com/user-attachments/assets/711f4e27-a809-496b-9da5-9acca0656ab9" />

## How did you test this change?
<img width="922" height="603" alt="image" src="https://github.com/user-attachments/assets/6b026de0-597e-458f-8fb5-29bc712f7d31" />

dev