### PR TITLE
fix: Add validation for platforms ending in number

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -15,6 +15,10 @@ local CustomData = Lua.requireIfExists('Module:Links/CustomData', {loadData = tr
 
 local Links = {}
 
+local VALID_PLATFORMS_ENDING_IN_NUMBER = {
+    ['fastcup-cs2'] = true,
+}
+
 local PREFIXES = {
 	['365chess'] = {
 		'https://www.365chess.com/tournaments/',
@@ -760,6 +764,9 @@ end
 ---@param key string
 ---@return string
 function Links.removeAppendedNumber(key)
+    if VALID_PLATFORMS_ENDING_IN_NUMBER[key] then
+        return key
+    end
 	return (string.gsub(key, '%d$', ''))
 end
 


### PR DESCRIPTION
## Summary
Validation check needed if we wanna keep number in platforms without stripping that number

Personally unsure with the naming or if this is right approach.

<img width="1906" height="779" alt="image" src="https://github.com/user-attachments/assets/24fd718c-4657-4025-88f2-8ab4cb495a20" />


## How did you test this change?

dev