### PR TITLE
chore: add match2 substitute templates to list of templates to protect

### DIFF
--- a/templates/templatesToProtect
+++ b/templates/templatesToProtect
@@ -259,11 +259,13 @@ NavBox
 NavBoxChild
 Next_match
 Opponent
+OpponentPlayer
 Patches_calendar
 Patches_list
 Person
 Persons
 Placement
+PlayerSubstitutions
 QuadOpponent
 Qualification
 Round
@@ -276,6 +278,7 @@ SoloPrizePool
 Stage
 StageWinnings
 Streams
+Substitution
 SwissStandings
 Tabs_dynamic
 Tabs_static


### PR DESCRIPTION
protection run ongoing locally