### PR TITLE
remove secondary 70 color

### DIFF
--- a/stylesheets/commons/BattleRoyale/Panel.scss
+++ b/stylesheets/commons/BattleRoyale/Panel.scss
@@ -45,7 +45,7 @@ Author(s): Elysienna
 			border-bottom-color: transparent;
 
 			.theme--dark & {
-				color: var( --clr-secondary-70 );
+				color: var( --clr-secondary-80 );
 				border-color: var( --clr-secondary-16 );
 				border-bottom-color: transparent;
 			}
@@ -321,7 +321,7 @@ Author(s): Elysienna
 			margin: 0 0.5rem;
 
 			.theme--dark & {
-				color: var( --clr-secondary-70 );
+				color: var( --clr-secondary-80 );
 			}
 		}
 	}

--- a/stylesheets/commons/Jquery.scss
+++ b/stylesheets/commons/Jquery.scss
@@ -25,7 +25,7 @@ div.ui-widget-header {
 		}
 
 		.theme--dark & {
-			border-color: var( --clr-secondary-70 );
+			border-color: var( --clr-secondary-80 );
 		}
 	}
 }
@@ -64,7 +64,7 @@ div.ui-widget-content {
 		}
 
 		.theme--dark & {
-			border: 0.0625rem solid var( --clr-secondary-70 );
+			border: 0.0625rem solid var( --clr-secondary-80 );
 		}
 	}
 
@@ -90,7 +90,7 @@ div.ui-widget-content {
 		}
 
 		.theme--dark & {
-			border-color: var( --clr-secondary-70 );
+			border-color: var( --clr-secondary-80 );
 		}
 
 		&:hover {

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -1339,7 +1339,7 @@ $placement-colors: (
 	"darkgrey": ( var( --clr-elm-10 ) ),
 	"win": ( var( --clr-semantic-positive-40 ), var( --clr-semantic-positive-20 ) ),
 	"draw": ( var( --clr-tuliptree-80 ), var( --clr-tuliptree-40 ) ),
-	"lose": ( var( --clr-secondary-70 ), var( --clr-secondary-25 ) ),
+	"lose": ( var( --clr-secondary-80 ), var( --clr-secondary-25 ) ),
 	"up": ( var( --clr-atlantis-40 ), var( --clr-atlantis-30 ) ),
 	"stay": ( var( --clr-sun-40 ), var( --clr-sun-30 ) ),
 	"down": ( color-mix( in srgb, #ffffff 30%, var( --clr-semantic-negative-40 ) ), var( --clr-semantic-negative-30 ) ),

--- a/stylesheets/commons/TeamTemplates.scss
+++ b/stylesheets/commons/TeamTemplates.scss
@@ -48,7 +48,7 @@ Author(s): FO-nTTaX
 	i {
 		font-size: 25px;
 		vertical-align: middle;
-		color: var( --clr-secondary-70 );
+		color: var( --clr-secondary-80 );
 	}
 }
 


### PR DESCRIPTION
## Summary

--clr-secondary-70 is a duplicate of --clr-secondary-80 and we're trying to standardize it throughout lighthouse, lakesideview, and lua modules.

## How did you test this change?

I just used search and replace
