### PR TITLE
fix(PlayerTournamentAppearances): players with spaces/underscores not counted together correctly

### DIFF
--- a/lua/wikis/commons/PlayerTournamentAppearances.lua
+++ b/lua/wikis/commons/PlayerTournamentAppearances.lua
@@ -152,7 +152,7 @@ function Appearances:_fetchPlayers(pageNames)
 			if Opponent.playerIsTbd(player) then
 				return
 			end
-			local pageName = player.pageName
+			local pageName = Page.pageifyLink(player.pageName)
 			---@cast pageName -nil
 			if not players[pageName] then
 				players[pageName] = player


### PR DESCRIPTION
## Summary
new team participants store with spaces unless `Info.config.forceUnderscores` is enabled
old TC did store with underscores on some wikis

this mismatch causes issues in PlayerTournamentAppearances as it doesn't treat e.g. `A_Hao_ei` and `A Hao ei` as the same

## How did you test this change?
dev