### PR TITLE
fix(match2): Change number of max bans

### DIFF
--- a/lua/wikis/identityv/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/identityv/MatchGroup/Input/Custom.lua
@@ -22,7 +22,7 @@ local MatchFunctions = {}
 ---@class IdentityvMapParser: MapParserInterface
 local MapFunctions = {}
 
-local MAX_NUM_BANS = 6
+local MAX_NUM_BANS = 9
 local MAX_NUM_PICKS = 5
 local VALID_SIDES = {
 	'hunter',


### PR DESCRIPTION
## Summary
Just a way to increase number of bans displayed, for backward compatibility with matches from pre-global Ban & Pick where there can be up to 6 survivors + 3 hunter bans.

## How did you test this change?
[/dev](https://liquipedia.net/identityv/Module:MatchGroup/Input/Custom/dev/freg)

## Other Stuff
Anyway of getting rid the weird spacing for non-input bans?
<img width="513" height="517" alt="image" src="https://github.com/user-attachments/assets/26f9be1e-61c8-4b1a-90a7-53b692d3cfbc" />
