### PR TITLE
feat(match2): references support for substitute player input

### DIFF
--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -17,6 +17,7 @@ local Page = Lua.import('Module:Page')
 local PlayerDisplay = Lua.import('Module:Player/Display')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
+local Template = Lua.import('Module:Template')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
 
 local Info = Lua.import('Module:Info', {loadData = true})
@@ -98,6 +99,7 @@ function DisplayHelper.createSubstitutesComment(match)
 		if Logic.isEmpty(substitutions) then
 			return
 		end
+		---@cast substitutions MatchGroupInputSubstituteInformation[]
 
 		Array.forEach(substitutions, function(substitution)
 			if Logic.isEmpty(substitution.substitute) then
@@ -131,11 +133,27 @@ function DisplayHelper.createSubstitutesComment(match)
 				table.insert(subString, string.format('due to %s', substitution.reason))
 			end
 
-			table.insert(comment, table.concat(subString, ' ') .. '.')
+			table.insert(comment, table.concat(subString, ' ') .. '.' .. DisplayHelper._createSubstituteReferences(substitution.references))
 		end)
 	end)
 
 	return comment
+end
+
+---@private
+---@param references table[]?
+---@return string
+function DisplayHelper._createSubstituteReferences(references)
+	if Logic.isEmpty(references) then
+		return ''
+	end
+	---@cast references -nil
+	local frame = mw.getCurrentFrame()
+	return table.concat(Array.map(references, function (reference)
+		return frame:extensionTag('ref', Template.safeExpand(
+			frame, 'Cite web', reference
+		))
+	end))
 end
 
 ---Creates display components for caster(s).

--- a/lua/wikis/commons/MatchGroup/Display/Helper.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Helper.lua
@@ -133,7 +133,10 @@ function DisplayHelper.createSubstitutesComment(match)
 				table.insert(subString, string.format('due to %s', substitution.reason))
 			end
 
-			table.insert(comment, table.concat(subString, ' ') .. '.' .. DisplayHelper._createSubstituteReferences(substitution.references))
+			table.insert(
+				comment,
+				table.concat(subString, ' ') .. '.' .. DisplayHelper._createSubstituteReferences(substitution.references)
+			)
 		end)
 	end)
 

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -128,6 +128,7 @@ local contentLanguage = mw.getContentLanguage()
 ---@field player standardPlayer?
 ---@field games string[]
 ---@field reason string?
+---@field references table[]?
 
 ---@param dateString string?
 ---@param dateFallbacks string[]?
@@ -406,6 +407,7 @@ function MatchGroupInputUtil.extractManualPlayersInput(match, opponentIndex, opp
 			player = makeStandardPlayer(substitution.out),
 			games = Logic.nilIfEmpty(Array.parseCommaSeparatedString(substitution.games, ';')),
 			reason = substitution.reason,
+			references = substitution.references,
 		}
 	end)
 


### PR DESCRIPTION
## Summary

This PR adds support for adding references of player substitutions.

## How did you test this change?

dev