### PR TITLE
fix(TeamParticipants): normalize player pagenames in lpdb storage

### DIFF
--- a/lua/spec/opponent_spec.lua
+++ b/lua/spec/opponent_spec.lua
@@ -288,6 +288,23 @@ describe('opponent', function()
 			}, Opponent.toLpdbStruct(Opponent.fromMatch2Record(Config.exampleMatch2RecordDuo) --[[@as standardOpponent]]))
 			--can not test for team opponent due to missing team templates
 		end)
+
+		it('forceUnderscores option normalizes player pagenames', function()
+			local opponent = {
+				type = Opponent.solo,
+				players = {
+					{displayName = 'Some Player', flag = 'Sweden', pageName = 'Some Player'},
+				},
+				extradata = {},
+			} --[[@as standardOpponent]]
+			-- Without the option, no wiki-level forceUnderscores in the test env -> raw.
+			assert.are_equal('Some Player', Opponent.toLpdbStruct(opponent).opponentplayers.p1)
+			-- With the option, pagename is underscore-normalized regardless of wiki config.
+			assert.are_equal(
+				'Some_Player',
+				Opponent.toLpdbStruct(opponent, {forceUnderscores = true}).opponentplayers.p1
+			)
+		end)
 	end)
 
 	describe('from lpdb struct', function()

--- a/lua/wikis/commons/Info.lua
+++ b/lua/wikis/commons/Info.lua
@@ -34,5 +34,10 @@ return {
 			matchPage = false,
 			status = 2,
 		},
+		-- TODO: stopgap so new TeamParticipants storage matches each wiki's legacy TeamCard
+		-- pagename form. Should go away once underscore-normalization is unconditional at
+		-- every LPDB write site. Override to `false` on wikis whose legacy TeamCard stored
+		-- player pagenames with spaces (audit on-wiki LPDB before flipping).
+		opponentLpdbForceUnderscores = true,
 	},
 }

--- a/lua/wikis/commons/Info.lua
+++ b/lua/wikis/commons/Info.lua
@@ -34,10 +34,5 @@ return {
 			matchPage = false,
 			status = 2,
 		},
-		-- TODO: stopgap so new TeamParticipants storage matches each wiki's legacy TeamCard
-		-- pagename form. Should go away once underscore-normalization is unconditional at
-		-- every LPDB write site. Override to `false` on wikis whose legacy TeamCard stored
-		-- player pagenames with spaces (audit on-wiki LPDB before flipping).
-		opponentLpdbForceUnderscores = true,
 	},
 }

--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -549,7 +549,7 @@ end
 
 ---Reads an opponent struct and builds a standings/placement lpdb struct from it
 ---@param opponent standardOpponent
----@param options {setPlayersInTeam: boolean?}?
+---@param options {setPlayersInTeam: boolean?, forceUnderscores: boolean?}?
 ---@return {opponentname: string, opponenttemplate: string?, opponenttype: OpponentType, opponentplayers: table?}
 function Opponent.toLpdbStruct(opponent, options)
 	options = options or {}
@@ -558,6 +558,13 @@ function Opponent.toLpdbStruct(opponent, options)
 		opponenttemplate = opponent.template,
 		opponenttype = opponent.type,
 	}
+
+	-- TODO: this per-call `forceUnderscores` override is a stopgap. Storage of player
+	-- pagenames should be unconditionally underscore-normalized at every write site,
+	-- not gated by a wiki-level config flag. Remove this option once that lands.
+	local normalizePageName = options.forceUnderscores
+		and function(pageName) return pageName and (pageName:gsub(' ', '_')) or pageName end
+		or Page.applyUnderScoresIfEnforced
 
 	-- Add players for Party Type opponents, or if config is set to force it.
 	if Opponent.typeIsParty(opponent.type) or options.setPlayersInTeam then
@@ -575,7 +582,7 @@ function Opponent.toLpdbStruct(opponent, options)
 				prefix = 'p' .. playerCount
 			end
 
-			players[prefix] = Page.applyUnderScoresIfEnforced(player.pageName)
+			players[prefix] = normalizePageName(player.pageName)
 			players[prefix .. 'dn'] = player.displayName
 			players[prefix .. 'flag'] = player.flag
 			players[prefix .. 'team'] = player.team and

--- a/lua/wikis/commons/TeamParticipants/Repository.lua
+++ b/lua/wikis/commons/TeamParticipants/Repository.lua
@@ -10,7 +10,6 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
 local FnUtil = Lua.import('Module:FnUtil')
-local Info = Lua.import('Module:Info', {loadData = true})
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Page = Lua.import('Module:Page')
@@ -92,12 +91,12 @@ function TeamParticipantsRepository.save(participant)
 		local activeOpponent = Table.deepCopy(participant.opponent)
 		activeOpponent.players = Array.filter(activeOpponent.players or {}, shouldStorePlayer)
 		-- Add full opponent data for players with results with this team
-		-- TODO: per-wiki `opponentLpdbForceUnderscores` is a stopgap so TP storage matches
-		-- the legacy TeamCard pagename form on each wiki. Drop the option (and the flag)
-		-- once underscore-normalization is unconditional at every LPDB write site.
+		-- TODO: `forceUnderscores` is a stopgap so TP storage normalizes player pagenames
+		-- regardless of `Info.config.forceUnderscores`. Drop the option once underscore
+		-- normalization is unconditional at every LPDB write site.
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(activeOpponent, {
 			setPlayersInTeam = true,
-			forceUnderscores = Info.config.opponentLpdbForceUnderscores,
+			forceUnderscores = true,
 		}))
 		-- Legacy participant fields
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLegacyParticipantData(activeOpponent))
@@ -162,12 +161,10 @@ function TeamParticipantsRepository.setPageVars(participant)
 				playerPrefix = 'p' .. playerCount
 			end
 
-			-- TODO: keep wiki-variable pagenames (consumed by matches/HiddenDataBox) in the
-			-- same form as the LPDB write above, gated on the same per-wiki flag. Drop
-			-- once pagename normalization is unconditional everywhere.
-			local normalizedPageName = Info.config.opponentLpdbForceUnderscores
-				and Page.pageifyLink(player.pageName)
-				or player.pageName
+			-- TODO: stopgap so wiki-variable pagenames (consumed by matches/HiddenDataBox)
+			-- match the underscore-normalized form of the LPDB write above. Drop once
+			-- pagename normalization is unconditional everywhere.
+			local normalizedPageName = Page.pageifyLink(player.pageName)
 			Array.forEach(teamPrefixes, function(teamPrefix)
 				local combinedPrefix = teamPrefix .. '_' .. playerPrefix
 				globalVars:set(combinedPrefix, normalizedPageName)

--- a/lua/wikis/commons/TeamParticipants/Repository.lua
+++ b/lua/wikis/commons/TeamParticipants/Repository.lua
@@ -10,8 +10,10 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
 local FnUtil = Lua.import('Module:FnUtil')
+local Info = Lua.import('Module:Info', {loadData = true})
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
+local Page = Lua.import('Module:Page')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
 local Table = Lua.import('Module:Table')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
@@ -90,7 +92,13 @@ function TeamParticipantsRepository.save(participant)
 		local activeOpponent = Table.deepCopy(participant.opponent)
 		activeOpponent.players = Array.filter(activeOpponent.players or {}, shouldStorePlayer)
 		-- Add full opponent data for players with results with this team
-		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(activeOpponent, { setPlayersInTeam = true }))
+		-- TODO: per-wiki `opponentLpdbForceUnderscores` is a stopgap so TP storage matches
+		-- the legacy TeamCard pagename form on each wiki. Drop the option (and the flag)
+		-- once underscore-normalization is unconditional at every LPDB write site.
+		lpdbData = Table.mergeInto(lpdbData, Opponent.toLpdbStruct(activeOpponent, {
+			setPlayersInTeam = true,
+			forceUnderscores = Info.config.opponentLpdbForceUnderscores,
+		}))
 		-- Legacy participant fields
 		lpdbData = Table.mergeInto(lpdbData, Opponent.toLegacyParticipantData(activeOpponent))
 		lpdbData.players = lpdbData.opponentplayers
@@ -154,9 +162,15 @@ function TeamParticipantsRepository.setPageVars(participant)
 				playerPrefix = 'p' .. playerCount
 			end
 
+			-- TODO: keep wiki-variable pagenames (consumed by matches/HiddenDataBox) in the
+			-- same form as the LPDB write above, gated on the same per-wiki flag. Drop
+			-- once pagename normalization is unconditional everywhere.
+			local normalizedPageName = Info.config.opponentLpdbForceUnderscores
+				and Page.pageifyLink(player.pageName)
+				or player.pageName
 			Array.forEach(teamPrefixes, function(teamPrefix)
 				local combinedPrefix = teamPrefix .. '_' .. playerPrefix
-				globalVars:set(combinedPrefix, player.pageName)
+				globalVars:set(combinedPrefix, normalizedPageName)
 				globalVars:set(combinedPrefix .. 'flag', player.flag)
 				globalVars:set(combinedPrefix .. 'dn', player.displayName)
 				globalVars:set(combinedPrefix .. 'id', player.apiId)


### PR DESCRIPTION
## Summary

- Adds a `forceUnderscores` option to `Opponent.toLpdbStruct` so callers can force player-pagename underscore normalization regardless of `Info.config.forceUnderscores` (which is display-side, only set on starcraft2).
- `TeamParticipants` now passes `forceUnderscores = true` so LPDB writes are consistent on every wiki, not just on wikis with the display-side flag.
- Applies the same normalization to the matching wiki-variable writes so matches/HiddenDataBox see the same form as LPDB.
- Stopgap with TODOs at each site — the proper fix is unconditional underscore-normalization at every LPDB storage write site.

### Impact

Per mbergen's audit, only overwatch and AoE legacy TeamCards stored player pagenames with spaces

## How did you test this change?

Storage-only change — no visible output difference.