### PR TITLE
Move Brackets  Style

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -2,6 +2,26 @@
 * Styles shared between BracketDisplay, MatchlistDisplay, and MatchSummary
 */
 
+$brackets-colors: (
+	header-background-color: ( light: #cfcfcf,                  dark: var( --clr-secondary-16 ) ),
+	header-border-color:     ( light: #aaaaaa,                  dark: var( --clr-secondary-16 ) ),
+	background-color:        ( light: #f2f2f2,                  dark: var( --clr-secondary-9 ) ),
+	score-background-color:  ( light: #ebebeb,                  dark: var( --clr-secondary-16 ) ),
+	border-color:            ( light: #aaaaaa,                  dark: var( --clr-secondary-16 ) ),
+);
+
+html.theme--light {
+	@each $name, $values in $brackets-colors {
+		--brackets-#{$name}: #{map-get( $values, light )};
+	}
+}
+
+html.theme--dark {
+	@each $name, $values in $brackets-colors {
+		--brackets-#{$name}: #{map-get( $values, dark )};
+	}
+}
+
 .brkts-match-has-details {
 	cursor: pointer;
 }

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -3,11 +3,11 @@
 */
 
 $brackets-colors: (
-	header-background-color: ( light: #cfcfcf,                  dark: var( --clr-secondary-16 ) ),
-	header-border-color:     ( light: #aaaaaa,                  dark: var( --clr-secondary-16 ) ),
-	background-color:        ( light: #f2f2f2,                  dark: var( --clr-secondary-9 ) ),
-	score-background-color:  ( light: #ebebeb,                  dark: var( --clr-secondary-16 ) ),
-	border-color:            ( light: #aaaaaa,                  dark: var( --clr-secondary-16 ) ),
+	header-background-color: ( light: #cfcfcf, dark: var( --clr-secondary-16 ) ),
+	header-border-color: ( light: #aaaaaa, dark: var( --clr-secondary-16 ) ),
+	background-color: ( light: #f2f2f2, dark: var( --clr-secondary-9 ) ),
+	score-background-color: ( light: #ebebeb, dark: var( --clr-secondary-16 ) ),
+	border-color: ( light: #aaaaaa, dark: var( --clr-secondary-16 ) ),
 );
 
 html.theme--light {


### PR DESCRIPTION
## Summary
Moving the brackets colors logic from the Lakesideview rep to the Lua-Modules repo.
This is part of the CSS cleanup task, similar to what was done in this PR :https://github.com/Liquipedia/Lua-Modules/pull/7479

## Related MR
https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/merge_requests/195

## How did you test this change?
* Deployed to my dev wiki (lakesideview + Lua-Modules changes):
  * Test page: https://jujin.wiki.tldev.eu/rocketleague/Collegiate_Rocket_League/2026/Spring/Open_Qualifier/2
  * Staging baseline (unchanged): https://mediawiki.wiki.tldev.eu/rocketleague/Collegiate_Rocket_League/2026/Spring/Open_Qualifier/2
* Verified the five `--brackets-*` custom properties resolve to identical values on dev and staging in both light and dark themes (`#cfcfcf` / `#282828`,`#aaaaaa` / `#282828`, `#f2f2f2` / `#181818`, `#ebebeb` / `#282828`, `#aaaaaa` / `#282828`). . Visually identical to staging.