### PR TITLE
fix(TeamParticipants): isolate missing team template errors per participant

### DIFF
--- a/lua/spec/team_participant_spec.lua
+++ b/lua/spec/team_participant_spec.lua
@@ -632,6 +632,30 @@ describe('Team Participant', function()
 			end)
 		end)
 
+		describe('missing team template', function()
+			local date = os.date("!*t", os.time()) --[[@as osdateparam]]
+			insulate('parseParticipant', function()
+				local TeamTemplateMock
+				before_each(function()
+					TeamTemplateMock = require('wikis.commons.Mock.TeamTemplate')
+					TeamTemplateMock.setUp()
+				end)
+				after_each(function()
+					TeamTemplateMock.tearDown()
+				end)
+
+				it('marks the participant broken without calling Opponent.resolve', function()
+					local result = TeamParticipantsWikiParser.parseParticipant({'definitely missing'}, date)
+					assert.is_true(result.broken)
+					assert.is_truthy(result.errorMessage)
+				end)
+
+				it('leaves valid templates untouched', function()
+					local result = TeamParticipantsWikiParser.parseParticipant({'team liquid'}, date)
+					assert.is_nil(result.broken)
+				end)
+			end)
+		end)
 
 	end)
 

--- a/lua/spec/teamcard_legacy_spec.lua
+++ b/lua/spec/teamcard_legacy_spec.lua
@@ -448,11 +448,13 @@ describe('TeamCard Legacy', function()
 
         it('passes minimumplayers = defaultRowNumber + extraRows + sum(p_extra)', function()
             local TPParser = require('Module:TeamParticipants/Parse/Wiki')
+            local TeamTemplate = require('Module:TeamTemplate')
             local captured
             local stubParse = stub(TPParser, 'parseWikiInput', function(args)
                 captured = args
                 return {participants = {}, expectedPlayerCount = tonumber(args.minimumplayers)}
             end)
+            local stubExists = stub(TeamTemplate, 'exists', function() return true end)
 
             Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
             Template.stashReturnValue({__source = 'toggle', p_extra = '2'}, 'LegacyTeamCard')
@@ -463,8 +465,101 @@ describe('TeamCard Legacy', function()
             assert.are_equal('8', tostring(captured.minimumplayers))
 
             stubParse:revert()
+            stubExists:revert()
         end)
 
+    end)
+
+    describe('run — missing team template', function()
+        local Template = require('Module:Template')
+        local LegacyTeamCard = require('Module:TeamCard/Legacy')
+        local TPParser = require('Module:TeamParticipants/Parse/Wiki')
+        local TeamTemplate = require('Module:TeamTemplate')
+
+        it('drops the card from TP args and adds a tracking category', function()
+            local captured
+            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
+                captured = args
+                return {participants = {}, expectedPlayerCount = 0}
+            end)
+            local stubExists = stub(TeamTemplate, 'exists', function(template)
+                return template == 'good'
+            end)
+            local addCategory = stub(mw.ext.TeamLiquidIntegration, 'add_category', function() end)
+
+            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
+            Template.stashReturnValue({__source = 'card', team = 'good'}, 'LegacyTeamCard')
+            Template.stashReturnValue({__source = 'card', team = 'missing'}, 'LegacyTeamCard')
+
+            LegacyTeamCard.run()
+
+            assert.are_equal(1, #captured)
+            assert.are_equal('good', captured[1][1])
+            assert.stub(addCategory).was.called_with('Pages with missing TeamCard team template')
+
+            addCategory:revert()
+            stubExists:revert()
+            stubParse:revert()
+        end)
+
+        it('skips the check for empty and TBD templates', function()
+            local captured
+            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
+                captured = args
+                return {participants = {}, expectedPlayerCount = 0}
+            end)
+            local stubExists = stub(TeamTemplate, 'exists', function() return false end)
+
+            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
+            Template.stashReturnValue({__source = 'card', team = 'TBD'}, 'LegacyTeamCard')
+            Template.stashReturnValue({__source = 'card', team = ''}, 'LegacyTeamCard')
+
+            LegacyTeamCard.run()
+
+            assert.are_equal(2, #captured)
+            stubExists:revert()
+            stubParse:revert()
+        end)
+
+        it('keeps a contender card when at least one team template exists', function()
+            local captured
+            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
+                captured = args
+                return {participants = {}, expectedPlayerCount = 0}
+            end)
+            local stubExists = stub(TeamTemplate, 'exists', function(template)
+                return template == 'good'
+            end)
+
+            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
+            Template.stashReturnValue(
+                {__source = 'card', team = 'missing1', team2 = 'good', team3 = 'missing2'}, 'LegacyTeamCard')
+
+            LegacyTeamCard.run()
+            assert.are_equal(1, #captured)
+            stubExists:revert()
+            stubParse:revert()
+        end)
+
+        it('drops a contender card when ALL team templates are missing', function()
+            local stubParse = stub(TPParser, 'parseWikiInput', function()
+                return {participants = {}, expectedPlayerCount = 0}
+            end)
+            local stubExists = stub(TeamTemplate, 'exists', function() return false end)
+            local addCategory = stub(mw.ext.TeamLiquidIntegration, 'add_category', function() end)
+
+            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
+            Template.stashReturnValue(
+                {__source = 'card', team = 'm1', team2 = 'm2', team3 = 'm3'}, 'LegacyTeamCard')
+
+            LegacyTeamCard.run()
+            assert.stub(stubParse).was_not_called()
+            assert.stub(addCategory).was.called_with('Pages with missing TeamCard team template')
+
+            addCategory:revert()
+            stubExists:revert()
+            stubParse:revert()
+        end)
     end)
 
     describe('run — preprocessCard hook', function()

--- a/lua/spec/teamcard_legacy_spec.lua
+++ b/lua/spec/teamcard_legacy_spec.lua
@@ -502,45 +502,6 @@ describe('TeamCard Legacy', function()
             stubParse:revert()
         end)
 
-        it('skips the check for empty and TBD templates', function()
-            local captured
-            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
-                captured = args
-                return {participants = {}, expectedPlayerCount = 0}
-            end)
-            local stubExists = stub(TeamTemplate, 'exists', function() return false end)
-
-            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
-            Template.stashReturnValue({__source = 'card', team = 'TBD'}, 'LegacyTeamCard')
-            Template.stashReturnValue({__source = 'card', team = ''}, 'LegacyTeamCard')
-
-            LegacyTeamCard.run()
-
-            assert.are_equal(2, #captured)
-            stubExists:revert()
-            stubParse:revert()
-        end)
-
-        it('keeps a contender card when at least one team template exists', function()
-            local captured
-            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
-                captured = args
-                return {participants = {}, expectedPlayerCount = 0}
-            end)
-            local stubExists = stub(TeamTemplate, 'exists', function(template)
-                return template == 'good'
-            end)
-
-            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
-            Template.stashReturnValue(
-                {__source = 'card', team = 'missing1', team2 = 'good', team3 = 'missing2'}, 'LegacyTeamCard')
-
-            LegacyTeamCard.run()
-            assert.are_equal(1, #captured)
-            stubExists:revert()
-            stubParse:revert()
-        end)
-
         it('drops a contender card when ALL team templates are missing', function()
             local stubParse = stub(TPParser, 'parseWikiInput', function()
                 return {participants = {}, expectedPlayerCount = 0}
@@ -590,6 +551,7 @@ describe('TeamCard Legacy', function()
 
             stubParse:revert()
         end)
+
     end)
 
     describe('integration', function()

--- a/lua/spec/teamcard_legacy_spec.lua
+++ b/lua/spec/teamcard_legacy_spec.lua
@@ -448,13 +448,11 @@ describe('TeamCard Legacy', function()
 
         it('passes minimumplayers = defaultRowNumber + extraRows + sum(p_extra)', function()
             local TPParser = require('Module:TeamParticipants/Parse/Wiki')
-            local TeamTemplate = require('Module:TeamTemplate')
             local captured
             local stubParse = stub(TPParser, 'parseWikiInput', function(args)
                 captured = args
                 return {participants = {}, expectedPlayerCount = tonumber(args.minimumplayers)}
             end)
-            local stubExists = stub(TeamTemplate, 'exists', function() return true end)
 
             Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
             Template.stashReturnValue({__source = 'toggle', p_extra = '2'}, 'LegacyTeamCard')
@@ -465,62 +463,8 @@ describe('TeamCard Legacy', function()
             assert.are_equal('8', tostring(captured.minimumplayers))
 
             stubParse:revert()
-            stubExists:revert()
         end)
 
-    end)
-
-    describe('run — missing team template', function()
-        local Template = require('Module:Template')
-        local LegacyTeamCard = require('Module:TeamCard/Legacy')
-        local TPParser = require('Module:TeamParticipants/Parse/Wiki')
-        local TeamTemplate = require('Module:TeamTemplate')
-
-        it('drops the card from TP args and adds a tracking category', function()
-            local captured
-            local stubParse = stub(TPParser, 'parseWikiInput', function(args)
-                captured = args
-                return {participants = {}, expectedPlayerCount = 0}
-            end)
-            local stubExists = stub(TeamTemplate, 'exists', function(template)
-                return template == 'good'
-            end)
-            local addCategory = stub(mw.ext.TeamLiquidIntegration, 'add_category', function() end)
-
-            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
-            Template.stashReturnValue({__source = 'card', team = 'good'}, 'LegacyTeamCard')
-            Template.stashReturnValue({__source = 'card', team = 'missing'}, 'LegacyTeamCard')
-
-            LegacyTeamCard.run()
-
-            assert.are_equal(1, #captured)
-            assert.are_equal('good', captured[1][1])
-            assert.stub(addCategory).was.called_with('Pages with missing TeamCard team template')
-
-            addCategory:revert()
-            stubExists:revert()
-            stubParse:revert()
-        end)
-
-        it('drops a contender card when ALL team templates are missing', function()
-            local stubParse = stub(TPParser, 'parseWikiInput', function()
-                return {participants = {}, expectedPlayerCount = 0}
-            end)
-            local stubExists = stub(TeamTemplate, 'exists', function() return false end)
-            local addCategory = stub(mw.ext.TeamLiquidIntegration, 'add_category', function() end)
-
-            Template.stashReturnValue({__source = 'header'}, 'LegacyTeamCard')
-            Template.stashReturnValue(
-                {__source = 'card', team = 'm1', team2 = 'm2', team3 = 'm3'}, 'LegacyTeamCard')
-
-            LegacyTeamCard.run()
-            assert.stub(stubParse).was_not_called()
-            assert.stub(addCategory).was.called_with('Pages with missing TeamCard team template')
-
-            addCategory:revert()
-            stubExists:revert()
-            stubParse:revert()
-        end)
     end)
 
     describe('run — preprocessCard hook', function()

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -94,8 +94,15 @@ function LegacyTeamCard.run(dependency)
 
 	local toggleFolded = LegacyTeamCard._foldToggles(toggles)
 
+	local processedCards = Array.map(cardEntries, function(card)
+		if dependency.preprocessCard then
+			return dependency.preprocessCard(card)
+		end
+		return card
+	end)
+
 	local validCards, brokenCards = {}, {}
-	Array.forEach(cardEntries, function(card)
+	Array.forEach(processedCards, function(card)
 		local errorMessage = cardTemplateError(card)
 		if errorMessage then
 			table.insert(brokenCards, {card = card, message = errorMessage})
@@ -123,9 +130,6 @@ function LegacyTeamCard.run(dependency)
 		showplayerinfo = toggleFolded.showPlayerInfo and 'true' or nil,
 	}
 	Array.forEach(validCards, function(card)
-		if dependency.preprocessCard then
-			card = dependency.preprocessCard(card)
-		end
 		table.insert(tpArgs, LegacyTeamCard.mapCard(card))
 	end)
 

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local ErrorDisplay = Lua.import('Module:Error/Display')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
@@ -107,10 +108,7 @@ function LegacyTeamCard.run(dependency)
 	if #brokenCards > 0 then
 		mw.ext.TeamLiquidIntegration.add_category('Pages with missing TeamCard team template')
 		errorWidgets = Array.map(brokenCards, function(broken)
-			return HtmlWidgets.Div{
-				classes = {'team-participant__error', 'ambox', 'ambox-red'},
-				children = {broken.message},
-			}
+			return ErrorDisplay.Box{text = broken.message}
 		end)
 	end
 

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -12,6 +12,7 @@ local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
 local Template = Lua.import('Module:Template')
+local TeamTemplate = Lua.import('Module:TeamTemplate')
 local Tournament = Lua.import('Module:Tournament')
 
 local TeamParticipantsController = Lua.import('Module:TeamParticipants/Controller')
@@ -22,6 +23,38 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local teamParticipantsVars = PageVariableNamespace('TeamParticipants')
 
 local LegacyTeamCard = {}
+
+---Returns an error message if the card's team template(s) can't be resolved.
+---For contender (multi-team) cards, only flags when ALL listed teams are missing.
+---Skips empty/TBD templates — TP handles those.
+---@param card table
+---@return string?
+local function cardTemplateError(card)
+	---@param value string?
+	---@return boolean
+	local function isCheckable(value)
+		return Logic.isNotEmpty(value) and value:lower() ~= 'tbd'
+	end
+
+	if Logic.isNotEmpty(card.team2) or Logic.isNotEmpty(card.team3) then
+		local candidates = {}
+		Array.forEach({{'team', 'link'}, {'team2', 'link2'}, {'team3', 'link3'}}, function(pair)
+			local value = card[pair[2]] or card[pair[1]]
+			if isCheckable(value) then
+				table.insert(candidates, value)
+			end
+		end)
+		if #candidates == 0 then return nil end
+		local anyExists = Array.any(candidates, function(name) return TeamTemplate.exists(name) end)
+		if anyExists then return nil end
+		return 'Missing team templates: ' .. table.concat(candidates, ', ')
+	end
+
+	local template = card.link or card.team
+	if not isCheckable(template) then return nil end
+	if TeamTemplate.exists(template) then return nil end
+	return TeamTemplate.noTeamMessage(template)
+end
 
 ---@param entries table[]
 ---@return table[], table?, table[]
@@ -60,8 +93,29 @@ function LegacyTeamCard.run(dependency)
 
 	local toggleFolded = LegacyTeamCard._foldToggles(toggles)
 
-	local defaultRows, extraRows = 0, 0
+	local validCards, brokenCards = {}, {}
 	Array.forEach(cardEntries, function(card)
+		local errorMessage = cardTemplateError(card)
+		if errorMessage then
+			table.insert(brokenCards, {card = card, message = errorMessage})
+		else
+			table.insert(validCards, card)
+		end
+	end)
+
+	local errorWidgets
+	if #brokenCards > 0 then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with missing TeamCard team template')
+		errorWidgets = Array.map(brokenCards, function(broken)
+			return HtmlWidgets.Div{
+				classes = {'team-participant__error', 'ambox', 'ambox-red'},
+				children = {broken.message},
+			}
+		end)
+	end
+
+	local defaultRows, extraRows = 0, 0
+	Array.forEach(validCards, function(card)
 		defaultRows = tonumber(card.defaultRowNumber) or defaultRows
 		extraRows = tonumber(card.extraRows) or extraRows
 	end)
@@ -70,7 +124,7 @@ function LegacyTeamCard.run(dependency)
 		minimumplayers = defaultRows + extraRows + toggleFolded.extraPlayers,
 		showplayerinfo = toggleFolded.showPlayerInfo and 'true' or nil,
 	}
-	Array.forEach(cardEntries, function(card)
+	Array.forEach(validCards, function(card)
 		if dependency.preprocessCard then
 			card = dependency.preprocessCard(card)
 		end
@@ -81,8 +135,11 @@ function LegacyTeamCard.run(dependency)
 		tpArgs.store = 'false'
 	end
 
-	local display = TeamParticipantsController.fromTemplate(tpArgs)
-	teamParticipantsVars:set('externalControlsRendered', 'true')
+	local display
+	if #validCards > 0 then
+		display = TeamParticipantsController.fromTemplate(tpArgs)
+		teamParticipantsVars:set('externalControlsRendered', 'true')
+	end
 
 	local notesWidget
 	if #toggleFolded.notes > 0 then
@@ -93,7 +150,7 @@ function LegacyTeamCard.run(dependency)
 		}
 	end
 
-	return HtmlWidgets.Fragment{children = WidgetUtil.collect(notesWidget, display)}
+	return HtmlWidgets.Fragment{children = WidgetUtil.collect(errorWidgets, notesWidget, display)}
 end
 
 ---@param rawQualifier string|table|nil

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -8,12 +8,10 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
-local ErrorDisplay = Lua.import('Module:Error/Display')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
 local Template = Lua.import('Module:Template')
-local TeamTemplate = Lua.import('Module:TeamTemplate')
 local Tournament = Lua.import('Module:Tournament')
 
 local TeamParticipantsController = Lua.import('Module:TeamParticipants/Controller')
@@ -24,38 +22,6 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local teamParticipantsVars = PageVariableNamespace('TeamParticipants')
 
 local LegacyTeamCard = {}
-
----Returns an error message if the card's team template(s) can't be resolved.
----For contender (multi-team) cards, only flags when ALL listed teams are missing.
----Skips empty/TBD templates — TP handles those.
----@param card table
----@return string?
-local function cardTemplateError(card)
-	---@param value string?
-	---@return boolean
-	local function isCheckable(value)
-		return Logic.isNotEmpty(value) and value:lower() ~= 'tbd'
-	end
-
-	if Logic.isNotEmpty(card.team2) or Logic.isNotEmpty(card.team3) then
-		local candidates = {}
-		Array.forEach({{'team', 'link'}, {'team2', 'link2'}, {'team3', 'link3'}}, function(pair)
-			local value = card[pair[2]] or card[pair[1]]
-			if isCheckable(value) then
-				table.insert(candidates, value)
-			end
-		end)
-		if #candidates == 0 then return nil end
-		local anyExists = Array.any(candidates, function(name) return TeamTemplate.exists(name) end)
-		if anyExists then return nil end
-		return 'Missing team templates: ' .. table.concat(candidates, ', ')
-	end
-
-	local template = card.link or card.team
-	if not isCheckable(template) then return nil end
-	if TeamTemplate.exists(template) then return nil end
-	return TeamTemplate.noTeamMessage(template)
-end
 
 ---@param entries table[]
 ---@return table[], table?, table[]
@@ -101,26 +67,8 @@ function LegacyTeamCard.run(dependency)
 		return card
 	end)
 
-	local validCards, brokenCards = {}, {}
-	Array.forEach(processedCards, function(card)
-		local errorMessage = cardTemplateError(card)
-		if errorMessage then
-			table.insert(brokenCards, {card = card, message = errorMessage})
-		else
-			table.insert(validCards, card)
-		end
-	end)
-
-	local errorWidgets
-	if #brokenCards > 0 then
-		mw.ext.TeamLiquidIntegration.add_category('Pages with missing TeamCard team template')
-		errorWidgets = Array.map(brokenCards, function(broken)
-			return ErrorDisplay.Box{text = broken.message}
-		end)
-	end
-
 	local defaultRows, extraRows = 0, 0
-	Array.forEach(validCards, function(card)
+	Array.forEach(processedCards, function(card)
 		defaultRows = tonumber(card.defaultRowNumber) or defaultRows
 		extraRows = tonumber(card.extraRows) or extraRows
 	end)
@@ -129,7 +77,7 @@ function LegacyTeamCard.run(dependency)
 		minimumplayers = defaultRows + extraRows + toggleFolded.extraPlayers,
 		showplayerinfo = toggleFolded.showPlayerInfo and 'true' or nil,
 	}
-	Array.forEach(validCards, function(card)
+	Array.forEach(processedCards, function(card)
 		table.insert(tpArgs, LegacyTeamCard.mapCard(card))
 	end)
 
@@ -137,11 +85,8 @@ function LegacyTeamCard.run(dependency)
 		tpArgs.store = 'false'
 	end
 
-	local display
-	if #validCards > 0 then
-		display = TeamParticipantsController.fromTemplate(tpArgs)
-		teamParticipantsVars:set('externalControlsRendered', 'true')
-	end
+	local display = TeamParticipantsController.fromTemplate(tpArgs)
+	teamParticipantsVars:set('externalControlsRendered', 'true')
 
 	local notesWidget
 	if #toggleFolded.notes > 0 then
@@ -152,7 +97,7 @@ function LegacyTeamCard.run(dependency)
 		}
 	end
 
-	return HtmlWidgets.Fragment{children = WidgetUtil.collect(errorWidgets, notesWidget, display)}
+	return HtmlWidgets.Fragment{children = WidgetUtil.collect(notesWidget, display)}
 end
 
 ---@param rawQualifier string|table|nil

--- a/lua/wikis/commons/TeamParticipants/Controller.lua
+++ b/lua/wikis/commons/TeamParticipants/Controller.lua
@@ -40,6 +40,14 @@ function TeamParticipantsController.fromTemplate(frame)
 	local args = Arguments.getArgs(frame)
 	local parsedArgs = Json.parseStringifiedArgs(args)
 	local parsedData = TeamParticipantsWikiParser.parseWikiInput(parsedArgs)
+
+	local brokenParticipants = Array.filter(parsedData.participants, function(p) return p.broken end)
+	parsedData.participants = Array.filter(parsedData.participants, function(p) return not p.broken end)
+
+	if #brokenParticipants > 0 then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with missing team templates')
+	end
+
 	TeamParticipantsController.importParticipants(parsedData)
 	TeamParticipantsController.fillIncompleteRosters(parsedData)
 	if Logic.nilOr(Logic.readBoolOrNil(parsedArgs.enrichPlayerDates), true) then
@@ -57,6 +65,7 @@ function TeamParticipantsController.fromTemplate(frame)
 
 	return TeamParticipantsDisplay{
 		participants = parsedData.participants,
+		brokenParticipants = brokenParticipants,
 		showPlayerInfo = Logic.readBool(args.showplayerinfo),
 		showControls = showControls,
 		mergeStaffTabIfOnlyOneStaff = Logic.nilOr(

--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -24,7 +24,7 @@ local TeamParticipantsWikiParser = {}
 
 ---@alias TeamParticipant {opponent: standardOpponent, notes: {text: string, highlighted: boolean}[], aliases: string[],
 ---qualification: QualificationStructure?, shouldImportFromDb: boolean, date: integer,
----potentialQualifiers: standardOpponent[]?, warnings: string[]?}
+---potentialQualifiers: standardOpponent[]?, warnings: string[]?, broken: boolean?, errorMessage: string?}
 
 ---@alias QualificationMethod 'invite'|'qual'
 ---@alias QualificationType 'tournament'|'internal'|'external'|'other'
@@ -156,6 +156,20 @@ function TeamParticipantsWikiParser.parseParticipant(input, defaultDate)
 		opponent = Opponent.readOpponentArgs(Table.merge(input, {
 			type = Opponent.team,
 		}))
+
+		if not TeamTemplate.exists(opponent.template) then
+			return {
+				opponent = opponent,
+				broken = true,
+				errorMessage = TeamTemplate.noTeamMessage(opponent.template),
+				aliases = {},
+				notes = {},
+				potentialQualifiers = {},
+				warnings = {},
+				shouldImportFromDb = false,
+				date = date or defaultDate,
+			}
+		end
 
 		opponent.players = TeamParticipantsWikiParser.parsePlayers(input)
 		local resolvedOptions = {

--- a/lua/wikis/commons/Widget/Participants/Team/CardsGroup.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/CardsGroup.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Class = Lua.import('Module:Class')
+local ErrorDisplay = Lua.import('Module:Error/Display')
 
 local Widget = Lua.import('Module:Widget')
 local AnalyticsWidget = Lua.import('Module:Widget/Analytics')
@@ -20,6 +21,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class ParticipantsTeamCardsGroupProps
 ---@field participants TeamParticipant[]|nil
+---@field brokenParticipants TeamParticipant[]|nil
 ---@field showPlayerInfo boolean
 ---@field showControls boolean
 ---@field mergeStaffTabIfOnlyOneStaff boolean|nil
@@ -37,8 +39,14 @@ function ParticipantsTeamCardsGroup:render()
 	end
 
 	local showControls = self.props.showControls
+	local brokenParticipants = self.props.brokenParticipants or {}
+
+	local errorBoxes = Array.map(brokenParticipants, function(broken)
+		return ErrorDisplay.Box{text = broken.errorMessage}
+	end)
 
 	local children = WidgetUtil.collect(
+		errorBoxes,
 		showControls and ParticipantControls{showPlayerInfo = self.props.showPlayerInfo} or nil,
 		AnalyticsWidget{
 			analyticsName = 'Team participants card',


### PR DESCRIPTION
## Summary

- `TeamParticipants/Parse/Wiki.parseParticipant` marks a participant as `broken` when its team template doesn't resolve, instead of throwing in `Opponent.toName` / `Opponent.resolve` and taking down the whole render
- Controller skips broken participants from storage and page-var writes, and emits the existing `Pages with missing team templates` tracking category
- `Widget/Participants/Team/CardsGroup` accepts a `brokenParticipants` prop and renders an `ErrorDisplay.Box` per entry above the grid

## How did you test this change?

dev

<img width="1485" height="503" alt="image" src="https://github.com/user-attachments/assets/6d94133d-eaac-4c24-92b1-9fe301fd5253" />
