### PR TITLE
fix(HDB): variable setting broken due to data changes via TP vs TC

### DIFF
--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -174,7 +174,7 @@ function HiddenDataBox._setWikiVariablesFromPlacement(placement, date)
 	local participant = placement.opponentname
 	local participantResolved = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
 
-	local aliases = Array.map(placement.extradata.opponentaliases or {}, TeamTemplate.getPageName)
+	local aliases = Array.map((placement.extradata or {}).opponentaliases or {}, TeamTemplate.getPageName)
 	aliases = Array.extend(aliases,
 		placement.extradata.opponentaliases or {},
 		Array.map(aliases, String.upperCaseFirst),

--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -176,12 +176,12 @@ function HiddenDataBox._setWikiVariablesFromPlacement(placement, date)
 
 	local aliases = Array.map(placement.extradata.opponentaliases or {}, TeamTemplate.getPageName)
 	aliases = Array.extend(aliases,
+		placement.extradata.opponentaliases or {},
 		Array.map(aliases, String.upperCaseFirst),
 		participant,
 		participant ~= participantResolved and participantResolved or nil
 	)
 	aliases = Array.unique(aliases)
-	mw.logObject(aliases)
 
 	Table.iter.forEachPair(placement.opponentplayers or {}, function(key, value)
 		Array.forEach(aliases, function(alias)

--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -32,8 +32,6 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local HiddenDataBox = {}
 local DEFAULT_TIER_TYPE = 'general'
 
-local Language = mw.getContentLanguage()
-
 local Opponent = Lua.import('Module:Opponent/Custom')
 
 ---Entry point

--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -177,27 +177,19 @@ function HiddenDataBox._setWikiVariablesFromPlacement(placement, date)
 	local participantResolved = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
 
 	local aliases = Array.map(placement.extradata.opponentaliases or {}, TeamTemplate.getPageName)
-	Array.appendWith(aliases,
+	aliases = Array.extend(aliases,
+		Array.map(aliases, String.upperCaseFirst),
 		participant,
 		participant ~= participantResolved and participantResolved or nil
 	)
 	aliases = Array.unique(aliases)
+	mw.logObject(aliases)
 
 	Table.iter.forEachPair(placement.opponentplayers or {}, function(key, value)
 		Array.forEach(aliases, function(alias)
-			HiddenDataBox._setWikiVariableForParticipantKey(alias, key, value)
+			Variables.varDefine(alias .. '_' .. key, value)
 		end)
 	end)
-end
-
--- overridable so that wikis can add custom vars
----@param alias string
----@param key string
----@param value string|number
-function HiddenDataBox._setWikiVariableForParticipantKey(alias, key, value)
-	Variables.varDefine(alias .. '_' .. key, value)
-	participant = Language:ucfirst(alias)
-	Variables.varDefine(alias .. '_' .. key, value)
 end
 
 ---Validates the provided tier, tierType pair

--- a/lua/wikis/commons/HiddenDataBox.lua
+++ b/lua/wikis/commons/HiddenDataBox.lua
@@ -19,6 +19,7 @@ local Namespace = Lua.import('Module:Namespace')
 local ReferenceCleaner = Lua.import('Module:ReferenceCleaner')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
+local TeamTemplate = Lua.import('Module:TeamTemplate')
 local TextSanitizer = Lua.import('Module:TextSanitizer')
 local Tier = Lua.import('Module:Tier/Custom')
 local Variables = Lua.import('Module:Variables')
@@ -174,29 +175,29 @@ function HiddenDataBox._setWikiVariablesFromPlacement(placement, date)
 	-- Would need a rework for the function that does it however
 	local participant = placement.opponentname
 	local participantResolved = mw.ext.TeamLiquidIntegration.resolve_redirect(participant)
+
+	local aliases = Array.map(placement.extradata.opponentaliases or {}, TeamTemplate.getPageName)
+	Array.appendWith(aliases,
+		participant,
+		participant ~= participantResolved and participantResolved or nil
+	)
+	aliases = Array.unique(aliases)
+
 	Table.iter.forEachPair(placement.opponentplayers or {}, function(key, value)
-		if Table.isNotEmpty((placement.extradata or {}).opponentaliases) then
-			Array.forEach(placement.extradata.opponentaliases, function(alias)
-				HiddenDataBox._setWikiVariableForParticipantKey(alias, participantResolved, key, value)
-			end)
-		else
-			HiddenDataBox._setWikiVariableForParticipantKey(participant, participantResolved, key, value)
-		end
+		Array.forEach(aliases, function(alias)
+			HiddenDataBox._setWikiVariableForParticipantKey(alias, key, value)
+		end)
 	end)
 end
 
 -- overridable so that wikis can add custom vars
----@param participant string
----@param participantResolved string
+---@param alias string
 ---@param key string
 ---@param value string|number
-function HiddenDataBox._setWikiVariableForParticipantKey(participant, participantResolved, key, value)
-	Variables.varDefine(participant .. '_' .. key, value)
-	participant = Language:ucfirst(participant)
-	Variables.varDefine(participant .. '_' .. key, value)
-	if participant ~= participantResolved then
-		Variables.varDefine(participantResolved .. '_' .. key, value)
-	end
+function HiddenDataBox._setWikiVariableForParticipantKey(alias, key, value)
+	Variables.varDefine(alias .. '_' .. key, value)
+	participant = Language:ucfirst(alias)
+	Variables.varDefine(alias .. '_' .. key, value)
 end
 
 ---Validates the provided tier, tierType pair


### PR DESCRIPTION
context: https://discord.com/channels/@me/1506575739535888474/1507815419258339419

## Summary
TeamParticipants stores opponent templates  into extradata.opponentaliases instead of pagenames (as TC did)
this leads to HDB wiki var setting breaking

as suggested by salt we adjust HDB to work with that instead of adjusting TP as "templates would be preferable"

## How did you test this change?
dev