### PR TITLE
chore: Moving the infobox, crosstable, and matchlist colors logic

### DIFF
--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -19,9 +19,9 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 .crosstable[ class*="crosstable-row-" ] td,
 .crosstable[ class*="crosstable-col-" ] td {
 	opacity: 0.5;
-	-moz-box-shadow: inset 0 0 10px -7px rgba( 0, 0, 0, 1 ), inset 0 0 10px -7px rgba( 0, 0, 0, 1 );
-	-webkit-box-shadow: inset 0 0 10px -7px rgba( 0, 0, 0, 1 ), inset 0 0 10px -7px rgba( 0, 0, 0, 1 );
-	box-shadow: inset 0 0 10px -7px rgba( 0, 0, 0, 1 ), inset 0 0 10px -7px rgba( 0, 0, 0, 1 );
+	-moz-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
+	-webkit-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
+	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
 	background-color: var( --table-background-color, #ffffff );
 	background-clip: padding-box;
 }

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -2,6 +2,14 @@
 Template(s): All Crosstables
 Author(s): FO-nTTaX
 *******************************************************************************/
+.theme--light {
+	--crosstable-box-shadow-color: rgba( 0, 0, 0, 1 );
+}
+
+.theme--dark {
+	--crosstable-box-shadow-color: rgba( 255, 255, 255, 1 );
+}
+
 $crosstable-max: 40;
 $crosstable-size: 40;
 $crosstable-yellow: var( --clr-pear-background-color, #f9f9c7 );

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -3,11 +3,11 @@ Template(s): All Crosstables
 Author(s): FO-nTTaX
 *******************************************************************************/
 .theme--light {
-	--crosstable-box-shadow-color: rgba( 0, 0, 0, 1 );
+	--crosstable-box-shadow-color: #000000;
 }
 
 .theme--dark {
-	--crosstable-box-shadow-color: rgba( 255, 255, 255, 1 );
+	--crosstable-box-shadow-color: #ffffff;
 }
 
 $crosstable-max: 40;

--- a/stylesheets/commons/Crosstable.scss
+++ b/stylesheets/commons/Crosstable.scss
@@ -19,9 +19,7 @@ $crosstable-red: var( --table-red-background-color, #fbdfdf );
 .crosstable[ class*="crosstable-row-" ] td,
 .crosstable[ class*="crosstable-col-" ] td {
 	opacity: 0.5;
-	-moz-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	-webkit-box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
-	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) ), inset 0 0 10px -7px var( --crosstable-box-shadow-color, rgba( 0, 0, 0, 1 ) );
+	box-shadow: inset 0 0 10px -7px var( --crosstable-box-shadow-color ), inset 0 0 10px -7px var( --crosstable-box-shadow-color );
 	background-color: var( --table-background-color, #ffffff );
 	background-clip: padding-box;
 }

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -2,6 +2,14 @@
 Template(s): All Infoboxes
 Author(s): FO-nTTaX
 *******************************************************************************/
+.theme--light {
+	--infobox-header-background-color: var( --clr-wiki-primary-container );
+}
+
+.theme--dark {
+	--infobox-header-background-color: var( --clr-wiki-theme-20 );
+}
+
 $infobox-width: 336px;
 $infobox-margin: 10px;
 $infobox-padding: 10px;

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -2345,6 +2345,14 @@ Author(s): Elysienna
 	background: linear-gradient( 90deg, var( --table-header-variant-background-color, rgba( 234, 236, 240, 1 ) ) 0%, rgba( 237, 208, 80, 1 ) 75%, var( --table-header-variant-background-color, rgba( 234, 236, 240, 1 ) ) 100% );
 }
 
+.theme--light {
+	--matchlist-header-background-color: #fbf2df;
+}
+
+.theme--dark {
+	--matchlist-header-background-color: var( --clr-secondary-16 );
+}
+
 .matchlist-header {
 	border-bottom: 0.125rem solid var( --table-border-color, #bbbbbb );
 }


### PR DESCRIPTION
## Summary
Moving the infobox, crosstable, and matchlist colors logic from the Lakesideview repo to the Lua-Modules repo.  
This is part of the CSS cleanup task, similar to what was done in this PR:https://github.com/Liquipedia/Lua-Modules/pull/7479

## Related MR
- https://gitlab.com/teamliquid-dev/liquipedia/web/skins/lakesideview/-/merge_requests/199

## How did you test this change?
- Deployed to my [dev wiki](https://jujin.wiki.tldev.eu/rocketleague/Rival_Rush/Season_2/Split_2) (lakesideview + Lua-Modules changes)
  - Infobox: verified --infobox-header-background-color resolves to correct values, in light (`#d9e2ff`) and dark (`#003866`). 
  - Crosstable: verified --crosstable-box-shadow-color resolves to correct values in light (rgba(0,0,0,1)) and dark (rgba(255,255,255,1)).
  - Matchlist: verified --matchlist-header-background-color resolves to correct values in light (`#fbf2df`) and dark (`#282828`). 