### PR TITLE
feat: add InGameRoles for teamfortress

### DIFF
--- a/lua/wikis/teamfortress/InGameRoles.lua
+++ b/lua/wikis/teamfortress/InGameRoles.lua
@@ -1,0 +1,30 @@
+---
+-- @Liquipedia
+-- page=Module:InGameRoles
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+---@type table<string, RoleBaseData>
+local inGameRoles = {
+	['scout'] = {category = 'Scouts', display = 'Scout'},
+	['soldier'] = {category = 'Soldiers', display = 'Soldier'},
+	['pocket'] = {category = 'Pocket Soldiers', display = 'Pocket Soldier'},
+	['pyro'] = {category = 'Pyros', display = 'Pyro'},
+	['demoman'] = {category = 'Demomen', display = 'Demoman'},
+	['heavy'] = {category = 'Heavies', display = 'Heavy'},
+	['engineer'] = {category = 'Engineers', display = 'Engineer'},
+	['medic'] = {category = 'Medics', display = 'Medic'},
+	['sniper'] = {category = 'Snipers', display = 'Sniper'},
+	['spy'] = {category = 'Spies', display = 'Spy'},
+}
+
+inGameRoles['solly'] = inGameRoles.soldier
+inGameRoles['roamer'] = inGameRoles.soldier
+inGameRoles['pocketsoldier'] = inGameRoles.pocket
+inGameRoles['pocketsolly'] = inGameRoles.pocket
+inGameRoles['demo'] = inGameRoles.demoman
+inGameRoles['engi'] = inGameRoles.engineer
+inGameRoles['med'] = inGameRoles.medic
+
+return inGameRoles


### PR DESCRIPTION
## Summary

- Add `Module:InGameRoles` for teamfortress so player classes (scout, soldier, demoman, medic, pyro, heavy, engineer, sniper, spy, pocket) are typed as `INGAME` by `Module:Role/Util`.
- Without this, TeamParticipant rendered the class both as a left-side icon (via `Module:PositionIcon/data`) and as a right-side text badge (since unknown-typed roles fall through to the non-ingame branch in `Widget/Participants/Team/Roster`).
- Includes the aliases present in the wiki's PositionIcon/data: `solly`/`roamer` → soldier, `pocketsoldier`/`pocketsolly` → pocket, `demo` → demoman, `engi` → engineer, `med` → medic.

## How did you test this change?

dev