### PR TITLE
chore(match2): add substitute reference templates to protected templates

### DIFF
--- a/templates/templatesToProtect
+++ b/templates/templatesToProtect
@@ -279,6 +279,8 @@ Stage
 StageWinnings
 Streams
 Substitution
+SubstitutionReference
+SubstitutionReferences
 SwissStandings
 Tabs_dynamic
 Tabs_static


### PR DESCRIPTION
## Summary

Related: #7531
Protection run ongoing locally