### PR TITLE
fix(infobox): property not initialized in breakdown component

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/Breakdown.lua
+++ b/lua/wikis/commons/Widget/Infobox/Breakdown.lua
@@ -42,4 +42,4 @@ local function Breakdown(props)
 	}
 end
 
-return Component.component(Breakdown)
+return Component.component(Breakdown, {contentClasses = {}})


### PR DESCRIPTION
## Summary

Reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1509490957114933310

## How did you test this change?

untested