### PR TITLE
fix(infobox): `content` still being used over `children`

### DIFF
--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -74,7 +74,7 @@ function CustomInjector:parse(id, widgets)
 				Array.map(
 					titles,
 					function (title)
-						return Cell{name = title.name, content = {args['title_' .. title.code]}}
+						return Cell{name = title.name, children = {args['title_' .. title.code]}}
 					end
 				)
 			)

--- a/lua/wikis/counterstrike/Infobox/League/Custom.lua
+++ b/lua/wikis/counterstrike/Infobox/League/Custom.lua
@@ -193,7 +193,7 @@ function CustomInjector:parse(id, widgets)
 			},
 			Cell{
 				name = Template.safeExpand(mw.getCurrentFrame(), 'Valve/infobox') .. ' Tier',
-				content = self.caller:_createValveTierCell(),
+				children = self.caller:_createValveTierCell(),
 				classes = {'valvepremier-highlighted'},
 				options = {separator = '&ensp;'}
 			}


### PR DESCRIPTION
## Summary
as title states

## How did you test this change?
live on cs, trivial