### PR TITLE
feat(TeamParticipants): Add support for disqualified/withdrawn/replacement

### DIFF
--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -22,8 +22,14 @@ local Variables = Lua.import('Module:Variables')
 
 local TeamParticipantsWikiParser = {}
 
+local STATUS_DISQUALIFIED = 'DISQUALIFIED'
+local STATUS_WITHDRAWN = 'WITHDRAWN'
+local STATUS_REPLACEMENT = 'REPLACEMENT'
+
+---@alias TeamParticipantStatus `STATUS_DISQUALIFIED`|`STATUS_WITHDRAWN`|`STATUS_REPLACEMENT`
+
 ---@alias TeamParticipant {opponent: standardOpponent, notes: {text: string, highlighted: boolean}[], aliases: string[],
----qualification: QualificationStructure?, shouldImportFromDb: boolean, date: integer,
+---qualification: QualificationStructure?, shouldImportFromDb: boolean, date: integer, status: TeamParticipantStatus?,
 ---potentialQualifiers: standardOpponent[]?, warnings: string[]?, broken: boolean?, errorMessage: string?}
 
 ---@alias QualificationMethod 'invite'|'qual'
@@ -202,6 +208,10 @@ function TeamParticipantsWikiParser.parseParticipant(input, defaultDate)
 		aliases = Array.flatMap(aliases, function(alias)
 			return TeamTemplate.queryHistoricalNames(alias)
 		end),
+		status = Logic.readBool(input.disqualified) and STATUS_DISQUALIFIED
+			or Logic.readBool(input.withdrawn) and STATUS_WITHDRAWN
+			or Logic.readBool(input.replacement) and STATUS_REPLACEMENT
+			or nil,
 		notes = Array.map(input.notes or {}, function(note)
 			local text = note[1]
 			if not text then

--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -22,9 +22,9 @@ local Variables = Lua.import('Module:Variables')
 
 local TeamParticipantsWikiParser = {}
 
-local STATUS_DISQUALIFIED = 'DISQUALIFIED'
-local STATUS_WITHDRAWN = 'WITHDRAWN'
-local STATUS_REPLACEMENT = 'REPLACEMENT'
+local STATUS_DISQUALIFIED = 'disqualified'
+local STATUS_WITHDRAWN = 'withdrawn'
+local STATUS_REPLACEMENT = 'replacement'
 
 ---@alias TeamParticipantStatus `STATUS_DISQUALIFIED`|`STATUS_WITHDRAWN`|`STATUS_REPLACEMENT`
 

--- a/lua/wikis/commons/TeamParticipants/Repository.lua
+++ b/lua/wikis/commons/TeamParticipants/Repository.lua
@@ -122,6 +122,7 @@ function TeamParticipantsRepository.save(participant)
 			end
 
 			lpdbData.extradata = lpdbData.extradata or {}
+			lpdbData.extradata.status = participant.status
 			lpdbData.extradata.opponentaliases = participant.aliases
 			if participant.potentialQualifiers and #participant.potentialQualifiers > 0 then
 				local serializedQualifiers = Array.map(participant.potentialQualifiers, Opponent.toName)

--- a/lua/wikis/commons/Widget/Participants/Team/Header.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Header.lua
@@ -19,9 +19,9 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
-local STATUS_DISQUALIFIED = 'DISQUALIFIED'
-local STATUS_WITHDRAWN = 'WITHDRAWN'
-local STATUS_REPLACEMENT = 'REPLACEMENT'
+local STATUS_DISQUALIFIED = 'disqualified'
+local STATUS_WITHDRAWN = 'withdrawn'
+local STATUS_REPLACEMENT = 'replacement'
 
 ---@class ParticipantsTeamHeader: Widget
 ---@operator call(table): ParticipantsTeamHeader

--- a/lua/wikis/commons/Widget/Participants/Team/Header.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Header.lua
@@ -19,6 +19,10 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local Div = HtmlWidgets.Div
 
+local STATUS_DISQUALIFIED = 'DISQUALIFIED'
+local STATUS_WITHDRAWN = 'WITHDRAWN'
+local STATUS_REPLACEMENT = 'REPLACEMENT'
+
 ---@class ParticipantsTeamHeader: Widget
 ---@operator call(table): ParticipantsTeamHeader
 local ParticipantsTeamHeader = Class.new(Widget)
@@ -101,11 +105,16 @@ function ParticipantsTeamHeader:_renderLabel(participant)
 	local labelText
 	local isTbd = Logic.isNotEmpty(participant.potentialQualifiers) or Opponent.isTbd(participant.opponent);
 	local qualificationData = participant.qualification
-	if not qualificationData then
-		return
-	end
 
-	if qualificationData.method == 'qual' then
+	if participant.status == STATUS_DISQUALIFIED then
+		labelText = 'Disqualified'
+	elseif participant.status == STATUS_WITHDRAWN then
+		labelText = 'Withdrawn'
+	elseif participant.status == STATUS_REPLACEMENT then
+		labelText = 'Replacement'
+	elseif not qualificationData then
+		return
+	elseif qualificationData.method == 'qual' then
 		labelText = 'Qualifier'
 	elseif qualificationData.method == 'invite' then
 		labelText = 'Invited'


### PR DESCRIPTION
## Summary
As per discussion on discord add support for disqualified/withdrawn/replacement.
[The Figma](https://www.figma.com/design/ZmgcrdHunoVLZjE4JUsIF8/Team-Participants?node-id=0-1&p=f) showed it with colors and an icon, but so does it for Invited/Qualifier.
This PR implements the new badges the same way as the Invited/Qualifier ones.

## Open questions
- should it be stored?
  - currently the pr adds storage as `.extradata.status`
  - if yes should we add a value if it is neither replacement/withdrawn nor disqualified?
- should TeamParticipants that withdrew or got disqualified be stored at all?
- do we want an additional strikethrough for withdrawn/disqualified participants?
  - https://liquipedia.net/commons/index.php?title=Module%3AWidget%2FParticipants%2FTeam%2FHeader%2Fdev%2Fhjp&diff=989356&oldid=989351
  - personally i like it better without and figma also doesn't have it
  - **decission: no strike-through**

## How did you test this change?
dev
https://liquipedia.net/leagueoflegends/User:Hjpalpha