### PR TITLE
feat(TeamCard): wildrift legacy wrapper custom mapping

### DIFF
--- a/lua/wikis/wildrift/InGameRoles.lua
+++ b/lua/wikis/wildrift/InGameRoles.lua
@@ -7,11 +7,11 @@
 
 ---@type table<string, RoleBaseData>
 local inGameRoles = {
-	['baron'] = {category = 'Baron Lane players', display = 'Baron'},
-	['support'] = {category = 'Support players', display = 'Support'},
-	['jungle'] = {category = 'Jungle players', display = 'Jungle'},
-	['mid'] = {category = 'Mid Lane players', display = 'Mid'},
-	['dragon'] = {category = 'Dragon Lane players', display = 'Dragon'},
+	['baron'] = {category = 'Baron Lane players', display = 'Baron', sortOrder = 1},
+	['jungle'] = {category = 'Jungle players', display = 'Jungle', sortOrder = 2},
+	['mid'] = {category = 'Mid Lane players', display = 'Mid', sortOrder = 3},
+	['dragon'] = {category = 'Dragon Lane players', display = 'Dragon', sortOrder = 4},
+	['support'] = {category = 'Support players', display = 'Support', sortOrder = 5},
 }
 
 inGameRoles['jgl'] = inGameRoles.jungle

--- a/lua/wikis/wildrift/TeamCard/Legacy/Custom.lua
+++ b/lua/wikis/wildrift/TeamCard/Legacy/Custom.lua
@@ -1,0 +1,59 @@
+---
+-- @Liquipedia
+-- page=Module:TeamCard/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
+local LegacyTeamCard = Lua.import('Module:TeamCard/Legacy')
+local Logic = Lua.import('Module:Logic')
+local MathUtil = Lua.import('Module:MathUtil')
+local Table = Lua.import('Module:Table')
+
+local DEFAULT_MAX_PLAYER_INDEX = 10
+local INGAME_ROLES_BY_ORDER = Table.map(InGameRoles, function(_, roleData)
+	return roleData.sortOrder, roleData.display
+end)
+
+local CustomLegacyTeamCard = {}
+
+-- Template entry point
+---@return Widget
+function CustomLegacyTeamCard.run()
+	return LegacyTeamCard.run(CustomLegacyTeamCard)
+end
+
+---@param card table
+---@return table
+function CustomLegacyTeamCard.preprocessCard(card)
+	card.defaultRowNumber = MathUtil.toInteger(card.defaultRowNumber) or 5
+	card.t2title = Logic.emptyOr(card.t2title, 'Substitutes')
+	card.t3title = Logic.emptyOr(card.t3title, 'Staff')
+
+	Array.forEach(Array.range(1, DEFAULT_MAX_PLAYER_INDEX), function(index)
+		local key = 'p' .. index
+		card[key .. 'pos'] = Logic.emptyOr(
+			card[key .. 'pos'],
+			Table.extract(card, 'pos' .. index),
+			INGAME_ROLES_BY_ORDER[index]
+		)
+	end)
+
+	for tabIndex = 2, 3 do
+		Array.forEach(Array.range(1, DEFAULT_MAX_PLAYER_INDEX), function(index)
+			local key = 't' .. tabIndex .. 'p' .. index
+			card[key .. 'pos'] = Logic.emptyOr(
+				card[key .. 'pos'],
+				Table.extract(card, 't' .. tabIndex .. 'pos' .. index)
+			)
+		end)
+	end
+
+	return card
+end
+
+return CustomLegacyTeamCard

--- a/lua/wikis/wildrift/TeamCard/Legacy/Custom.lua
+++ b/lua/wikis/wildrift/TeamCard/Legacy/Custom.lua
@@ -11,7 +11,6 @@ local Array = Lua.import('Module:Array')
 local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
 local LegacyTeamCard = Lua.import('Module:TeamCard/Legacy')
 local Logic = Lua.import('Module:Logic')
-local MathUtil = Lua.import('Module:MathUtil')
 local Table = Lua.import('Module:Table')
 
 local DEFAULT_MAX_PLAYER_INDEX = 10
@@ -30,10 +29,6 @@ end
 ---@param card table
 ---@return table
 function CustomLegacyTeamCard.preprocessCard(card)
-	card.defaultRowNumber = MathUtil.toInteger(card.defaultRowNumber) or 5
-	card.t2title = Logic.emptyOr(card.t2title, 'Substitutes')
-	card.t3title = Logic.emptyOr(card.t3title, 'Staff')
-
 	Array.forEach(Array.range(1, DEFAULT_MAX_PLAYER_INDEX), function(index)
 		local key = 'p' .. index
 		card[key .. 'pos'] = Logic.emptyOr(


### PR DESCRIPTION
## Summary

- Add `Module:TeamCard/Legacy/Custom` for wildrift, mirroring the [LoL custom mapping:](https://github.com/Liquipedia/Lua-Modules/pull/7510) defaults `pNpos` by slot index via `Module:InGameRoles` `sortOrder` so old TC pages without explicit lane positions still render icons under the Legacy wrapper.
- Add `sortOrder` fields to `Module:InGameRoles` (baron=1, jungle=2, mid=3, dragon=4, support=5) so the slot-to-lane defaulting has data to read.

## How did you test this change?

dev (live in prod)