### PR TITLE
feat(heroes): add InGameRoles module

### DIFF
--- a/lua/wikis/heroes/InGameRoles.lua
+++ b/lua/wikis/heroes/InGameRoles.lua
@@ -1,0 +1,28 @@
+---
+-- @Liquipedia
+-- page=Module:InGameRoles
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+---@type table<string, RoleBaseData>
+local inGameRoles = {
+	['warrior'] = {category = 'Warriors', display = 'Warrior'},
+	['melee'] = {category = 'Melee Assassins', display = 'Melee Assassin'},
+	['ranged'] = {category = 'Ranged Assassins', display = 'Ranged Assassin'},
+	['flex'] = {category = 'Flex players', display = 'Flex'},
+	['support'] = {category = 'Support players', display = 'Support'},
+	['healer'] = {category = 'Healers', display = 'Healer'},
+	['offlane'] = {category = 'Offlaners', display = 'Offlaner'},
+}
+
+inGameRoles['war'] = inGameRoles.warrior
+inGameRoles['tank'] = inGameRoles.warrior
+inGameRoles['mel'] = inGameRoles.melee
+inGameRoles['ran'] = inGameRoles.ranged
+inGameRoles['sup'] = inGameRoles.support
+inGameRoles['heal'] = inGameRoles.healer
+inGameRoles['off'] = inGameRoles.offlane
+inGameRoles['solo'] = inGameRoles.offlane
+
+return inGameRoles


### PR DESCRIPTION
## Summary

- Add `Module:InGameRoles` for the heroes wiki registering warrior/melee/ranged/flex/support plus healer/offlane, with abbreviation aliases (war, mel, ran, sup, heal, off, solo) and tank→warrior matching the on-wiki `Module:PositionIcon/data` mapping.
- Lets `Module:Roles` recognise these as in-game roles so they render icon-only (no duplicate text label) - prep work for TeamCard Legacy wrapper rollout on heroes.

## How did you test this change?

dev