### PR TITLE
fix(TeamCard/Legacy): unwrap NoteBig wikitext in notes/inotes

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -11,6 +11,7 @@ local Array = Lua.import('Module:Array')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
+local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Template = Lua.import('Module:Template')
 local Tournament = Lua.import('Module:Tournament')
@@ -37,14 +38,14 @@ end
 ---@param value string
 ---@return string
 local function cleanNote(value)
-	value = mw.text.trim(value)
+	value = String.trim(value)
 	-- Unwrap a single outer <div>...</div> (e.g. Template:NoteBig expands to one).
 	value = value:gsub('^<div>%s*', ''):gsub('%s*</div>$', '')
 	-- Strip wikitext definition-list markers (`:` at the start of a line). The new
 	-- notification widget provides its own styling, so we don't want MW to re-parse
 	-- these as <dl><dd>...</dd></dl>. Multi-note NoteBig expansions become <br>.
 	value = value:gsub('^:+%s*', ''):gsub('\n:+%s*', '<br>')
-	return mw.text.trim(value)
+	return String.trim(value)
 end
 
 ---@param entries table[]

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -34,6 +34,19 @@ local function normalizePosition(value)
 	return PositionConvert[value:lower()] or value
 end
 
+---@param value string
+---@return string
+local function cleanNote(value)
+	value = mw.text.trim(value)
+	-- Unwrap a single outer <div>...</div> (e.g. Template:NoteBig expands to one).
+	value = value:gsub('^<div>%s*', ''):gsub('%s*</div>$', '')
+	-- Strip wikitext definition-list markers (`:` at the start of a line). The new
+	-- notification widget provides its own styling, so we don't want MW to re-parse
+	-- these as <dl><dd>...</dd></dl>. Multi-note NoteBig expansions become <br>.
+	value = value:gsub('^:+%s*', ''):gsub('\n:+%s*', '<br>')
+	return mw.text.trim(value)
+end
+
 ---@param entries table[]
 ---@return table[], table?, table[]
 local function partitionStash(entries)
@@ -421,10 +434,10 @@ function LegacyTeamCard.mapCard(tcArgs)
 
 	local notes = {}
 	if Logic.isNotEmpty(tcArgs.notes) then
-		table.insert(notes, {[1] = tcArgs.notes, highlighted = false})
+		table.insert(notes, {[1] = cleanNote(tcArgs.notes), highlighted = false})
 	end
 	if Logic.isNotEmpty(tcArgs.inotes) then
-		table.insert(notes, {[1] = tcArgs.inotes, highlighted = false})
+		table.insert(notes, {[1] = cleanNote(tcArgs.inotes), highlighted = false})
 	end
 	if #notes > 0 then card.notes = notes end
 


### PR DESCRIPTION
## Summary

- `Template:NoteBig` expands to `<div>\n:<sup>...</sup> <small>...</small>\n</div>`, and when that string reached the new notification widget MW re-parsed the `:` markers as `<dl><dd>...</dd></dl>` — wrecking the layout vs. a plain TeamParticipants notification. Example: https://liquipedia.net/worldoftanks/Wargaming.net_League/The_Final_Battle/2017
- Trim each `notes` / `inotes` value in `LegacyTeamCard.mapCard`: unwrap a single outer `<div>`, strip leading `:`, and convert `\n:` separators (multi-note NoteBig) into `<br>`.

## How did you test this change?

dev

before:
<img width="299" height="144" alt="image" src="https://github.com/user-attachments/assets/3deeeb51-ba92-4aa4-a47c-6f3631fbce41" />

after:
<img width="295" height="163" alt="image" src="https://github.com/user-attachments/assets/422758e4-1938-4217-9997-a80a05a38075" />
