### PR TITLE
refactor(match2): use generic label style in dota2 matchpage

### DIFF
--- a/lua/wikis/commons/Widget/Basic/Label.lua
+++ b/lua/wikis/commons/Widget/Basic/Label.lua
@@ -7,6 +7,8 @@
 
 local Lua = require('Module:Lua')
 
+local Array = Lua.import('Module:Array')
+
 local Component = Lua.import('Module:Widget/Component')
 local Html = Lua.import('Module:Widget/Html')
 
@@ -29,10 +31,11 @@ local function GenericLabel(props)
 
 	return Html.Div{
 		attributes = props.attributes,
-		classes = {
+		classes = Array.extend(
 			'generic-label',
 			props.labelScheme and ('label--' .. props.labelScheme) or nil,
-		},
+			props.classes
+		),
 		css = props.css,
 		children = props.children,
 	}

--- a/lua/wikis/commons/Widget/Match/Page/SeriesDots.lua
+++ b/lua/wikis/commons/Widget/Match/Page/SeriesDots.lua
@@ -22,8 +22,8 @@ local Label = Lua.import('Module:Widget/Basic/Label')
 local RESULT_DISPLAY_TYPES = {
 	['w'] = 'win',
 	['l'] = 'loss',
-	['winner'] = 'win',
-	['loser'] = 'loss',
+	['win'] = 'win',
+	['loss'] = 'loss',
 	['-'] = 'default'
 }
 

--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -249,7 +249,7 @@ function MatchPage:_renderStatsTeamDisplay(game, teamIndex)
 			Label{
 				labelType = 'result-' .. (scoreDisplay == '-' and 'default' or scoreDisplay),
 				classes = {'match-bm-team-stats-team-state'},
-				children = team.scoreDisplay
+				children = scoreDisplay
 			}
 		}
 	}

--- a/lua/wikis/dota2/MatchPage.lua
+++ b/lua/wikis/dota2/MatchPage.lua
@@ -15,6 +15,7 @@ local Table = Lua.import('Module:Table')
 
 local BaseMatchPage = Lua.import('Module:MatchPage/Base')
 
+local Label = Lua.import('Module:Widget/Basic/Label')
 local Link = Lua.import('Module:Widget/Basic/Link')
 local Html = Lua.import('Module:Widget/Html')
 local Div = Html.Div
@@ -51,7 +52,7 @@ function MatchPage:populateGames()
 		game.teams = Array.map(Array.range(1, 2), function(teamIdx)
 			local team = {}
 
-			team.scoreDisplay = game.winner == teamIdx and 'winner' or game.finished and 'loser' or '-'
+			team.scoreDisplay = game.winner == teamIdx and 'win' or game.finished and 'loss' or '-'
 			team.side = String.nilIfEmpty(game.extradata['team' .. teamIdx ..'side'])
 			team.players = Array.map(Array.filter(game.opponents[teamIdx].players or {}, Table.isNotEmpty), function(player)
 				local newPlayer = Table.mergeInto(player, {
@@ -233,6 +234,7 @@ end
 ---@return Renderable
 function MatchPage:_renderStatsTeamDisplay(game, teamIndex)
 	local team = game.teams[teamIndex]
+	local scoreDisplay = team.scoreDisplay
 	return Div{
 		classes = {'match-bm-team-stats-team'},
 		children = {
@@ -244,11 +246,9 @@ function MatchPage:_renderStatsTeamDisplay(game, teamIndex)
 				classes = {'match-bm-team-stats-team-side'},
 				children = team.side
 			},
-			Div{
-				classes = {
-					'match-bm-team-stats-team-state',
-					'state--' .. team.scoreDisplay
-				},
+			Label{
+				labelType = 'result-' .. (scoreDisplay == '-' and 'default' or scoreDisplay),
+				classes = {'match-bm-team-stats-team-state'},
 				children = team.scoreDisplay
 			}
 		}

--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1146,23 +1146,9 @@ span.slash {
 		}
 
 		&-state {
-			background-color: var( --clr-on-background );
-			border-radius: 0.875rem;
-			min-height: 1.5rem;
-			color: #ffffff;
-			padding: 0.125rem 0.5rem;
-			text-transform: uppercase;
 			font-weight: bold;
-			width: 5.5rem;
-			text-align: center;
-
-			&.state--winner {
-				background-color: var( --clr-semantic-positive-40 );
-			}
-
-			&.state--loser {
-				background-color: var( --clr-semantic-negative-40 );
-			}
+			text-transform: uppercase;
+			--label-scale: 1.25;
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR replaces dota2 matchpage-specific style with standardized label design.

## How did you test this change?

dev + browser dev tools

<img width="1190" height="326" alt="image" src="https://github.com/user-attachments/assets/15fadbc3-8b1c-4cbd-abff-f3fc91ffce5d" />
