### PR TITLE
fix(match2): broken links in valorant map veto display

### DIFF
--- a/lua/wikis/commons/Map.lua
+++ b/lua/wikis/commons/Map.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
+local Game = Lua.import('Module:Game')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
@@ -120,7 +121,7 @@ function Map.fromRecord(record)
 		imageDark = Logic.nilIfEmpty(record.imagedark),
 		creators = creators,
 		creatorDisplayNames = creatorDisplayNames,
-		game = Table.extract(record.extradata, 'game'),
+		game = Game.toIdentifier{game = Table.extract(record.extradata, 'game'), useDefault = false},
 		gameModes = Table.extract(record.extradata, 'modes'),
 		extradata = record.extradata
 	}

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -13,6 +13,7 @@ local Class = Lua.import('Module:Class')
 local FnUtil = Lua.import('Module:FnUtil')
 local Image = Lua.import('Module:Image')
 local Logic = Lua.import('Module:Logic')
+local Map = Lua.import('Module:Map')
 local Table = Lua.import('Module:Table')
 local VodLink = Lua.import('Module:VodLink')
 
@@ -312,7 +313,7 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 end
 
 ---@param mapVetoes table
----@param options {game: string?, emptyMapDisplay: string?}?
+---@param options {game: string?, emptyMapDisplay: string?, useLpdb: boolean?}?
 ---@return MapVetoProps?
 function MatchSummary.preProcessMapVeto(mapVetoes, options)
 	if Logic.isEmpty(mapVetoes) then
@@ -320,15 +321,26 @@ function MatchSummary.preProcessMapVeto(mapVetoes, options)
 	end
 
 	options = options or {}
-	local mapInputToDisplay = function(map)
+
+	---@param map string?
+	---@return {name: string, link: string?}
+	local mapInputToDisplay = FnUtil.memoize(function(map)
 		if Logic.isEmpty(map) then
 			return {name = options.emptyMapDisplay or TBD}
+		end
+		---@cast map -nil
+		if options.useLpdb then
+			local mapData = Map.getMapByName(map)
+			if mapData then
+				return {name = mapData.displayName, link = mapData.pageName}
+			end
+			return {name = map}
 		end
 		if options.game then
 			return {name = map, link = map .. '/' .. options.game}
 		end
 		return {name = map, link = map}
-	end
+	end)
 
 	return {
 		firstVeto = tonumber(mapVetoes[1].vetostart),

--- a/lua/wikis/commons/Widget/Match/Header.lua
+++ b/lua/wikis/commons/Widget/Match/Header.lua
@@ -23,7 +23,7 @@ local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 ---@class MatchHeaderProps
 ---@field match MatchGroupUtilMatch
 ---@field teamStyle? teamStyle
----@field variant 'horizontal'|'vertical'
+---@field variant? 'horizontal'|'vertical'
 
 local MatchHeader = {}
 MatchHeader.defaultProps = {

--- a/lua/wikis/valorant/MatchSummary.lua
+++ b/lua/wikis/valorant/MatchSummary.lua
@@ -45,7 +45,7 @@ function CustomMatchSummary.createBody(match)
 		},
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
 		MatchSummaryWidgets.MapVeto(
-			MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game, useLpdb = true})
+			MatchSummary.preProcessMapVeto(match.extradata.mapveto, {useLpdb = true})
 		)
 	}
 end

--- a/lua/wikis/valorant/MatchSummary.lua
+++ b/lua/wikis/valorant/MatchSummary.lua
@@ -44,7 +44,9 @@ function CustomMatchSummary.createBody(match)
 			end)
 		},
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game}))
+		MatchSummaryWidgets.MapVeto(
+			MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game, useLpdb = true})
+		)
 	}
 end
 


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/64f0ccdd078b289e8ea9e7bfc9e82a4a3d152bca/lua/wikis/commons/MatchSummary/Base.lua#L327-L329

https://github.com/Liquipedia/Lua-Modules/blob/64f0ccdd078b289e8ea9e7bfc9e82a4a3d152bca/lua/wikis/valorant/MatchSummary.lua#L47

The `game = match.game` option passed into `MatchSummary.preProcessMapVeto` caused the returned links to have `/val` appended to the returned link. This wasn't a problem until #7586 as the link was never used for display due to key inconsistency (see https://github.com/Liquipedia/Lua-Modules/pull/7586#discussion_r3332836640).

This PR fixes the above issue by adding a LPDB map check, similar to how match pages handle map veto.

## How did you test this change?

dev