### PR TITLE
feat: Add `top` as alias for `baron` in wildrift IngameRoles

### DIFF
--- a/lua/wikis/wildrift/InGameRoles.lua
+++ b/lua/wikis/wildrift/InGameRoles.lua
@@ -14,6 +14,7 @@ local inGameRoles = {
 	['support'] = {category = 'Support players', display = 'Support', sortOrder = 5},
 }
 
+inGameRoles['top'] = inGameRoles.baron
 inGameRoles['jgl'] = inGameRoles.jungle
 inGameRoles['solomiddle'] = inGameRoles.mid
 inGameRoles['carry'] = inGameRoles.dragon


### PR DESCRIPTION
## Summary

Added an alias for the Ingame Roles of Wild Rift. Top is more used as Baron 

## How did you test this change?

N/A