### PR TITLE
feat: add Array.mapRange

### DIFF
--- a/lua/spec/array_spec.lua
+++ b/lua/spec/array_spec.lua
@@ -247,6 +247,14 @@ describe('array', function()
 		end)
 	end)
 
+	describe('mapRange', function()
+		it('check', function()
+			assert.are_same({'arg1', 'arg2', 'arg3'}, Array.mapRange(1, 3, function (index)
+				return 'arg' .. index
+			end))
+		end)
+	end)
+
 	describe('ForEach', function()
 		it('check', function()
 			local a = {}

--- a/lua/wikis/commons/Array.lua
+++ b/lua/wikis/commons/Array.lua
@@ -522,8 +522,8 @@ end
 ---@nodiscard
 function Array.mapRange(from, to, funct)
 	local elements = {}
-	for element = from, to do
-		table.insert(elements, funct(element))
+	for i = from, to do
+		table.insert(elements, funct(i))
 	end
 	return elements
 end

--- a/lua/wikis/commons/Array.lua
+++ b/lua/wikis/commons/Array.lua
@@ -511,6 +511,23 @@ function Array.range(from, to)
 	return elements
 end
 
+---Returns the array `{funct(from), funct(from + 1), funct(from + 2), ..., funct(to)}`.
+---
+---This is equivalent to `Array.map(Array.range(from, to), funct)`.
+---@generic T
+---@param from integer
+---@param to integer
+---@param funct fun(index: integer): T
+---@return T[]
+---@nodiscard
+function Array.mapRange(from, to, funct)
+	local elements = {}
+	for element = from, to do
+		table.insert(elements, funct(element))
+	end
+	return elements
+end
+
 ---Extracts keys from a given table into an array. An order can be supplied via an iterator.
 ---@generic K, V
 ---@param tbl {[K]: V}

--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -148,7 +148,7 @@ function MediaList._buildMultiKeyCondition(value, prefix, limit)
 		return
 	end
 	return ConditionTree(BooleanOperator.any):add(
-		Array.map(Array.range(1, limit), function (index)
+		Array.mapRange(1, limit, function (index)
 			return ConditionUtil.anyOf(ColumnName(prefix .. index), {value, value:gsub(' ', '_')})
 		end)
 	)

--- a/lua/wikis/commons/GetMatchGroupCopyPaste.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste.lua
@@ -44,7 +44,7 @@ function CopyPaste._generateID()
 		return string.char(60 + num)
 	end
 
-	local id = table.concat(Array.map(Array.range(1, 10), function()
+	local id = table.concat(Array.mapRange(1, 10, function()
 		return charFromNumber(math.random(62))
 	end))
 
@@ -190,7 +190,7 @@ function CopyPaste.matchlist(frame, args)
 	local namedMatchParams = Logic.readBool(Logic.nilOr(args.namedMatchParams, true))
 	local headersUpTop = Logic.readBool(args.headersUpTop)
 
-	local matchesCopyPaste = Array.map(Array.range(1, matches), function(matchIndex)
+	local matchesCopyPaste = Array.mapRange(1, matches, function(matchIndex)
 		if customHeader and headersUpTop then
 			display = display .. '\n|M' .. matchIndex .. 'header='
 		end

--- a/lua/wikis/commons/GetMatchGroupCopyPaste/Starcraft.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste/Starcraft.lua
@@ -66,10 +66,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
 		Logic.readBool(args.casters) and (INDENT .. '|caster1=|caster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof),function (mapIndex)
+		Array.mapRange(1, bestof ,function (mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '=' ..
 				WikiCopyPaste._getMapCode(mode, mapIndex, hasSubmatch, tonumber(args.submatch))
 		end),

--- a/lua/wikis/commons/GetMatchGroupCopyPaste/wiki/Base.lua
+++ b/lua/wikis/commons/GetMatchGroupCopyPaste/wiki/Base.lua
@@ -46,7 +46,7 @@ end
 ---@return string
 function WikiCopyPaste._getMaps(bestof)
 	local map = '{{Map|map=}}'
-	local lines = Array.map(Array.range(1, bestof), function(mapIndex)
+	local lines = Array.mapRange(1, bestof, function(mapIndex)
 		return INDENT .. '|map' .. mapIndex .. '=' .. map
 	end)
 
@@ -66,7 +66,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	return table.concat(Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return '\n' .. INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
 		'\n' .. INDENT .. '|finished=\n' .. INDENT .. '|date=\n' .. INDENT .. '}}'
@@ -109,7 +109,7 @@ end
 ---@param mapCount integer
 ---@return string
 function WikiCopyPaste.getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
+	local mapScores = table.concat(Array.mapRange(1, mapCount, function(idx)
 		return '|m' .. idx .. '={{MS||}}'
 	end))
 

--- a/lua/wikis/commons/Infobox/Extension/Achievements.lua
+++ b/lua/wikis/commons/Infobox/Extension/Achievements.lua
@@ -85,7 +85,7 @@ function Achievements._playerConditions(player, onlySolo, playerLimit)
 	end
 
 	local playerConditions = ConditionTree(BooleanOperator.any):add(
-		Array.map(Array.range(1, playerLimit), function(playerIndex)
+		Array.mapRange(1, playerLimit, function(playerIndex)
 			return ConditionUtil.anyOf(ColumnName('p' .. playerIndex, 'opponentplayers'), playerNames)
 		end)
 	)
@@ -207,7 +207,7 @@ function Achievements._getLpdbKeys(opponentType)
 		return {'opponenttemplate'}
 	end
 
-	return Array.map(Array.range(1, MAX_PARTY_SIZE), function(opponentIndex)
+	return Array.mapRange(1, MAX_PARTY_SIZE, function(opponentIndex)
 		return 'opponentplayers_p' .. opponentIndex .. 'team'
 	end)
 end

--- a/lua/wikis/commons/MatchGroup/Coordinates.lua
+++ b/lua/wikis/commons/MatchGroup/Coordinates.lua
@@ -319,7 +319,7 @@ function MatchGroupCoordinates.groupMatchIdsByField(bracket, fieldName)
 	local countFieldName = fieldName:gsub('Index$', 'Count')
 	local count = Table.getByPathOrNil(bracket.matches, {1, 'bracketData', 'coordinates', countFieldName}) or 0
 
-	local byField = Array.map(Array.range(1, count), function() return {} end)
+	local byField = Array.mapRange(1, count, function() return {} end)
 	for matchId in MatchGroupCoordinates.dfs(bracket) do
 		local coordinates = bracket.coordinatesByMatchId[matchId]
 		table.insert(byField[coordinates[fieldName]], matchId)
@@ -363,7 +363,7 @@ The third place match is not counted.
 function MatchGroupCoordinates.computeRawCounts(bracket)
 	local reverseRounds = Array.reverse(bracket.rounds)
 
-	local countsBySection = Array.map(Array.range(1, #bracket.sections), function(sectionIx) return 0 end)
+	local countsBySection = Array.mapRange(1, #bracket.sections, function(sectionIx) return 0 end)
 	local countsByReverseRound = {}
 	for _, round in ipairs(reverseRounds) do
 		for _, matchId in ipairs(round) do

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1629,7 +1629,7 @@ function MatchGroupInputUtil.parseSettings(match, opponentCount)
 	end)
 
 	-- Info per Placement
-	local placementInfo = Array.map(Array.range(1, opponentCount), function(index)
+	local placementInfo = Array.mapRange(1, opponentCount, function(index)
 		return {
 			placement = index,
 			killPoints = tonumber(match['p' .. index .. '_kill']) or tonumber(match.p_kill),

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -362,7 +362,7 @@ end
 ---@param maxNumberOfCharacters integer
 ---@return string[]
 function MatchSummary.buildCharacterList(data, prefix, maxNumberOfCharacters)
-	return Array.map(Array.range(1, maxNumberOfCharacters), function(index)
+	return Array.mapRange(1, maxNumberOfCharacters, function(index)
 		return data[prefix .. index]
 	end)
 end

--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -455,7 +455,7 @@ function Opponent.readOpponentArgs(args)
 		return {type = Opponent.solo, players = {player}, extradata = {}}
 
 	elseif partySize then
-		local players = Array.map(Array.range(1, partySize), function(playerIndex)
+		local players = Array.mapRange(1, partySize, function(playerIndex)
 			return Opponent.readPlayerArgs(args, playerIndex)
 		end)
 		return {type = args.type, players = players, extradata = {}}
@@ -606,7 +606,7 @@ function Opponent.fromLpdbStruct(storageStruct)
 	if partySize then
 		local players = storageStruct.opponentplayers
 		return {
-			players = Array.map(Array.range(1, partySize), FnUtil.curry(Opponent.playerFromLpdbStruct, players)),
+			players = Array.mapRange(1, partySize, FnUtil.curry(Opponent.playerFromLpdbStruct, players)),
 			type = storageStruct.opponenttype,
 			extradata = {},
 		}

--- a/lua/wikis/commons/OpponentDisplay/Starcraft.lua
+++ b/lua/wikis/commons/OpponentDisplay/Starcraft.lua
@@ -135,7 +135,7 @@ function StarcraftOpponentDisplay.BlockPlayers(props)
 	-- remaining case: opponent.isSpecialArchon
 	return HtmlWidgets.Div{
 		classes = {'starcraft-special-archon-block-opponent', 'block-players-wrapper'},
-		children = Array.map(Array.range(1, #opponent.players / 2), function (archonIx)
+		children = Array.mapRange(1, #opponent.players / 2, function (archonIx)
 			local primaryFaction = opponent.players[2 * archonIx - 1].faction
 			local secondaryFaction = opponent.players[2 * archonIx].faction
 			local primaryIcon = Faction.Icon{size = 'large', faction = primaryFaction}

--- a/lua/wikis/commons/PlayerTournamentAppearances.lua
+++ b/lua/wikis/commons/PlayerTournamentAppearances.lua
@@ -231,7 +231,7 @@ function Appearances:build()
 		children = WidgetUtil.collect(
 			self:_header(),
 			TableWidgets.TableBody{
-				children = Array.map(Array.range(1, limit), FnUtil.curry(Appearances._row, self))
+				children = Array.mapRange(1, limit, FnUtil.curry(Appearances._row, self))
 			}
 		),
 		footer = self:_buildQueryLink()

--- a/lua/wikis/commons/PortalStatistics.lua
+++ b/lua/wikis/commons/PortalStatistics.lua
@@ -125,7 +125,7 @@ function StatisticsPortal.topEarningsChart(args)
 	local config = StatisticsPortal._getChartConfig(args, params)
 	local topEarningsList = StatisticsPortal._getOpponentEarningsData(args, config)
 
-	local yearSeriesData = Array.map(Array.range(config.startYear, tonumber(args.year) or CURRENT_YEAR), function(year)
+	local yearSeriesData = Array.mapRange(config.startYear, tonumber(args.year) or CURRENT_YEAR, function(year)
 		return Array.map(Array.reverse(topEarningsList), function(teamData)
 			return teamData.earningsbyyear[year] or 0
 		end)
@@ -1283,7 +1283,7 @@ function StatisticsPortal._buildChartData(config, yearSeriesData, nonYearCategor
 	local yearList = {}
 	local chartData = {}
 	local seriesData = {}
-	local earningsTable = Array.map(Array.range(1, Table.size(nonYearCategories)), function() return 0 end)
+	local earningsTable = Array.mapRange(1, Table.size(nonYearCategories), function() return 0 end)
 
 	for yearIndex, yearValue in pairs(defaultYearTable) do
 		earningsTable = StatisticsPortal._addArrays({earningsTable, yearSeriesData[yearIndex]})
@@ -1292,7 +1292,7 @@ function StatisticsPortal._buildChartData(config, yearSeriesData, nonYearCategor
 			table.insert(yearList, yearText)
 			table.insert(seriesData, earningsTable)
 			prevYear = yearValue + 1
-			earningsTable = Array.map(Array.range(1, Table.size(nonYearCategories)), function() return 0 end)
+			earningsTable = Array.mapRange(1, Table.size(nonYearCategories), function() return 0 end)
 		end
 	end
 
@@ -1300,10 +1300,10 @@ function StatisticsPortal._buildChartData(config, yearSeriesData, nonYearCategor
 	local seriesNames = yearList
 
 	if transpose == true then
-		seriesData = Array.map(Array.range(1, Table.size(nonYearCategories)), function(index)
+		seriesData = Array.mapRange(1, Table.size(nonYearCategories), function(index)
 			return Array.map(seriesData, function(teamData)
-					return teamData[index] or 0
-				end)
+				return teamData[index] or 0
+			end)
 		end)
 		seriesNames, categoryNames = categoryNames, seriesNames
 	end

--- a/lua/wikis/commons/PrizePool/Import.lua
+++ b/lua/wikis/commons/PrizePool/Import.lua
@@ -221,7 +221,7 @@ function Import:_computeStagePlacementEntries(stage, options)
 		and math.min(maxPlacementCount, endingPlacement)
 		or maxPlacementCount
 
-	return Array.map(Array.range(startingPlacement, maxPlacementCount), function(placementIndex)
+	return Array.mapRange(startingPlacement, maxPlacementCount, function(placementIndex)
 		return Array.flatten(Array.map(groupPlacementEntries, function(placementEntries)
 			return placementEntries[placementIndex]
 		end))
@@ -482,7 +482,7 @@ function Import._findBracketFirstDropdownRounds(bracket)
 	local countsByRound = MatchGroupCoordinates.computeRawCounts(bracket)
 	local roundIndexes = Array.range(1, #bracket.rounds)
 
-	return Array.map(Array.range(2, #bracket.sections), function(sectionIndex)
+	return Array.mapRange(2, #bracket.sections, function(sectionIndex)
 		local firstRoundWithPositiveCount = Array.find(roundIndexes, function(roundIndex)
 			return countsByRound[roundIndex][sectionIndex] >= 0 end)
 

--- a/lua/wikis/commons/Standings.lua
+++ b/lua/wikis/commons/Standings.lua
@@ -231,7 +231,7 @@ function Standings.makeRounds(standings)
 	local roundCount = Array.maxBy(Array.map(standingsEntries, function(entry)
 		return tonumber(entry.roundindex) or 1 end), FnUtil.identity)
 
-	return Array.map(Array.range(1, roundCount or 1), function(roundIndex)
+	return Array.mapRange(1, roundCount or 1, function(roundIndex)
 		local roundEntries = Array.filter(standingsEntries, function(entry)
 			return tonumber(entry.roundindex) == roundIndex
 		end)

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -103,7 +103,7 @@ end
 function StandingsParseLpdb.newOpponent(opponentData, maxRounds)
 	return {
 		opponent = opponentData,
-		rounds = Array.map(Array.range(1, maxRounds), function()
+		rounds = Array.mapRange(1, maxRounds, function()
 			return {
 				scoreboard = {
 					match = {w = 0, d = 0, l = 0},

--- a/lua/wikis/commons/Standings/Table/Legacy/Ffa.lua
+++ b/lua/wikis/commons/Standings/Table/Legacy/Ffa.lua
@@ -104,7 +104,7 @@ function StandingTableLegacyFfa.templateEnd(frame)
 		return
 	end
 	Variables.varDefine('standings_legacy_start', nil)
-	local slots = Array.map(Array.range(1, cnt), function(index)
+	local slots = Array.mapRange(1, cnt, function(index)
 		local data = (Json.parseIfString(Variables.varDefault('standings_legacy_slot_' .. index)))
 		Variables.varDefine('standings_legacy_slot_' .. index, nil)
 		return data

--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -283,7 +283,7 @@ end
 ---@param count number
 ---@return standardPlayer[]
 function TeamParticipantsWikiParser.createTBDPlayers(count)
-	return Array.map(Array.range(1, count), function()
+	return Array.mapRange(1, count, function()
 		return TeamParticipantsWikiParser.parsePlayer{'TBD'}
 	end)
 end

--- a/lua/wikis/commons/Widget/EmptyPagePreview/Person.lua
+++ b/lua/wikis/commons/Widget/EmptyPagePreview/Person.lua
@@ -165,11 +165,11 @@ end
 function EmptyPersonPagePreview:_backfillInformationFromPlacements()
 	local personConditions = ConditionTree(BooleanOperator.any)
 		-- players
-		:add(Array.map(Array.range(1, DEFAULT_MAX_PLAYERS_PER_PLACEMENT), function(index)
+		:add(Array.mapRange(1, DEFAULT_MAX_PLAYERS_PER_PLACEMENT, function(index)
 			return ConditionNode(ColumnName('p' .. index, 'opponentplayers'), Comparator.eq, self.person)
 		end))
 		-- coaches (etc)
-		:add(Array.map(Array.range(1, 5), function(index)
+		:add(Array.mapRange(1, 5, function(index)
 			return ConditionNode(ColumnName('c' .. index, 'opponentplayers'), Comparator.eq, self.person)
 		end))
 

--- a/lua/wikis/commons/Widget/Infobox/Table.lua
+++ b/lua/wikis/commons/Widget/Infobox/Table.lua
@@ -42,7 +42,7 @@ function InfoboxTableWidget:render()
 	return Array.map(rows, function(row)
 		return Html.Div{
 			classes = self.props.classes,
-			children = Array.map(Array.range(1, options.columns), function(columnIndex)
+			children = Array.mapRange(1, options.columns, function(columnIndex)
 				local columnOptions = options.columnOptions[columnIndex] or {}
 				return Html.Div{
 					classes = columnOptions.classes or {},

--- a/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
+++ b/lua/wikis/commons/Widget/Match/Page/RoundsOverview.lua
@@ -66,7 +66,7 @@ local function MatchPageRoundsOverview(props)
 		return round['t' .. team .. 'side']
 	end
 
-	local teamContainers = Array.map(Array.range(1, numTeamContainers), function(container)
+	local teamContainers = Array.mapRange(1, numTeamContainers, function(container)
 		return Div{
 			classes = {'match-bm-rounds-overview-teams'},
 			children = {

--- a/lua/wikis/commons/Widget/Participants/Team/TeamMember.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/TeamMember.lua
@@ -77,7 +77,7 @@ function ParticipantsTeamMember:render()
 			},
 			trophies and trophies > 0 and Div{
 				classes = {'team-participant-card__member-trophies'},
-				children = trophies < 4 and Array.map(Array.range(1, trophies), function()
+				children = trophies < 4 and Array.mapRange(1, trophies, function()
 						return trophyIcon
 					end) or WidgetUtil.collect(
 						Div{

--- a/lua/wikis/commons/Widget/Patch/Calendar.lua
+++ b/lua/wikis/commons/Widget/Patch/Calendar.lua
@@ -54,8 +54,8 @@ function PatchCalendar:render()
 		tableCss = {['text-align'] = 'center', ['font-size'] = '110%'},
 		children = {
 			Tr{children = {Th{attributes = {colspan = 6}, children = {self.displayYear}}}},
-			Tr{children = Array.map(Array.range(1, 6), buildMonthCell)},
-			Tr{children = Array.map(Array.range(7, 12), buildMonthCell)},
+			Tr{children = Array.mapRange(1, 6, buildMonthCell)},
+			Tr{children = Array.mapRange(7, 12, buildMonthCell)},
 		}
 	}
 end

--- a/lua/wikis/commons/Widget/Standings/RoundSelector.lua
+++ b/lua/wikis/commons/Widget/Standings/RoundSelector.lua
@@ -30,7 +30,7 @@ local function RoundSelectorWidget(props)
 		return
 	end
 
-	local roundTitles = Array.map(Array.range(1, props.rounds), function (round)
+	local roundTitles = Array.mapRange(1, props.rounds, function (round)
 		if round == props.rounds then
 			return finalRoundTitle(props.hasEnded, props.rounds)
 		else


### PR DESCRIPTION
## Summary

We use `Array.range` as an argument to `Array.map` (i.e., `Array.map(Array.range(from, to), funct)`) quite frequently (207 uses). Each of these calls creates an intermediate `integer[]` that is used nowhere else.
To optimize such calls, this PR introduces `Array.mapRange` and updates existing uses in Commons to use `mapRange`.

## How did you test this change?

included test
