### PR TITLE
Revert "fix(TeamCard/Legacy): unwrap NoteBig wikitext in notes/inotes"

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -11,7 +11,6 @@ local Array = Lua.import('Module:Array')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
-local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Template = Lua.import('Module:Template')
 local Tournament = Lua.import('Module:Tournament')
@@ -33,19 +32,6 @@ local function normalizePosition(value)
 	if Logic.isEmpty(value) then return value end
 	---@cast value -nil
 	return PositionConvert[value:lower()] or value
-end
-
----@param value string
----@return string
-local function cleanNote(value)
-	value = String.trim(value)
-	-- Unwrap a single outer <div>...</div> (e.g. Template:NoteBig expands to one).
-	value = value:gsub('^<div>%s*', ''):gsub('%s*</div>$', '')
-	-- Strip wikitext definition-list markers (`:` at the start of a line). The new
-	-- notification widget provides its own styling, so we don't want MW to re-parse
-	-- these as <dl><dd>...</dd></dl>. Multi-note NoteBig expansions become <br>.
-	value = value:gsub('^:+%s*', ''):gsub('\n:+%s*', '<br>')
-	return String.trim(value)
 end
 
 ---@param entries table[]
@@ -435,10 +421,10 @@ function LegacyTeamCard.mapCard(tcArgs)
 
 	local notes = {}
 	if Logic.isNotEmpty(tcArgs.notes) then
-		table.insert(notes, {[1] = cleanNote(tcArgs.notes), highlighted = false})
+		table.insert(notes, {[1] = tcArgs.notes, highlighted = false})
 	end
 	if Logic.isNotEmpty(tcArgs.inotes) then
-		table.insert(notes, {[1] = cleanNote(tcArgs.inotes), highlighted = false})
+		table.insert(notes, {[1] = tcArgs.inotes, highlighted = false})
 	end
 	if #notes > 0 then card.notes = notes end
 


### PR DESCRIPTION
Reverts Liquipedia/Lua-Modules#7592

Resulted on some very weird behavior on some pages:
<img width="1845" height="971" alt="image" src="https://github.com/user-attachments/assets/a5318a10-4905-4a0d-9e5f-3aa2d175075d" />

https://liquipedia.net/pubgmobile/PUBG_Mobile_Global_Championship/2025