### PR TITLE
feat(TeamCard/Legacy): parse NoteBig wikitext in notes/inotes as json

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -398,6 +398,18 @@ function LegacyTeamCard.mapCoaches(tcArgs)
 	return coaches
 end
 
+---@param parsedNotes table
+---@return {[1]: string, highlighted: boolean}[]
+local function parseNotes(parsedNotes)
+	return Array.mapIndexes(function (index)
+		local note = parsedNotes['n' .. index]
+		if Logic.isEmpty(note) then
+			return
+		end
+		return {[1] = note, highlighted = false}
+	end)
+end
+
 ---@param tcArgs table
 ---@return table  -- TP opponent arg
 function LegacyTeamCard.mapCard(tcArgs)
@@ -425,13 +437,7 @@ function LegacyTeamCard.mapCard(tcArgs)
 	if Logic.isNotEmpty(tcArgs.notes) then
 		local parsedNotes = Json.parseIfTable(tcArgs.notes)
 		if parsedNotes then
-			for i = 1, math.huge do
-				local note = parsedNotes['n' .. i]
-				if Logic.isEmpty(note) then
-					break
-				end
-				table.insert(notes, {[1] = note, highlighted = false})
-			end
+			Array.extendWith(notes, parseNotes(parsedNotes))
 		else
 			table.insert(notes, {[1] = tcArgs.notes, highlighted = false})
 		end
@@ -439,13 +445,7 @@ function LegacyTeamCard.mapCard(tcArgs)
 	if Logic.isNotEmpty(tcArgs.inotes) then
 		local parsedNotes = Json.parseIfTable(tcArgs.inotes)
 		if parsedNotes then
-			for i = 1, math.huge do
-				local note = parsedNotes['n' .. i]
-				if Logic.isEmpty(note) then
-					break
-				end
-				table.insert(notes, {[1] = note, highlighted = false})
-			end
+			Array.extendWith(notes, parseNotes(parsedNotes))
 		else
 			table.insert(notes, {[1] = tcArgs.inotes, highlighted = false})
 		end

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Namespace = Lua.import('Module:Namespace')
 local PageVariableNamespace = Lua.import('Module:PageVariableNamespace')
@@ -422,10 +423,32 @@ function LegacyTeamCard.mapCard(tcArgs)
 
 	local notes = {}
 	if Logic.isNotEmpty(tcArgs.notes) then
-		table.insert(notes, {[1] = tcArgs.notes, highlighted = false})
+		local parsedNotes = Json.parseIfTable(tcArgs.notes)
+		if parsedNotes then
+			for i = 1, math.huge do
+				local note = parsedNotes['n' .. i]
+				if Logic.isEmpty(note) then
+					break
+				end
+				table.insert(notes, {[1] = note, highlighted = false})
+			end
+		else
+			table.insert(notes, {[1] = tcArgs.notes, highlighted = false})
+		end
 	end
 	if Logic.isNotEmpty(tcArgs.inotes) then
-		table.insert(notes, {[1] = tcArgs.inotes, highlighted = false})
+		local parsedNotes = Json.parseIfTable(tcArgs.inotes)
+		if parsedNotes then
+			for i = 1, math.huge do
+				local note = parsedNotes['n' .. i]
+				if Logic.isEmpty(note) then
+					break
+				end
+				table.insert(notes, {[1] = note, highlighted = false})
+			end
+		else
+			table.insert(notes, {[1] = tcArgs.inotes, highlighted = false})
+		end
 	end
 	if #notes > 0 then card.notes = notes end
 

--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -301,6 +301,7 @@ end
 ---@return string
 local function normalizeKey(value)
 	if Logic.isEmpty(value) then return '' end
+	---@cast value -nil
 	return value:gsub(' ', '_'):lower()
 end
 


### PR DESCRIPTION
## Summary

> could we change the note template wikicode to `{{#if:legacy team card page var defined|{{Json}}|keep old behavior}}` (this is pseudo-wikicode btw) instead?
> that way we could possibly avoid html stripping entirely
> 
> _Originally posted by @ElectricalBoy in https://github.com/Liquipedia/Lua-Modules/issues/7592#issuecomment-4611821747_

Template change: https://liquipedia.net/leagueoflegends/Special:Diff/1025829

## How did you test this change?

dev