### PR TITLE
feat(TeamCard): add smite Legacy/Custom for slot-index icons

### DIFF
--- a/lua/wikis/smite/InGameRoles.lua
+++ b/lua/wikis/smite/InGameRoles.lua
@@ -7,11 +7,14 @@
 
 ---@type table<string, RoleBaseData>
 local inGameRoles = {
-	['solo'] = {category = 'Solo players', display = 'Solo'},
-	['jungler'] = {category = 'Jungle players', display = 'Jungler'},
-	['support'] = {category = 'Support players', display = 'Support'},
-	['mid'] = {category = 'Mid Lane players', display = 'Mid'},
-	['carry'] = {category = 'Carry players', display = 'Carry'},
+	['solo'] = {category = 'Solo players', display = 'Solo', sortOrder = 1},
+	['jungler'] = {category = 'Jungle players', display = 'Jungler', sortOrder = 2},
+	['mid'] = {category = 'Mid Lane players', display = 'Mid', sortOrder = 3},
+	['support'] = {category = 'Support players', display = 'Support', sortOrder = 4},
+	['carry'] = {category = 'Carry players', display = 'Carry', sortOrder = 5},
 }
+
+inGameRoles['guardian'] = inGameRoles.support
+inGameRoles['hunter'] = inGameRoles.carry
 
 return inGameRoles

--- a/lua/wikis/smite/TeamCard/Legacy/Custom.lua
+++ b/lua/wikis/smite/TeamCard/Legacy/Custom.lua
@@ -1,0 +1,54 @@
+---
+-- @Liquipedia
+-- page=Module:TeamCard/Legacy/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
+local LegacyTeamCard = Lua.import('Module:TeamCard/Legacy')
+local Logic = Lua.import('Module:Logic')
+local Table = Lua.import('Module:Table')
+
+local DEFAULT_MAX_PLAYER_INDEX = 10
+local INGAME_ROLES_BY_ORDER = Table.map(InGameRoles, function(_, roleData)
+	return roleData.sortOrder, roleData.display
+end)
+
+local CustomLegacyTeamCard = {}
+
+-- Template entry point
+---@return Widget
+function CustomLegacyTeamCard.run()
+	return LegacyTeamCard.run(CustomLegacyTeamCard)
+end
+
+---@param card table
+---@return table
+function CustomLegacyTeamCard.preprocessCard(card)
+	Array.forEach(Array.range(1, DEFAULT_MAX_PLAYER_INDEX), function(index)
+		local key = 'p' .. index
+		card[key .. 'pos'] = Logic.emptyOr(
+			card[key .. 'pos'],
+			Table.extract(card, 'pos' .. index),
+			INGAME_ROLES_BY_ORDER[index]
+		)
+	end)
+
+	for tabIndex = 2, 3 do
+		Array.forEach(Array.range(1, DEFAULT_MAX_PLAYER_INDEX), function(index)
+			local key = 't' .. tabIndex .. 'p' .. index
+			card[key .. 'pos'] = Logic.emptyOr(
+				card[key .. 'pos'],
+				Table.extract(card, 't' .. tabIndex .. 'pos' .. index)
+			)
+		end)
+	end
+
+	return card
+end
+
+return CustomLegacyTeamCard


### PR DESCRIPTION
## Summary

- Add `Module:TeamCard/Legacy/Custom` for smite — defaults `pNpos` by slot index so role icons still render for pages that omit explicit positions (replaces old TC's `iconModule` slot-based defaulting)
- Add `sortOrder` (1–5) to smite `InGameRoles` for `solo`/`jungler`/`mid`/`support`/`carry`, plus `guardian`→`support` and `hunter`→`carry` aliases

## How did you test this change?

dev