### PR TITLE
feat: add option to query staff in player tournament information forms

### DIFF
--- a/lua/wikis/commons/PlayerTournamentAppearances.lua
+++ b/lua/wikis/commons/PlayerTournamentAppearances.lua
@@ -70,7 +70,11 @@ function Appearances:init(frame)
 		isFormQuery = Logic.readBool(args.query),
 		restrictToPlayersParticipatingIn = args.playerspage,
 		restrictToFirstPrizePool = Logic.readBool(args.restrictToFirstPrizePool),
+		player = Logic.nilOr(Logic.readBoolOrNil(args.player), true),
+		staff = Logic.readBool(args.staff),
 	}
+
+	assert(self.config.player or self.config.staff, 'Invalid config: at least one of |player= or |staff= must be true')
 
 	self.args = {
 		conditions = args.conditions,
@@ -168,7 +172,7 @@ function Appearances:_fetchPlayers(pageNames)
 			extradata.results[placement.parent] = {
 				placement = placement.placement,
 				date = placement.date,
-				team = placement.opponenttype == Opponent.team and placement.opponenttemplate or player.team
+				team = opponent.type == Opponent.team and opponent.template or player.team
 			}
 			local rawPlacement = Placement.raw(placement.placement)
 			extradata.placementSum = extradata.placementSum + (tonumber(rawPlacement.placement[1]) or 1000)

--- a/lua/wikis/commons/PlayerTournamentAppearances.lua
+++ b/lua/wikis/commons/PlayerTournamentAppearances.lua
@@ -152,7 +152,9 @@ function Appearances:_fetchPlayers(pageNames)
 		query = 'opponentplayers, opponenttype, opponentname, parent, date, placement, opponenttemplate',
 	}, function (placement)
 		local opponent = Opponent.fromLpdbStruct(placement)
-		Array.forEach(opponent.players, function (player)
+
+		---@param player standardPlayer
+		local function processPlayer(player)
 			if Opponent.playerIsTbd(player) then
 				return
 			end
@@ -176,7 +178,16 @@ function Appearances:_fetchPlayers(pageNames)
 			}
 			local rawPlacement = Placement.raw(placement.placement)
 			extradata.placementSum = extradata.placementSum + (tonumber(rawPlacement.placement[1]) or 1000)
-		end)
+		end
+
+		if self.config.player then
+			Array.forEach(opponent.players, processPlayer)
+		end
+		if self.config.staff then
+			Array.forEach(Array.mapIndexes(function (index)
+				return Logic.nilIfEmpty(Opponent.staffFromLpdbStruct(placement.opponentplayers, index))
+			end), processPlayer)
+		end
 	end)
 
 	local playersArray = Array.extractValues(players)

--- a/lua/wikis/commons/PlayerTournamentAppearances.lua
+++ b/lua/wikis/commons/PlayerTournamentAppearances.lua
@@ -32,7 +32,7 @@ local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 local ConditionUtil = Condition.Util
 
-local HtmlWidgets = Lua.import('Module:Widget/Html/All')
+local Html = Lua.import('Module:Widget/Html')
 local LinkWidget = Lua.import('Module:Widget/Basic/Link')
 local TableWidgets = Lua.import('Module:Widget/Table2/All')
 local TournamentTitle = Lua.import('Module:Widget/Tournament/Title')
@@ -245,7 +245,7 @@ function Appearances:_header()
 		TableWidgets.Row{children = WidgetUtil.collect(
 			TableWidgets.CellHeader{},
 			TableWidgets.CellHeader{children = 'Player'},
-			TableWidgets.CellHeader{children = HtmlWidgets.Abbr{children = 'TA.', title = 'Total appearances'}},
+			TableWidgets.CellHeader{children = Html.Abbr{children = 'TA.', title = 'Total appearances'}},
 			Array.map(self.tournaments, function (tournament)
 				return TableWidgets.CellHeader{children = TournamentTitle{
 					tournament = tournament, useShortName = true

--- a/lua/wikis/commons/TournamentPlayerInformation.lua
+++ b/lua/wikis/commons/TournamentPlayerInformation.lua
@@ -51,7 +51,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 
 ---@class TournamentPlayerInfo
 ---@operator call(table): TournamentPlayerInfo
----@field config {opponenttype: OpponentType?}
+---@field config {opponenttype: OpponentType?, player: boolean, staff: boolean}
 ---@field tournament StandardTournament
 ---@field protected data EnrichedStandardPlayer[]
 local TournamentPlayerInfo = Class.new(function(self, ...) self:init(...) end)
@@ -73,7 +73,9 @@ end
 ---@return self
 function TournamentPlayerInfo:init(args)
 	self.config = {
-		opponenttype = Logic.nilIfEmpty(args.opponenttype)
+		opponenttype = Logic.nilIfEmpty(args.opponenttype),
+		player = Logic.nilOr(Logic.readBoolOrNil(args.player), true),
+		staff = Logic.readBool(args.staff),
 	}
 
 	local pageName = Logic.emptyOr(args.pagename, args.page)
@@ -123,7 +125,10 @@ function TournamentPlayerInfo:_parseRecords(records)
 	local players = Array.flatMap(records, function (record)
 		local opponent = Opponent.fromLpdbStruct(record)
 
-		return Array.map(opponent.players, function (player, playerIndex)
+		---@param player standardPlayer
+		---@param playerIndex integer
+		---@return EnrichedStandardPlayer
+		local function processPlayer(player, playerIndex)
 			player.extradata = player.extradata or {}
 			player.extradata.index = playerIndex
 			if opponent.type == Opponent.team then
@@ -131,7 +136,21 @@ function TournamentPlayerInfo:_parseRecords(records)
 			end
 
 			return Table.merge(self:queryPlayerInfo(player), {fromOpponentType = opponent.type})
-		end)
+		end
+
+		---@type EnrichedStandardPlayer[]
+		local players = {}
+
+		if self.config.player then
+			Array.extendWith(players, Array.map(opponent.players, processPlayer))
+		end
+		if self.config.staff then
+			local staff = Array.mapIndexes(function (index)
+				return Logic.nilIfEmpty(Opponent.staffFromLpdbStruct(players, index))
+			end)
+			Array.extendWith(players, Array.map(staff, processPlayer))
+		end
+		return players
 	end)
 
 	-- sort by displayName if we have no team opponents

--- a/lua/wikis/commons/TournamentPlayerInformation.lua
+++ b/lua/wikis/commons/TournamentPlayerInformation.lua
@@ -33,8 +33,8 @@ local Box = Lua.import('Module:Widget/Basic/Box')
 local Button = Lua.import('Module:Widget/Basic/Button')
 local CopyToClipboard = Lua.import('Module:Widget/Basic/CopyToClipboard')
 local Dialog = Lua.import('Module:Widget/Basic/Dialog')
-local HtmlWidgets = Lua.import('Module:Widget/Html/All')
-local Div = HtmlWidgets.Div
+local Html = Lua.import('Module:Widget/Html')
+local Div = Html.Div
 local Image = Lua.import('Module:Widget/Image/Icon/Image')
 local Link = Lua.import('Module:Widget/Basic/Link')
 local TableWidgets = Lua.import('Module:Widget/Table2/All')
@@ -221,7 +221,7 @@ end
 
 ---@return Widget
 function TournamentPlayerInfo:build()
-	return HtmlWidgets.Fragment{children = WidgetUtil.collect(
+	return Html.Fragment{children = WidgetUtil.collect(
 		self:buildIntro(),
 		Box{
 			children = WidgetUtil.collect(
@@ -443,7 +443,7 @@ function TournamentPlayerInfo:buildPlayerRow(player)
 			},
 			children = WidgetUtil.collect(
 				Link{link = player.pageName, children = player.displayName},
-				Logic.isNotEmpty(player.name) and HtmlWidgets.Span{
+				Logic.isNotEmpty(player.name) and Html.Span{
 					css = {
 						display = 'block',
 						['font-size'] = 'small',
@@ -457,7 +457,7 @@ function TournamentPlayerInfo:buildPlayerRow(player)
 			trigger = Button{
 				children = {
 					'Show',
-					HtmlWidgets.Span{
+					Html.Span{
 						classes = {'mobile-hide'},
 						children = ' photo'
 					}

--- a/lua/wikis/commons/TournamentPlayerInformation.lua
+++ b/lua/wikis/commons/TournamentPlayerInformation.lua
@@ -66,11 +66,7 @@ function TournamentPlayerInfo.create(frame)
 		return 'No conditions set.'
 	end
 
-	return Html.Fragment{children = {
-		mw.text.jsonEncode(tournamentPlayerInfo.config),
-		mw.text.jsonEncode(tournamentPlayerInfo.data),
-		tournamentPlayerInfo:query():build()
-	}}
+	return tournamentPlayerInfo:query():build()
 end
 
 ---@param args table

--- a/lua/wikis/commons/TournamentPlayerInformation.lua
+++ b/lua/wikis/commons/TournamentPlayerInformation.lua
@@ -66,7 +66,11 @@ function TournamentPlayerInfo.create(frame)
 		return 'No conditions set.'
 	end
 
-	return tournamentPlayerInfo:query():build()
+	return Html.Fragment{children = {
+		mw.text.jsonEncode(tournamentPlayerInfo.config),
+		mw.text.jsonEncode(tournamentPlayerInfo.data),
+		tournamentPlayerInfo:query():build()
+	}}
 end
 
 ---@param args table
@@ -146,7 +150,7 @@ function TournamentPlayerInfo:_parseRecords(records)
 		end
 		if self.config.staff then
 			local staff = Array.mapIndexes(function (index)
-				return Logic.nilIfEmpty(Opponent.staffFromLpdbStruct(players, index))
+				return Logic.nilIfEmpty(Opponent.staffFromLpdbStruct(record.opponentplayers, index))
 			end)
 			Array.extendWith(players, Array.map(staff, processPlayer))
 		end

--- a/lua/wikis/commons/TournamentPlayerInformation.lua
+++ b/lua/wikis/commons/TournamentPlayerInformation.lua
@@ -169,6 +169,11 @@ function TournamentPlayerInfo:_parseRecords(records)
 		elseif a.team ~= b.team then
 			return a.team < b.team
 		end
+		local aType = (a.extradata or {}).type or 'player'
+		local bType = (a.extradata or {}).type or 'player'
+		if aType ~= bType then
+			return aType < bType
+		end
 		-- TODO: sort by role when it becomes available in queried placement data
 		return a.extradata.index < b.extradata.index
 	end)


### PR DESCRIPTION
## Summary

requested on discord: https://discord.com/channels/93055209017729024/268719633366777856/1513826720673828916

## How did you test this change?

- https://liquipedia.net/leagueoflegends/Special:RunQuery/Tournament_player_information/dev
- https://liquipedia.net/leagueoflegends/Special:RunQuery/Player_tournament_appearances/dev

use `dev=ElectricalBoy-pta-tpi-staff`