### PR TITLE
feat(TeamCard): track legacy cards rendered outside the columns wrapper

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -7,6 +7,7 @@
 
 local Lua = require('Module:Lua')
 
+local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
@@ -22,6 +23,7 @@ local HtmlWidgets = Lua.import('Module:Widget/Html/All')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local teamParticipantsVars = PageVariableNamespace('TeamParticipants')
+local legacyVars = PageVariableNamespace('LegacyTeamCard')
 
 local PositionConvert = Lua.requireIfExists('Module:PositionName/data', {loadData = true}) or {}
 
@@ -56,6 +58,28 @@ local function partitionStash(entries)
 		end
 	end)
 	return toggles, header, cards
+end
+
+-- Invoked by Template:TeamCard columns start. Opens the wrapper and stashes the header entry.
+---@param frame Frame
+---@return string
+function LegacyTeamCard.stashHeader(frame)
+	legacyVars:set('wrapperOpen', 'true')
+	local args = Arguments.getArgs(frame)
+	args.__source = 'header'
+	return Template.stashReturnValue(args, 'LegacyTeamCard')
+end
+
+-- Invoked by Template:TeamCard. Flags the page if no wrapper is open, then stashes the card entry.
+---@param frame Frame
+---@return string
+function LegacyTeamCard.stashCard(frame)
+	if not Logic.readBool(legacyVars:get('wrapperOpen')) then
+		mw.ext.TeamLiquidIntegration.add_category('Pages with unwrapped Legacy TeamCard')
+	end
+	local args = Arguments.getArgs(frame)
+	args.__source = 'card'
+	return Template.stashReturnValue(args, 'LegacyTeamCard')
 end
 
 ---@param dependency table<string, function>?
@@ -109,6 +133,7 @@ function LegacyTeamCard.run(dependency)
 		}
 	end
 
+	legacyVars:delete('wrapperOpen')
 	return HtmlWidgets.Fragment{children = WidgetUtil.collect(notesWidget, display)}
 end
 


### PR DESCRIPTION
## Summary

Bot runs missed some cases where teamcard were inside collapsibles. Now we need to catch those pages and fix them. Context:
https://discord.com/channels/321003439431745537/321641940879802368/1514058216764473394

- Add `LegacyTeamCard.stashCard` / `stashHeader` entry points: `columns start` sets a `wrapperOpen` page-var, each `{{TeamCard}}` checks it at invocation time, and `columns end`'s `run()` clears it.
- Cards invoked outside a `columns start`/`columns end` wrapper (which silently fail to render, since `run()` never flushes them) are now flagged with `[[Category:Pages with unwrapped Legacy TeamCard]]`.
- Detection happens at TeamCard-invocation time — the only point Lua executes for the no-`columns end` case, which a flush-time check cannot catch.

## Follow-up (required for this to take effect)

- On-wiki template edits per wiki: `Template:TeamCard` must invoke `module=TeamCard/Legacy|fn=stashCard` and `Template:TeamCard columns start` must invoke `fn=stashHeader`, replacing the generic `Template|stashArgs` calls.
- Run the touch script on pages that transclude `Template:TeamCard`, then bot-/manual-fix flagged pages.

## How did you test this change?

dev