### PR TITLE
fix: DateExt.parseIsoDate causes inconsistent timestamps

### DIFF
--- a/lua/spec/date_ext_spec.lua
+++ b/lua/spec/date_ext_spec.lua
@@ -68,12 +68,12 @@ describe('Date', function()
 
 	describe('parse iso date', function()
 		it('verify', function()
-			assert.are_same({year = 2023, month = 7, day = 24}, DateExt.parseIsoDate('2023-07-24'))
-			assert.are_same({year = 2023, month = 7, day = 24},
+			assert.are_same({year = 2023, month = 7, day = 24, hour = 0}, DateExt.parseIsoDate('2023-07-24'))
+			assert.are_same({year = 2023, month = 7, day = 24, hour = 0},
 				DateExt.parseIsoDate('2023-07-24asdkosdkmoasjoikmakmslkm'))
-			assert.are_same({year = 2023, month = 7, day = 1}, DateExt.parseIsoDate('2023-07'))
-			assert.are_same({year = 2023, month = 7, day = 1}, DateExt.parseIsoDate('2023-07sdfsdfdfs'))
-			assert.are_same({year = 2023, month = 1, day = 1}, DateExt.parseIsoDate('2023'))
+			assert.are_same({year = 2023, month = 7, day = 1, hour = 0}, DateExt.parseIsoDate('2023-07'))
+			assert.are_same({year = 2023, month = 7, day = 1, hour = 0}, DateExt.parseIsoDate('2023-07sdfsdfdfs'))
+			assert.are_same({year = 2023, month = 1, day = 1, hour = 0}, DateExt.parseIsoDate('2023'))
 			assert.is_nil(DateExt.parseIsoDate())
 		end)
 	end)

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -192,7 +192,16 @@ function DateExt.parseIsoDate(str)
 		day = 1
 	end
 	-- create simplified osdate
-	return {year = year, month = month, day = day}
+	return {
+		year = year,
+		month = month,
+		day = day,
+		--[[
+		Lua uses 12 as fallback of hour but we expect hour to be set to 0.
+		See https://github.com/Liquipedia/Lua-Modules/issues/7639
+		]]
+		hour = 0,
+	}
 end
 
 --- Converts a timezone offset (e.g. `+2:00`) to a UTC offset in seconds.

--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -46,7 +46,8 @@ local SECONDS_PER_DAY = 86400
 function DateExt.readTimestamp(dateInput)
 	if type(dateInput) == 'table' then
 		-- in this case we have osdate really being osdateparam
-		return tonumber(os.time(dateInput --[[@as osdateparam]]))
+		---@cast dateInput osdateparam
+		return os.time(dateInput)
 	end
 
 	if Logic.isEmpty(dateInput) then


### PR DESCRIPTION
## Summary

Fixes #7639

## How did you test this change?

logically trivial