### PR TITLE
fix: standings entries store final match W/D/L for every round

### DIFF
--- a/lua/spec/standings_parser_spec.lua
+++ b/lua/spec/standings_parser_spec.lua
@@ -186,9 +186,7 @@ describe('Standings Parser', function()
 
 		local alpha1 = findEntry(standingsTable.entries, 'Alpha', 1)
 		local alpha2 = findEntry(standingsTable.entries, 'Alpha', 2)
-		-- All rounds of an opponent share one cumulative match record;
-		-- earlier rounds therefore also show the final totals
-		assert.are_same({w = 1, d = 1, l = 1}, alpha1.match)
+		assert.are_same({w = 1, d = 0, l = 0}, alpha1.match)
 		assert.are_same({w = 1, d = 1, l = 1}, alpha2.match)
 	end)
 

--- a/lua/wikis/commons/Standings/Parser.lua
+++ b/lua/wikis/commons/Standings/Parser.lua
@@ -63,7 +63,7 @@ function StandingsParser.parse(rounds, opponents, bgs, title, matches, standings
 				standingsindex = standingsindex,
 				roundindex = round.roundNumber,
 				points = carryData.points,
-				match = carryData.match,
+				match = Table.copy(carryData.match),
 				matches = playedMatches or {},
 				extradata = {
 					pointschange = pointsFromRound,


### PR DESCRIPTION
## Summary

- `carryData.match` in `StandingsParser.parse` was a single shared table that every per-round entry stored by reference (`match = carryData.match`). This meant (a) every `standingsentry` row carried the **final** cumulative W/D/L regardless of `roundindex`, and (b) since placements are computed after all entries are built, match-based tiebreakers (`matchdiff` — the default Swiss tiebreaker — `matchwins`, `matchwinrate`, Buchholz) computed intermediate-round placements from end-of-tournament records.
- The fix snapshots the accumulator per round with `Table.copy(carryData.match)` at the point the entry is constructed. `carryData.match` itself continues to accumulate as before; only the stored snapshot per entry is now independent.
- **Reviewer note:** Final-round entries are unchanged (final cumulative = final cumulative), so `definitestatus` and final standings are untouched. Intermediate-round stored rows and mid-tournament placements decided by match-based tiebreakers will change on re-render — that is the fix. This PR is based on `standings-tests-ai` (PR #7647); the test that asserted the old shared-table behaviour is updated here.

## How did you test this change?

- Ran the full busted test suite (`605 successes / 0 failures / 0 errors / 0 pending`) against the updated code.
- Ran `luacheck` on both changed files with 0 warnings / 0 errors.
- Updated the test `accumulates match scoreboard across rounds` in `lua/spec/standings_parser_spec.lua`: round 1 entry now asserts `{w = 1, d = 0, l = 0}` (snapshot at end of round 1) and round 2 asserts `{w = 1, d = 1, l = 1}` (cumulative after round 2); the obsolete comment describing the shared-table behaviour was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)