### PR TITLE
perf: use lookup maps instead of linear opponent scans in standings widgets

### DIFF
--- a/lua/wikis/commons/Widget/Standings/Ffa.lua
+++ b/lua/wikis/commons/Widget/Standings/Ffa.lua
@@ -43,6 +43,14 @@ local function StandingsFfa(props)
 		function (round) return round.round end
 	) or {round = 0}).round
 
+	local entryByRound = Array.map(standings.rounds, function(round)
+		local byName = {}
+		Array.forEach(round.opponents, function(entry)
+			byName[Opponent.toName(entry.opponent)] = entry
+		end)
+		return byName
+	end)
+
 	local standingsTable = TableWidgets.Table{
 		classes = {'standings-ffa'},
 		columns = WidgetUtil.collect(
@@ -64,7 +72,7 @@ local function StandingsFfa(props)
 				if round.round > activeRounds then
 					return
 				end
-				return Helpers._createRoundBody(standings, round)
+				return Helpers._createRoundBody(standings, round, entryByRound)
 			end)
 		),
 		striped = false
@@ -146,9 +154,11 @@ end
 ---@private
 ---@param standings StandingsModel
 ---@param round StandingsRound
+---@param entryByRound table[]
 ---@return Renderable
-function Helpers._createRoundBody(standings, round)
+function Helpers._createRoundBody(standings, round, entryByRound)
 	return TableWidgets.TableBody{children = Array.map(round.opponents, function (slot)
+		local slotName = Opponent.toName(slot.opponent)
 		return TableWidgets.Row{
 			attributes = {
 				['data-position-status'] = slot.positionStatus,
@@ -180,12 +190,10 @@ function Helpers._createRoundBody(standings, round)
 						children = slot.tiebreakerValues[tiebreaker.id] and slot.tiebreakerValues[tiebreaker.id].display or ''
 					}
 				end),
-				Helpers._showRoundColumns(standings) and Array.map(standings.rounds, function (columnRound)
+				Helpers._showRoundColumns(standings) and Array.map(standings.rounds, function (columnRound, columnIndex)
 					local text
 					if columnRound.round <= round.round then
-						local opponent = Array.find(columnRound.opponents, function(columnSlot)
-							return Opponent.same(columnSlot.opponent, slot.opponent)
-						end)
+						local opponent = entryByRound[columnIndex][slotName]
 						if opponent then
 							local roundStatus = opponent.specialStatus
 							if roundStatus == '' then

--- a/lua/wikis/commons/Widget/Standings/Swiss.lua
+++ b/lua/wikis/commons/Widget/Standings/Swiss.lua
@@ -31,6 +31,14 @@ local function StandingsSwiss(props)
 
 	local lastRound = standings.rounds[#standings.rounds]
 
+	local entryByRound = Array.map(standings.rounds, function(round)
+		local byName = {}
+		Array.forEach(round.opponents, function(entry)
+			byName[Opponent.toName(entry.opponent)] = entry
+		end)
+		return byName
+	end)
+
 	return TableWidgets.Table{
 		classes = {'standings-swiss'},
 		title = Logic.nilIfEmpty(standings.title),
@@ -40,7 +48,7 @@ local function StandingsSwiss(props)
 			Helpers.headerRow(standings),
 			-- Rows
 			TableWidgets.TableBody{children = Array.map(lastRound.opponents, function(slot)
-				return Helpers.createRow(standings, slot)
+				return Helpers.createRow(standings, slot, entryByRound)
 			end)}
 		),
 		striped = false
@@ -94,8 +102,10 @@ end
 ---@private
 ---@param standings StandingsModel
 ---@param slot StandingsEntryModel
+---@param entryByRound table[]
 ---@return Renderable
-function Helpers.createRow(standings, slot)
+function Helpers.createRow(standings, slot, entryByRound)
+	local slotName = Opponent.toName(slot.opponent)
 	return TableWidgets.Row{
 		attributes = {['data-position-status'] = slot.positionStatus},
 		children = WidgetUtil.collect(
@@ -123,10 +133,8 @@ function Helpers.createRow(standings, slot)
 					children = slot.tiebreakerValues[tiebreaker.id] and slot.tiebreakerValues[tiebreaker.id].display or ''
 				}
 			end),
-			Array.map(standings.rounds, function(columnRound)
-				local entry = Array.find(columnRound.opponents, function(columnSlot)
-					return Opponent.same(columnSlot.opponent, slot.opponent)
-				end)
+			Array.map(standings.rounds, function(columnRound, columnIndex)
+				local entry = entryByRound[columnIndex][slotName]
 				if not entry then
 					return TableWidgets.Cell{}
 				end


### PR DESCRIPTION
## Summary

- The FFA widget previously used `Opponent.same` inside a per-cell nested loop to find an opponent's entry in each column round, producing O(R²·N²) `Opponent.same` calls per render. The Swiss widget had the same pattern at O(R·N²). `Opponent.same` is expensive: it can invoke uncached `mw.ext.TeamTemplate.raw` PHP callbacks for team opponents, or allocate and sort arrays for party opponents.
- Both widgets now build a `entryByRound` table once per standings render: an array (one entry per round) of `{ [Opponent.toName(entry.opponent)] = entry }` maps. `Opponent.toName` returns a stable identity string (no PHP calls, no allocation). The per-cell lookup becomes a plain O(1) table access, and `Opponent.toName(slot.opponent)` is hoisted out of each row's per-column closure so it is computed once per row rather than once per column.
- All rounds of one standings table share the same stored opponent records, so `toName` keys are consistent across rounds — no fallback needed for entry lookups.
- The `Array.indexOf(match.opponents, …)` call inside the Swiss per-cell body (which identifies the opposing player in a 2-opponent match) is deliberately left on `Opponent.same`: those opponents come from match2 records where renamed-team handling in `Opponent.same` matters, and it is only ever called on 2 opponents per match, so it is not a performance concern.
- Rendered output is byte-identical to the original; this is a pure performance change.

## How did you test this change?

- `busted --run=ci` (full suite): **605 successes / 0 failures / 0 errors** — including `spec/standings_model_spec.lua`, which renders both the FFA and Swiss widgets end-to-end and asserts row ordering and cell content.
- `luacheck` on both modified files: **0 warnings / 0 errors**.
- This branch is based on `standings-tests-ai` (PR #7647), which adds the widget render tests that lock the behavior being preserved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)