### PR TITLE
perf: constant-time match lookups in standings model

### DIFF
--- a/lua/wikis/commons/Standings.lua
+++ b/lua/wikis/commons/Standings.lua
@@ -175,9 +175,10 @@ function Standings.fetchMatches(standings)
 		return MatchGroupUtil.splitMatchId(matchid)
 	end))
 
+	local wantedMatchIds = Table.map(matchids, function(_, matchid) return matchid, true end)
 	local allMatchesFromBrackets = Array.flatMap(bracketIds, MatchGroupUtil.fetchMatches)
 	return Array.filter(allMatchesFromBrackets, function(match)
-		return Table.includes(matchids, match.matchId)
+		return wantedMatchIds[match.matchId]
 	end)
 end
 
@@ -193,10 +194,7 @@ function Standings.fetchMatch(entry)
 		return
 	end
 
-	local allMatchesFromBrackets = MatchGroupUtil.fetchMatches(bracketId)
-	return Array.filter(allMatchesFromBrackets, function(match)
-		return match.matchId == matchid
-	end)[1]
+	return MatchGroupUtil.fetchMatchGroup(bracketId).matchesById[matchid]
 end
 
 ---@param standings StandingsModel


### PR DESCRIPTION
## Summary

- `Standings.fetchMatches`: replaced the per-match linear `Table.includes` scan over `matchids` with a set (`wantedMatchIds` table built via `Table.map`), so each match lookup is O(1) instead of O(n). Result ordering (bracket order) is unchanged.
- `Standings.fetchMatch`: replaced `MatchGroupUtil.fetchMatches(bracketId)` + filter-all-then-pick-one with a direct `MatchGroupUtil.fetchMatchGroup(bracketId).matchesById[matchid]` lookup. `fetchMatchGroup` is already memoized, so this avoids re-filtering all bracket matches on every call. Existing nil-safety early returns are preserved.

Based on standings-tests-ai (#7647).

## How did you test this change?

- `busted --run=ci`: **605 successes / 0 failures / 0 errors / 0 pending**
- `luacheck lua/wikis/commons/Standings.lua`: **0 warnings / 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)