### PR TITLE
perf: index standings import opponents by name instead of linear search

### DIFF
--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -54,6 +54,8 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 
 	---@type StandingTableOpponentData[]
 	local opponents = {}
+	---@type table<string, StandingTableOpponentData>
+	local opponentsByName = {}
 	Lpdb.executeMassQuery(
 		'match2',
 		{
@@ -62,7 +64,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper)
 		function(match2)
 			local roundNumbers = matchIdToRound[match2.match2id]
 			Array.forEach(roundNumbers, function(roundNumber)
-				StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds)
+				StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, opponentsByName, scoreMapper, #rounds)
 			end)
 		end
 	)
@@ -116,18 +118,28 @@ end
 ---@param roundNumber integer
 ---@param match match2
 ---@param opponents StandingTableOpponentData[]
+---@param opponentsByName table<string, StandingTableOpponentData>
 ---@param scoreMapper fun(opponent: standardOpponent): number?
 ---@param maxRounds integer
-function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMapper, maxRounds)
+function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, opponentsByName, scoreMapper, maxRounds)
 	local match2 = MatchGroupUtil.matchFromRecord(match)
 	Array.forEach(match2.opponents, function(opponent)
 		---Find matching opponent
-		local standingsOpponentData = Array.find(opponents, function(opponentData)
-			return Opponent.same(opponentData.opponent, opponent)
-		end)
+		local key = Opponent.toName(opponent)
+		local standingsOpponentData = opponentsByName[key]
+		if not standingsOpponentData and opponent.type == Opponent.team then
+			-- renamed teams have differing names but compare equal via historicaltemplate
+			standingsOpponentData = Array.find(opponents, function(opponentData)
+				return Opponent.same(opponentData.opponent, opponent)
+			end)
+			if standingsOpponentData then
+				opponentsByName[key] = standingsOpponentData
+			end
+		end
 		if not standingsOpponentData then
 			standingsOpponentData = StandingsParseLpdb.newOpponent(opponent, maxRounds)
 			table.insert(opponents, standingsOpponentData)
+			opponentsByName[key] = standingsOpponentData
 		end
 		assert(standingsOpponentData.rounds[roundNumber], 'Round number out of bounds')
 


### PR DESCRIPTION
## Summary

- Per-match-opponent linear `Opponent.same` scan replaced by an `Opponent.toName`-keyed map, reducing complexity from O(matches × opponents) to O(matches).
- Team opponents get a one-time `Opponent.same` fallback scan to handle renamed teams (which differ by name but compare equal via `historicaltemplate`); on a hit the new key is aliased into the map so the cost is paid at most once per renamed team.
- TBD opponents continue to collapse onto a single entry (same behavior as before — they resolve to the same `Opponent.toName` key and are filtered out by `Opponent.isTbd` at the end).

## How did you test this change?

- `busted --run=ci`: 605 successes / 0 failures / 0 errors — includes `spec/standings_import_spec.lua` (7 cases covering dedupe across rounds, TBD dropping, score mappers).
- `luacheck lua/wikis/commons/Standings/Parse/Lpdb.lua`: 0 warnings / 0 errors.
- Based on standings-tests-ai (PR #7647), whose import spec covers the relevant behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)