### PR TITLE
perf: render standings directly from the model on the producing page

### DIFF
--- a/lua/spec/standings_model_spec.lua
+++ b/lua/spec/standings_model_spec.lua
@@ -120,6 +120,32 @@ describe('Standings model round trip', function()
 		GoldenTest('standings_ffa', html)
 	end)
 
+	it('direct-path render matches var-path render', function()
+		local StandingsDisplay = require('Module:Widget/Standings')
+
+		local rounds = {
+			{roundNumber = 1, started = true, finished = true, title = 'Day 1'},
+			{roundNumber = 2, started = true, finished = true, title = 'Day 2'},
+		}
+		local opponents = {
+			makeOpponent('Alpha', {3, 0}),
+			makeOpponent('Bravo', {1, 4}),
+			makeOpponent('Charlie', {0, 1}),
+		}
+		local standingsTable = StandingsParser.parse(
+			rounds, opponents, {[1] = 'up', [3] = 'down'}, 'Dir Standings', {}, 'ffa', {'full.points'})
+
+		-- Direct path: use the returned record/entries from StandingsStorage.run
+		local stored = StandingsStorage.run(standingsTable, {saveVars = true})
+		local directModel = Standings.standingsFromRecord(stored.record, stored.entries)
+		local htmlDirect = tostring(StandingsDisplay{standings = directModel})
+
+		-- Var path: read back from page variables (the same wiki-var write)
+		local htmlVar = tostring(StandingsDisplay{pageName = 'FakePage', standingsIndex = standingsTable.standingsindex})
+
+		assert.are_equal(htmlDirect, htmlVar)
+	end)
+
 	it('renders the swiss standings widget from the model', function()
 		local SwissStandings = require('Module:Widget/Standings/Swiss')
 

--- a/lua/wikis/commons/Standings/Storage.lua
+++ b/lua/wikis/commons/Standings/Storage.lua
@@ -69,11 +69,13 @@ function StandingsStorage.run(data, options)
 		return StandingsStorage.entry(entry, data.standingsindex)
 	end)
 
+	local storageTable = StandingsStorage.table(data)
+
 	if StandingsStorage.shouldStoreLpdb() then
-		StandingsStorage.saveLpdb(StandingsStorage.table(data), entries)
+		StandingsStorage.saveLpdb(storageTable, entries)
 	end
 	if options and options.saveVars then
-		StandingsStorage.saveVars(StandingsStorage.table(data), entries)
+		StandingsStorage.saveVars(storageTable, entries)
 	end
 end
 

--- a/lua/wikis/commons/Standings/Storage.lua
+++ b/lua/wikis/commons/Standings/Storage.lua
@@ -77,6 +77,14 @@ function StandingsStorage.run(data, options)
 	if options and options.saveVars then
 		StandingsStorage.saveVars(storageTable, entries)
 	end
+
+	-- Return the record in model-ready form (matches as a table, not a JSON string)
+	-- so callers on the producing page can skip the var round-trip.
+	local directRecord = Table.merge(storageTable, {
+		pagename = mw.title.getCurrentTitle().text,
+		matches = data.matches or {},
+	})
+	return {record = directRecord, entries = entries}
 end
 
 ---@param data table

--- a/lua/wikis/commons/Standings/Table.lua
+++ b/lua/wikis/commons/Standings/Table.lua
@@ -18,6 +18,7 @@ local StandingsParseLpdb = Lua.import('Module:Standings/Parse/Lpdb')
 local StandingsParser = Lua.import('Module:Standings/Parser')
 local StandingsStorage = Lua.import('Module:Standings/Storage')
 
+local Standings = Lua.import('Module:Standings')
 local StandingsDisplay = Lua.import('Module:Widget/Standings')
 
 local Opponent = Lua.import('Module:Opponent/Custom')
@@ -69,8 +70,9 @@ function StandingsTable.fromTemplate(frame)
 		standingsTable.extradata.placemapping = Logic.wrapTryOrLog(StandingsParseWiki.parsePlaceMapping)(args, opponents)
 	end
 
-	StandingsStorage.run(standingsTable, {saveVars = true})
-	return StandingsDisplay{pageName = mw.title.getCurrentTitle().text, standingsIndex = standingsTable.standingsindex}
+	local stored = StandingsStorage.run(standingsTable, {saveVars = true})
+	local model = Standings.standingsFromRecord(stored.record, stored.entries)
+	return StandingsDisplay{standings = model}
 end
 
 ---@param manualOpponents StandingTableOpponentData[]

--- a/lua/wikis/commons/Widget/Standings.lua
+++ b/lua/wikis/commons/Widget/Standings.lua
@@ -15,10 +15,15 @@ local SwissStandings = Lua.import('Module:Widget/Standings/Swiss')
 local Standings = Lua.import('Module:Standings')
 local StringUtils = Lua.import('Module:StringUtils')
 
----@param props {pageName: string, standingsIndex: integer?}
+---@param props {pageName: string?, standingsIndex: integer?, standings: StandingsModel?}
 ---@return VNode?
 local function StandingsWidget(props)
-	local standings = Standings.getStandingsTable(props.pageName, props.standingsIndex)
+	local standings
+	if props.standings then
+		standings = props.standings
+	else
+		standings = Standings.getStandingsTable(props.pageName, props.standingsIndex)
+	end
 	if not standings then
 		return
 	end


### PR DESCRIPTION
## Summary

- `StandingsStorage.run` now returns `{record, entries}` where `record` is a model-ready shallow copy of the storage record with `matches` restored as a Lua table (not a JSON string), and `pagename` set to the current page title
- `StandingsTable.fromTemplate` captures the return value and calls `Standings.standingsFromRecord(stored.record, stored.entries)` to build the model directly, then renders `StandingsDisplay{standings = model}` — eliminating the full stringify+parse round-trip through the wiki variable on the producing page
- `Widget/Standings` accepts an alternative `standings` prop (a prebuilt `StandingsModel`); when present it skips `Standings.getStandingsTable` entirely; the existing `pageName`/`standingsIndex` path is untouched
- The wiki-variable write (`saveVars`) is unchanged, so cross-template consumers (and later `{{Standings}}` transclusions on the same page) continue to work via the var path
- A new spec case `'direct-path render matches var-path render'` builds a standings table, renders it both via the returned model and via the page-variable read, and asserts the two HTML strings are identical

## How did you test this change?

- `busted --run=ci`: **606 successes / 0 failures / 0 errors** (605 pre-existing + 1 new equality spec)
- `luacheck` on all modified files: **0 warnings / 0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)