### PR TITLE
feat(prizepool): update weight calculation in overwatch

### DIFF
--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -21,7 +21,7 @@ local CustomLpdbInjector = Class.new(LpdbInjector)
 
 local CustomPrizePool = {}
 
-local TIER_VALUE = {10000, 5000, 2}
+local TIER_VALUE = {8, 4, 2}
 local TYPE_MODIFIER = {Online = 0.65}
 local TIER_TYPE_MODIFIER = {Showmatch = 0.1,  Misc = 0.25, Qualifier = 0.001, Monthly = 0.4, Weekly = 0.1}
 
@@ -77,7 +77,7 @@ function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType
 	end
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
-	local prizeFactor = (1000000 + prizeMoney) / 1000000
+	local prizeFactor = (100000 + prizeMoney) / 100000
 	local tierTypeFactor = TIER_TYPE_MODIFIER[tierType] or 1
 	local highlightedFactor = isHighlighted and 2 or 1
 	local typeFactor = TYPE_MODIFIER[tournamentType] or 1

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -71,7 +71,8 @@ end
 ---@param tierType string?
 ---@param isHighlighted boolean
 ---@return number
-function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType, tierType, isHighlighted)	if Logic.isEmpty(tier) then
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType, tierType, isHighlighted)	
+	if Logic.isEmpty(tier) then
 		return 0
 	end
 

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -9,12 +9,12 @@ local Lua = require('Module:Lua')
 
 local Arguments = Lua.import('Module:Arguments')
 local Class = Lua.import('Module:Class')
+local HighlightConditions = Lua.import('Module:HighlightConditions')
 local Logic = Lua.import('Module:Logic')
 local Variables = Lua.import('Module:Variables')
-local HighlightConditions = Lua.import('Module:HighlightConditions')
 
 local PrizePool = Lua.import('Module:PrizePool')
-local Opponent = Lua.import('Module:Opponent/Custom')
+local Opponent = Lua.import('Module:Opponent')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)
@@ -56,6 +56,8 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
 	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
+	Variables.varDefine('enddate_'.. lpdbData.participant .. '_date', lpdbData.date)
+	Variables.varDefine('status'.. lpdbData.participant .. '_date', lpdbData.date)
 
 	if Opponent.isTbd(opponent.opponentData) then
 		Variables.varDefine('minimum_secured', lpdbData.extradata.prizepoints)
@@ -71,7 +73,7 @@ end
 ---@param tierType string?
 ---@param isHighlighted boolean
 ---@return number
-function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType, tierType, isHighlighted)	
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType, tierType, isHighlighted)
 	if Logic.isEmpty(tier) then
 		return 0
 	end

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -14,7 +14,7 @@ local Logic = Lua.import('Module:Logic')
 local Variables = Lua.import('Module:Variables')
 
 local PrizePool = Lua.import('Module:PrizePool')
-local Opponent = Lua.import('Module:Opponent')
+local Opponent = Lua.import('Module:Opponent/Custom')
 
 local LpdbInjector = Lua.import('Module:Lpdb/Injector')
 local CustomLpdbInjector = Class.new(LpdbInjector)
@@ -56,8 +56,6 @@ function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
 
 	Variables.varDefine(participantLower .. '_prizepoints', lpdbData.extradata.prizepoints)
 	Variables.varDefine(participantLower .. '_prizepoints2', lpdbData.extradata.prizepoints2)
-	Variables.varDefine('enddate_'.. lpdbData.participant .. '_date', lpdbData.date)
-	Variables.varDefine('status'.. lpdbData.participant .. '_date', lpdbData.date)
 
 	if Opponent.isTbd(opponent.opponentData) then
 		Variables.varDefine('minimum_secured', lpdbData.extradata.prizepoints)

--- a/lua/wikis/overwatch/PrizePool/Custom.lua
+++ b/lua/wikis/overwatch/PrizePool/Custom.lua
@@ -11,6 +11,7 @@ local Arguments = Lua.import('Module:Arguments')
 local Class = Lua.import('Module:Class')
 local Logic = Lua.import('Module:Logic')
 local Variables = Lua.import('Module:Variables')
+local HighlightConditions = Lua.import('Module:HighlightConditions')
 
 local PrizePool = Lua.import('Module:PrizePool')
 local Opponent = Lua.import('Module:Opponent/Custom')
@@ -22,7 +23,7 @@ local CustomPrizePool = {}
 
 local TIER_VALUE = {10000, 5000, 2}
 local TYPE_MODIFIER = {Online = 0.65}
-local TIER_TYPE_MODIFIER = {Qualifier = 0.001}
+local TIER_TYPE_MODIFIER = {Showmatch = 0.1,  Misc = 0.25, Qualifier = 0.001, Monthly = 0.4, Weekly = 0.1}
 
 -- Template entry point
 ---@param frame Frame
@@ -41,12 +42,14 @@ end
 ---@param opponent BasePlacementOpponent
 ---@return placement
 function CustomLpdbInjector:adjust(lpdbData, placement, opponent)
+	lpdbData.publishertier = Variables.varDefault('tournament_publishertier', '')
 	lpdbData.weight = CustomPrizePool.calculateWeight(
 		lpdbData.prizemoney,
 		Variables.varDefault('tournament_liquipediatier'),
 		placement.placeStart,
 		Variables.varDefault('tournament_type'),
-		Variables.varDefault('tournament_liquipediatiertype')
+		Variables.varDefault('tournament_liquipediatiertype'),
+		HighlightConditions.tournament(lpdbData)
 	)
 
 	local participantLower = mw.ustring.lower(lpdbData.participant)
@@ -64,17 +67,21 @@ end
 ---@param prizeMoney number
 ---@param tier string?
 ---@param place integer
----@param type string?
+---@param tournamentType string?
 ---@param tierType string?
----@return integer
-function CustomPrizePool.calculateWeight(prizeMoney, tier, place, type, tierType)
-	if Logic.isEmpty(tier) then
+---@param isHighlighted boolean
+---@return number
+function CustomPrizePool.calculateWeight(prizeMoney, tier, place, tournamentType, tierType, isHighlighted)	if Logic.isEmpty(tier) then
 		return 0
 	end
 
 	local tierValue = TIER_VALUE[tier] or TIER_VALUE[tonumber(tier) or ''] or 1
+	local prizeFactor = (1000000 + prizeMoney) / 1000000
+	local tierTypeFactor = TIER_TYPE_MODIFIER[tierType] or 1
+	local highlightedFactor = isHighlighted and 2 or 1
+	local typeFactor = TYPE_MODIFIER[tournamentType] or 1
 
-	return tierValue * math.max(prizeMoney, 1) * (TYPE_MODIFIER[type] or 1) * (TIER_TYPE_MODIFIER[tierType] or 1) / place
+	return prizeFactor * tierValue * tierTypeFactor * highlightedFactor * typeFactor / place
 end
 
 return CustomPrizePool


### PR DESCRIPTION
Similar reasons as https://github.com/Liquipedia/Lua-Modules/pull/7187
Blizzard's prize pools have decreased dramatically since the end of the Overwatch League, hence recent important tournaments don't show up even if players are participating in tier 1 competition (e.g. [Proper](https://liquipedia.net/overwatch/Proper) regular seasons achievements in 2024-2025 barely show up).