### PR TITLE
feat(match2): Disable collapsible for match information in ffa match summary

### DIFF
--- a/lua/wikis/commons/Widget/Match/Summary/Ffa/MatchInformation.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/Ffa/MatchInformation.lua
@@ -34,8 +34,6 @@ function MatchSummaryFfaMatchInformation:render()
 	)
 	if #items == 0 then return end
 	return ContentItemContainer{
-		collapsible = #items > 1,
-		collapsed = #items > 1,
 		contentClass = 'panel-content__game-schedule',
 		title = 'Match Information',
 		items = items


### PR DESCRIPTION
## Summary

PUBGM editors always hated how using both `|mvp=` and `|comment=` at the same time would hide those important info under a collapsible by default. I share the same view and personally think removing that collapsible would benefit all other wikis using ffa brackets.

## How did you test this change?

`|dev=tcoi` at https://liquipedia.net/pubgmobile/PUBG_Mobile_World_Cup/2025#Grand_Finals

Before:
<img width="792" height="261" alt="image" src="https://github.com/user-attachments/assets/22f37e5d-a792-425f-8d22-b1ce672f784b" />
After:
<img width="795" height="285" alt="image" src="https://github.com/user-attachments/assets/3daa9647-b5be-46c2-871d-99c58d4be663" />

