### PR TITLE
feat(TC Legacy): catch some bad inputs in the wrapper

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -446,6 +446,11 @@ function LegacyTeamCard.mapCoaches(tcArgs)
 		elseif tabType == 'former' then sourceGroup = 'fc'
 		else sourceGroup = nil end
 
+		if tcArgs[tab .. 'c'] then
+			mw.ext.TeamLiquidIntegration.add_category('Pages with malformed Legacy TeamCard coach input')
+			tcArgs[tab .. 'c1'] = tcArgs[tab .. 'c']
+		end
+
 		Array.forEach(indicesPresent(tcArgs, tab .. 'c', MAX_COACH_INDEX), function(i)
 			table.insert(coaches, LegacyTeamCard.mapCoach(tcArgs, tab .. 'c' .. i, sourceGroup))
 		end)


### PR DESCRIPTION
## Summary
reported: https://discord.com/channels/93055209017729024/372075546231832576/1516025940872794232

basically some bad old input causing issues
to catch that add a workaround that also sets a category so those kinds of pages can be found

## How did you test this change?
dev