### PR TITLE
feat(match2): fix MapVeto in brawlstars

### DIFF
--- a/lua/wikis/brawlstars/MatchSummary.lua
+++ b/lua/wikis/brawlstars/MatchSummary.lua
@@ -39,7 +39,7 @@ function CustomMatchSummary.createBody(match)
 	return WidgetUtil.collect(
 		Array.map(match.games, CustomMatchSummary._createMapRow),
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {game = match.game})),
+		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {emptyMapDisplay = NONE})),
 		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date}
 	)
 end

--- a/lua/wikis/brawlstars/MatchSummary.lua
+++ b/lua/wikis/brawlstars/MatchSummary.lua
@@ -39,7 +39,7 @@ function CustomMatchSummary.createBody(match)
 	return WidgetUtil.collect(
 		Array.map(match.games, CustomMatchSummary._createMapRow),
 		MatchSummaryWidgets.Mvp(match.extradata.mvp),
-		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto, {emptyMapDisplay = NONE})),
+		MatchSummaryWidgets.MapVeto(MatchSummary.preProcessMapVeto(match.extradata.mapveto)),
 		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date}
 	)
 end


### PR DESCRIPTION
## Summary
We rarely use MapVeto, but now official tournament start to use it and we notice that Template:MapVeto show maps with wierd links
<img width="385" height="624" alt="image" src="https://github.com/user-attachments/assets/dce5707e-6acb-4c5d-84d6-2a804023debe" />

## How did you test this change?

dev
https://liquipedia.net/brawlstars/Brawl_Stars_Championship/2026/Season_4/EMEA/Monthly_Finals#Results
