### PR TITLE
fix(infobox): underscores used instead of spaces in patch display name

### DIFF
--- a/lua/wikis/starcraft2/Infobox/League/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/League/Custom.lua
@@ -102,7 +102,7 @@ end
 function CustomLeague:_computePatch(args)
 	local prefixPatch = function(patch)
 		if not patch then return end
-		return 'Patch ' .. patch:gsub(' ', '_')
+		return 'Patch ' .. patch:gsub('_', ' ')
 	end
 	self.data.patch = prefixPatch(args.patch)
 	self.data.endPatch = prefixPatch(args.epatch)


### PR DESCRIPTION
## Summary

The current code replaces spaces with underscores in "Patch" display names. With this change, it is the other way around.

## How did you test this change?

Live edit on the SC2 wiki: https://liquipedia.net/starcraft2/index.php?title=Module:Infobox/League/Custom&diff=prev&oldid=2671831