### PR TITLE
fix(infobox): Adding a parameter to remove the unintentional <li> tag usage.

### DIFF
--- a/lua/wikis/dota2/Infobox/Cosmetic/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Cosmetic/Custom.lua
@@ -65,7 +65,7 @@ function CustomInjector:parse(id, widgets)
 		Array.appendWith(widgets,
 			Cell{
 				options = {columns = args.hero and 3 or 10, suppressColon = true},
-				name = args.hero and Template.expandTemplate(mw.getCurrentFrame(), 'Hero entry', {args.hero}) or ' ',
+				name = args.hero and Template.expandTemplate(mw.getCurrentFrame(), 'Hero entry', {args.hero, 'x'}) or ' ',
 				children = {
 					'<b>Rarity:</b> ' .. Template.safeExpand(mw.getCurrentFrame(), 'Raritylink', {args.rarity}),
 					args.slot and ('<b>Slot:</b> ' .. slotText) or nil,


### PR DESCRIPTION
## Summary
This should tell the "Hero entry" template not to use the hardcoded `<li>` tag in the inclusions.

As of this PR creation, the "Hero entry" template uses the `<li>` tag as intended (1st pic). Alas, it being hardcoded created the problem where all inclusions had the `<li>` dot attached to it, including the "Infobox cosmetic" where it wasn't needed (2nd pic).

<img width="411" height="331" alt="image" src="https://github.com/user-attachments/assets/cd1a80a5-1977-4c8e-bdb7-89f54f50a5d1" />

<img width="323" height="551" alt="image" src="https://github.com/user-attachments/assets/38a6e2b1-c2a0-4881-9fd3-a99fdffdf46b" />

I've appended the template code so it would only add the tag if the second unnamed parameter is empty.
This PR change will add the dummy 'x' string to the function that calls for the template as that second parameter.

## How did you test this change?

This change was successfully implemented on /dota2gameru.
https://liquipedia.net/dota2gameru/Модуль:Infobox/Cosmetic/Custom
https://liquipedia.net/dota2gameru/Шаблон:Hero_entry