### PR TITLE
fix(opponent): apply container type only when dynamic style is used

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -1209,26 +1209,29 @@ div.brkts-popup-body-element-thumbs {
 	> .name {
 		flex: 1 1;
 		min-width: 0;
-		container: block-team-name / inline-size;
 
-		> .team-name-dynamic {
-			content: none;
+		&:has( > .team-name-dynamic ) {
+			container: block-team-name / inline-size;
 
-			@container block-team-name ( min-width: 15px ) and ( max-width: 109px ) {
-				&::before {
-					content: attr( data-team-shortname );
+			> .team-name-dynamic {
+				content: none;
+
+				@container block-team-name ( min-width: 15px ) and ( max-width: 109px ) {
+					&::before {
+						content: attr( data-team-shortname );
+					}
 				}
-			}
 
-			@container block-team-name ( min-width: 110px ) and ( max-width: 179px ) {
-				&::before {
-					content: attr( data-team-bracketname );
+				@container block-team-name ( min-width: 110px ) and ( max-width: 179px ) {
+					&::before {
+						content: attr( data-team-bracketname );
+					}
 				}
-			}
 
-			@container block-team-name ( min-width: 180px ) {
-				&::before {
-					content: attr( data-team-name );
+				@container block-team-name ( min-width: 180px ) {
+					&::before {
+						content: attr( data-team-name );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1516345484963348611

## How did you test this change?

browser dev tools