### PR TITLE
fix(match2): match summaries with bracket reset overflow popup height

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -543,6 +543,14 @@
 		justify-content: flex-start;
 		flex-wrap: unset;
 		gap: 0.5rem;
+
+		.toggle-area & {
+			max-height: 55vh; // 10vh for the switcher (compared to height in .brkts-popup)
+
+			@media ( max-width: 768px ) {
+				max-height: calc( 100dvh - ( 2.75rem + 4.1875rem + 4rem ) ); // 4 rem for the switcher (compared to .brkts-popup.brkts-match-info-popup)
+			}
+		}
 	}
 
 	.theme--light & {

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -544,6 +544,10 @@
 		flex-wrap: unset;
 		gap: 0.5rem;
 
+		.theme--dark & {
+			color-scheme: dark;
+		}
+
 		.toggle-area & {
 			max-height: 55vh; // 10vh for the switcher (compared to height in .brkts-popup)
 

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -562,7 +562,7 @@
 		border-color: var( --clr-on-surface-dark-primary-8 );
 	}
 
-	@media ( min-width: 769px ) {
+	@media ( width > 768px ) {
 		max-height: 65vh;
 	}
 

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -549,10 +549,14 @@
 		}
 
 		.toggle-area & {
-			max-height: 55vh; // 10vh for the switcher (compared to height in .brkts-popup)
+			max-height: calc( 100dvh - ( 2.75rem + 4.1875rem + 3.5rem ) ); // 3.5rem for the switcher (compared to .brkts-popup.brkts-match-info-popup)
+		}
 
-			@media ( max-width: 768px ) {
-				max-height: calc( 100dvh - ( 2.75rem + 4.1875rem + 4rem ) ); // 4 rem for the switcher (compared to .brkts-popup.brkts-match-info-popup)
+		@media ( width > 768px ) {
+			max-height: 65vh;
+
+			.toggle-area & {
+				max-height: calc( 65vh - 3.5rem ); // 3.5rem for the switcher
 			}
 		}
 	}
@@ -564,10 +568,6 @@
 	.theme--dark & {
 		background-color: var( --clr-secondary-16 );
 		border-color: var( --clr-on-surface-dark-primary-8 );
-	}
-
-	@media ( width > 768px ) {
-		max-height: 65vh;
 	}
 
 	.timer-object-date {


### PR DESCRIPTION
## Summary

Fixes #7682

Mainly inspired by https://github.com/Liquipedia/Lua-Modules/issues/7682#issuecomment-4760094475

## How did you test this change?

browser dev tools