### PR TITLE
fix(match2): non array table passed as children in edge case

### DIFF
--- a/lua/wikis/valorant/MatchPage.lua
+++ b/lua/wikis/valorant/MatchPage.lua
@@ -256,10 +256,10 @@ function MatchPage:_renderGameOverview(game)
 					},
 					Div{
 						classes = {'match-bm-lol-game-summary-team'},
-						children = {
+						children = WidgetUtil.collect(
 							self.opponents[2].iconDisplay,
-							makeTeamHalvesDisplay(team2),
-						}
+							makeTeamHalvesDisplay(team2)
+						)
 					},
 				}
 			}


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1520821496732319904

if the 2nd opponent has no iconDisplay a tbale of the form `{[2] = something}` gets passed to the div as children
hence it errors
to fix that use WidgetUtil.collect

## How did you test this change?
live