### PR TITLE
feat: Add modules to Predecessor

### DIFF
--- a/lua/wikis/predecessor/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/predecessor/GetMatchGroupCopyPaste/wiki.lua
@@ -1,0 +1,59 @@
+---
+-- @Liquipedia
+-- page=Module:GetMatchGroupCopyPaste/wiki
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
+
+local BaseCopyPaste = Lua.import('Module:GetMatchGroupCopyPaste/wiki/Base')
+
+---@class PredecessorMatch2CopyPaste: Match2CopyPasteBase
+local WikiCopyPaste = Class.new(BaseCopyPaste)
+
+local INDENT = WikiCopyPaste.Indent
+
+function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
+	local showScore = Logic.nilOr(Logic.readBoolOrNil, bestof == 0)
+	local bans = Logic.readBool(args.bans)
+
+	local lines = Array.extend(
+		'{{Match|bestof=' .. (bestof ~= 0 and bestof or ''),
+		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
+		Array.map(Array.range(1, opponents), function(opponentIndex)
+			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
+		end),
+		INDENT .. '|date=',
+		INDENT .. '|twitch=|youtube=|vod=',
+		Array.map(Array.range(1, bestof), function(mapIndex)
+			return WikiCopyPaste._getMapCode(mapIndex, bans)
+		end),
+		'}}'
+	)
+
+	return table.concat(lines, '\n')
+end
+
+---@param mapIndex integer
+---@param bans boolean
+---@return string
+function WikiCopyPaste._getMapCode(mapIndex, bans)
+	return table.concat(Array.extend(
+		INDENT .. '|map' .. mapIndex .. '={{Map',
+		INDENT .. INDENT .. '|team1side=',
+		INDENT .. INDENT .. '|t1h1=|t1h2=|t1h3=|t1h4=|t1h5=',
+		bans and (INDENT .. INDENT .. '|t1b1=|t1b2=|t1b3=|t1b4=|t1b5=') or nil,
+		INDENT .. INDENT .. '|team2side=',
+		INDENT .. INDENT .. '|t2h1=|t2h2=|t2h3=|t2h4=|t2h5=',
+		bans and (INDENT .. INDENT .. '|t2b1=|t2b2=|t2b3=|t2b4=|t2b5=') or nil,
+		INDENT .. INDENT .. '|length=|winner=|matchid=|vod=',
+		INDENT .. '}}'
+	), '\n')
+end
+
+return WikiCopyPaste

--- a/lua/wikis/predecessor/Info.lua
+++ b/lua/wikis/predecessor/Info.lua
@@ -1,0 +1,42 @@
+---
+-- @Liquipedia
+-- page=Module:Info
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+return {
+	startYear = 2024,
+	wikiName = 'predecessor',
+	name = 'Predecessor',
+	defaultGame = 'Predecessor',
+	games = {
+		predecessor = {
+			abbreviation = 'Predecessor',
+			name = 'Predecessor',
+			link = 'Predecessor',
+			logo = {
+				darkMode = 'Predecessor.png',
+				lightMode = 'Predecessor.png',
+			},
+			defaultTeamLogo = {
+				darkMode = 'Predecessor.png',
+				lightMode = 'Predecessor.png',
+			},
+		},
+	},
+	config = {
+		squads = {
+			hasPosition = true,
+			hasSpecialTeam = false,
+			allowManual = true,
+		},
+		match2 = {
+			status = 2,
+		},
+		participants = {
+			defaultPlayerNumber = 5,
+		},
+	},
+	defaultRoundPrecision = 0,
+}

--- a/lua/wikis/predecessor/Infobox/League/Custom.lua
+++ b/lua/wikis/predecessor/Infobox/League/Custom.lua
@@ -1,0 +1,69 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/League/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+local String = Lua.import('Module:StringUtils')
+
+local Injector = Lua.import('Module:Widget/Injector')
+local League = Lua.import('Module:Infobox/League')
+
+local Widgets = Lua.import('Module:Widget/All')
+local Cell = Widgets.Cell
+local Link = Lua.import('Module:Widget/Basic/Link')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+---@class PredecessorLeagueInfobox: InfoboxLeague
+local CustomLeague = Class.new(League)
+---@class PredecessorLeagueInfoboxWidgetInjector: WidgetInjector
+---@field caller PredecessorLeagueInfobox
+local CustomInjector = Class.new(Injector)
+
+---@param frame Frame
+---@return VNode
+function CustomLeague.run(frame)
+	local league = CustomLeague(frame)
+	league:setWidgetInjector(CustomInjector(league))
+
+	return league:createInfobox()
+end
+
+---@param id string
+---@param widgets Renderable[]
+---@return Renderable[]
+function CustomInjector:parse(id, widgets)
+	local args = self.caller.args
+
+	if id == 'custom' then
+		Array.appendWith(widgets,
+			Cell{name = 'Number of teams', children = {args.team_number}},
+			Cell{name = 'Number of players', children = {args.player_number}},
+			Cell{name = 'Version', children = self.caller:_createPatchCell(args)}
+		)
+	end
+
+	return widgets
+end
+
+---@param args table
+---@return Widget[]?
+function CustomLeague:_createPatchCell(args)
+	if String.isEmpty(args.patch) then
+		return
+	end
+	return WidgetUtil.collect(
+		Link{link = 'Patch_' .. args.patch, children = {args.patch}},
+		String.isNotEmpty(args.epatch) and args.patch ~= args.epatch and {
+			' &ndash; ',
+			Link{link = 'Patch_' .. args.epatch, children = {args.epatch}},
+		} or nil
+	)
+end
+
+return CustomLeague

--- a/lua/wikis/predecessor/MatchGroup/Custom.lua
+++ b/lua/wikis/predecessor/MatchGroup/Custom.lua
@@ -1,0 +1,126 @@
+---
+-- @Liquipedia
+-- page=Module:MatchGroup/Input/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local FnUtil = Lua.import('Module:FnUtil')
+local HeroNames = Lua.import('Module:HeroNames', {loadData = true})
+local Logic = Lua.import('Module:Logic')
+local Table = Lua.import('Module:Table')
+
+local MatchGroupInputUtil = Lua.import('Module:MatchGroup/Input/Util')
+
+local MatchFunctions = {}
+local MapFunctions = {}
+local CustomMatchGroupInput = {}
+
+MatchFunctions.OPPONENT_CONFIG = {
+	resolveRedirect = true,
+	pagifyTeamNames = true,
+	maxNumPlayers = 10,
+}
+MatchFunctions.getBestOf = MatchGroupInputUtil.getBestOf
+
+---@param match table
+---@param options? {isMatchPage: boolean?}
+---@return table
+function CustomMatchGroupInput.processMatch(match, options)
+	return MatchGroupInputUtil.standardProcessMatch(match, MatchFunctions)
+end
+
+---@param match table
+---@param games table[]
+---@return table
+function MatchFunctions.getLinks(match, games)
+	---@type table<string, string|table|nil>
+	local links = MatchGroupInputUtil.getLinks(match)
+	links.statlocker = {}
+
+	Array.forEach(games, function(map, mapIndex)
+		if Logic.isEmpty(map.matchid) then return end
+		links.statlocker[mapIndex] = 'https://statlocker.gg/match/' .. map.matchid
+	end)
+
+	return links
+end
+
+---@param match table
+---@param opponents MGIParsedOpponent[]
+---@return table[]
+function MatchFunctions.extractMaps(match, opponents)
+	return MatchGroupInputUtil.standardProcessMaps(match, opponents, MapFunctions)
+end
+
+---@param maps table[]
+---@return fun(opponentIndex: integer): integer
+function MatchFunctions.calculateMatchScore(maps)
+	return FnUtil.curry(MatchGroupInputUtil.computeMatchScoreFromMapWinners, maps)
+end
+
+---@param map table
+---@param mapIndex table
+---@param match table
+---@return string?
+---@return string?
+function MapFunctions.getMapName(map, mapIndex, match)
+	return nil
+end
+
+---@param match table
+---@param map table
+---@param opponents MGIParsedOpponent[]
+---@return table
+function MapFunctions.getExtraData(match, map, opponents)
+	local extradata = {
+		team1side = map.team1side,
+		team2side = map.team2side,
+	}
+
+	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
+	for opponentIndex = 1, #opponents do
+		for _, ban, banIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'b') do
+			extradata['team' .. opponentIndex .. 'ban' .. banIndex] = getCharacterName(ban)
+		end
+		for _, pick, pickIndex in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'h') do
+			extradata['team' .. opponentIndex .. 'hero' .. pickIndex] = getCharacterName(pick)
+		end
+	end
+
+	return extradata
+end
+
+--- TODO FIX:This function does not attempt to attach the data to the correct player!
+---@param map table
+---@param opponent MGIParsedOpponent
+---@param opponentIndex integer
+---@return table[]
+function MapFunctions.getPlayersOfMapOpponent(map, opponent, opponentIndex)
+	local getCharacterName = FnUtil.curry(MatchGroupInputUtil.getCharacterName, HeroNames)
+
+	local participants = {}
+	for _, hero in Table.iter.pairsByPrefix(map, 't' .. opponentIndex .. 'h', {requireIndex = true}) do
+		table.insert(participants, {character = getCharacterName(hero)})
+	end
+
+	return participants
+end
+
+---@param map table
+---@return fun(opponentIndex: integer): integer?
+function MapFunctions.calculateMapScore(map)
+	local winner = tonumber(map.winner)
+	return function(opponentIndex)
+		-- TODO Better to check if map has started, rather than finished, for a more correct handling
+		if not winner then
+			return
+		end
+		return winner == opponentIndex and 1 or 0
+	end
+end
+
+return CustomMatchGroupInput

--- a/lua/wikis/predecessor/MatchSummary.lua
+++ b/lua/wikis/predecessor/MatchSummary.lua
@@ -1,0 +1,75 @@
+---
+-- @Liquipedia
+-- page=Module:MatchSummary
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Array = Lua.import('Module:Array')
+local Class = Lua.import('Module:Class')
+
+local MatchSummary = Lua.import('Module:MatchSummary/Base')
+local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
+local MAX_NUM_BANS = 5
+local NUM_HEROES_PICK = 5
+local STATUS_NOT_PLAYED = 'notplayed'
+
+---@class PredecessorCustomMatchSummary: CustomMatchSummaryInterface
+local CustomMatchSummary = {}
+
+---@class PredecessorMatchSummaryGameRow: MatchSummaryGameRow
+---@operator call(MatchSummaryGameRowProps): PredecessorMatchSummaryGameRow
+local PredecessorMatchSummaryGameRow = Class.new(MatchSummaryWidgets.GameRow)
+
+---@param args table
+---@return Widget
+function CustomMatchSummary.getByMatchId(args)
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '480px', teamStyle = 'bracket'})
+end
+
+---@param match MatchGroupUtilMatch
+---@return Widget[]
+function CustomMatchSummary.createBody(match)
+	local characterBansData = MatchSummary.buildCharacterBanData(match.games, MAX_NUM_BANS)
+
+	return WidgetUtil.collect(
+		MatchSummaryWidgets.GamesContainer{
+			gridLayout = 'standard',
+			children = Array.map(match.games, function (game, gameIndex)
+				if game.status == STATUS_NOT_PLAYED then
+					return
+				end
+				return PredecessorMatchSummaryGameRow{game = game, gameIndex = gameIndex}
+			end)
+		},
+		MatchSummaryWidgets.CharacterBanTable{bans = characterBansData, date = match.date}
+	)
+end
+
+---@param opponentIndex integer
+---@return Widget
+function PredecessorMatchSummaryGameRow:createGameOpponentView(opponentIndex)
+	local props = self.props
+	local game = props.game
+	local extradata = game.extradata or {}
+
+	return MatchSummaryWidgets.Characters{
+		flipped = opponentIndex == 2,
+		characters = MatchSummary.buildCharacterList(
+			extradata, 'team' .. opponentIndex .. 'hero', NUM_HEROES_PICK
+		),
+		bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (extradata['team' .. opponentIndex .. 'side'] or ''),
+		date = game.date,
+	}
+end
+
+---@return Renderable?
+function PredecessorMatchSummaryGameRow:createGameOverview()
+	return self:lengthDisplay()
+end
+
+return CustomMatchSummary


### PR DESCRIPTION
Added necessary modules in order to enable brackets and league tracking in Predecessor wiki.

## Summary

In order to properly set up the Predecessor wiki I needed to add the necessary modules for using the bracket system.
Following the instructions found [here](https://liquipedia.net/commons/Liquipedia:Brackets/Wiki-specific_Setup).

## How did you test this change?

No changes were made to JS pages.
`npm run lua-test` passes.
