### PR TITLE
feat: explicitly throw if TeamTemplate.getRawOrNil gets nil input

### DIFF
--- a/lua/wikis/commons/TeamTemplate.lua
+++ b/lua/wikis/commons/TeamTemplate.lua
@@ -84,13 +84,14 @@ end
 Same as TeamTemplate.getRaw, except that it returns nil if the team template
 does not exist.
 ]]
----@param team string
+---@param team string?
 ---@param date string|number?
 ---@return teamTemplateData?
 function TeamTemplate.getRawOrNil(team, date)
 	if Logic.isEmpty(team) then
 		return
 	end
+	---@cast team -nil
 	team = team:gsub('_', ' '):lower()
 
 	-- return mw.ext.TeamTemplate.raw(team, date)

--- a/lua/wikis/commons/TeamTemplate.lua
+++ b/lua/wikis/commons/TeamTemplate.lua
@@ -83,15 +83,14 @@ end
 --[[
 Same as TeamTemplate.getRaw, except that it returns nil if the team template
 does not exist.
+
+Throws if `team` is nil.
 ]]
 ---@param team string?
 ---@param date string|number?
 ---@return teamTemplateData?
 function TeamTemplate.getRawOrNil(team, date)
-	if Logic.isEmpty(team) then
-		return
-	end
-	---@cast team -nil
+	assert(team ~= nil, 'TeamTemplate.getRawOrNil: \'team\' must not be nil')
 	team = team:gsub('_', ' '):lower()
 
 	-- return mw.ext.TeamTemplate.raw(team, date)

--- a/lua/wikis/commons/TeamTemplate.lua
+++ b/lua/wikis/commons/TeamTemplate.lua
@@ -84,7 +84,7 @@ end
 Same as TeamTemplate.getRaw, except that it returns nil if the team template
 does not exist.
 
-Throws if `team` is nil.
+Throws if `team` is `nil`.
 ]]
 ---@param team string?
 ---@param date string|number?

--- a/lua/wikis/commons/TeamTemplate.lua
+++ b/lua/wikis/commons/TeamTemplate.lua
@@ -86,7 +86,7 @@ does not exist.
 
 Throws if `team` is `nil`.
 ]]
----@param team string?
+---@param team string
 ---@param date string|number?
 ---@return teamTemplateData?
 function TeamTemplate.getRawOrNil(team, date)


### PR DESCRIPTION
## Summary

Inspiration: https://github.com/Liquipedia/Lua-Modules/pull/6863#discussion_r3403467682

This PR adjusts `TeamTemplate.getRawOrNil` to explicitly throw if `team` argument is `nil`.
There is no change in behavior (`team:gsub` throws if `team` is `nil` in the current implementation anyway); this is for making the check explicit and generating a more comprehensive error message.

## How did you test this change?

trivial