### PR TITLE
fix(TeamCard): use canonical role keys for mlbb lane defaults

### DIFF
--- a/lua/wikis/mobilelegends/TeamCard/Legacy/Custom.lua
+++ b/lua/wikis/mobilelegends/TeamCard/Legacy/Custom.lua
@@ -8,16 +8,18 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
-local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
 local LegacyTeamCard = Lua.import('Module:TeamCard/Legacy')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
 local DEFAULT_MAX_PLAYER_INDEX = 10
 local LANE_COUNT = 5
-local INGAME_ROLES_BY_ORDER = Table.map(InGameRoles, function(_, roleData)
-	return roleData.sortOrder, roleData.display
-end)
+-- Default lane role per slot, indexed by InGameRoles sortOrder. These are the canonical
+-- role *keys* (not displays): RoleUtil lowercases the position and looks it up in both
+-- Roles.All and PositionIcon/data, so the value must be a real key. mlbb displays
+-- ('EXP Laner', 'Mid Laner', 'Gold Laner') don't match their keys, so feeding displays
+-- back as positions fails to resolve and renders them as plain-text labels.
+local LANE_ROLE_BY_ORDER = {'exp lane', 'jungler', 'middle', 'gold lane', 'roamer'}
 
 local CustomLegacyTeamCard = {}
 
@@ -37,7 +39,7 @@ function CustomLegacyTeamCard.preprocessCard(card)
 			Table.extract(card, 'pos' .. index),
 			-- Only the five lane slots get a slot-index role default;
 			-- non-lane roles (e.g. flex) must not auto-fill higher slots
-			index <= LANE_COUNT and INGAME_ROLES_BY_ORDER[index] or nil
+			index <= LANE_COUNT and LANE_ROLE_BY_ORDER[index] or nil
 		)
 	end)
 


### PR DESCRIPTION
## Summary

- mlbb's Legacy TeamCard defaulted empty lane slots to the role *display* (`EXP Laner`, `Mid Laner`, `Gold Laner`), which RoleUtil lowercases and looks up as a role/icon key — those don't match the canonical keys, so icons failed to render and labels showed as plain text
- default to the canonical role keys (`exp lane`, `jungler`, `middle`, `gold lane`, `roamer`) instead, so each lane resolves in both `Roles.All` and `PositionIcon/data`
- drop the now-unused `InGameRoles` import

## How did you test this change?

dev