### PR TITLE
fix(TeamParticipant): show lone staff in Main tab regardless of subs/formers

### DIFF
--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -154,10 +154,25 @@ local function ParticipantsTeamRoster(props)
 		}
 	end
 
+	local players = participant.opponent.players or {}
+
+	-- If there's exactly one staff member, always show them in the Main tab instead of a separate
+	-- Staff tab, regardless of whether subs/formers are also present.
+	local promoteLoneStaff = props.mergeStaffTabIfOnlyOneStaff and #Array.filter(players, function(player)
+		return getPlayerTab(player) == TAB_ENUM.STAFF
+	end) == 1
+	local getTab = function(player)
+		local tab = getPlayerTab(player)
+		if promoteLoneStaff and tab == TAB_ENUM.STAFF then
+			return TAB_ENUM.MAIN
+		end
+		return tab
+	end
+
 	local tabs = Array.map(Table.entries(TAB_DATA), function(tabTuple)
 		local tabTypeEnum, tabData = tabTuple[1], tabTuple[2]
-		local tabPlayers = sortPlayers(Array.filter(participant.opponent.players or {}, function(player)
-			return getPlayerTab(player) == tabTypeEnum
+		local tabPlayers = sortPlayers(Array.filter(players, function(player)
+			return getTab(player) == tabTypeEnum
 		end))
 
 		local groups
@@ -191,16 +206,6 @@ local function ParticipantsTeamRoster(props)
 	tabs = Array.filter(tabs, function(tab)
 		return #tab.players > 0
 	end)
-	if props.mergeStaffTabIfOnlyOneStaff
-		and #tabs == 2
-		and tabs[1].type == TAB_ENUM.MAIN
-		and tabs[2].type == TAB_ENUM.STAFF
-		and #tabs[2].players == 1
-	then
-		-- If we only have main and staff, and exactly one staff, just show both rosters without a switch
-		local mergedPlayers = sortPlayers(Array.extend(tabs[1].players, tabs[2].players))
-		return makeRostersDisplay({ { players = mergedPlayers } })
-	end
 	tabs = Array.sortBy(tabs, Operator.property('order'))
 
 	local switchGroupUniqueId = tonumber(Variables.varDefault('teamParticipantRostersSwitchGroupId')) or 0


### PR DESCRIPTION
## Summary

- A team with exactly one staff member now always shows that staff in the Main tab, even when subs or formers are present (previously the merge only happened when Main + Staff were the only two tabs).
- Reclassify the lone staff to Main at player-classification time instead of merging tabs after the fact; drops the now-redundant post-hoc merge block (ContentSwitch already renders a single remaining tab without switch chrome).

## How did you test this change?

dev

| New | Old |
| --- | --- |
| <img width="297" height="358" alt="image" src="https://github.com/user-attachments/assets/ef8dd3cc-1738-44dc-81c3-3cbb3982cdbc" /> | <img width="298" height="318" alt="image" src="https://github.com/user-attachments/assets/58a63653-e309-4a3a-babe-61178aeb65e4" /> |