### PR TITLE
feat: Allow wrapping of tournament names in ResultsTable

### DIFF
--- a/lua/wikis/commons/ResultsTable.lua
+++ b/lua/wikis/commons/ResultsTable.lua
@@ -36,7 +36,7 @@ function ResultsTable:buildColumnDefinitions()
 		self.config.showType and {align = 'center'} or nil,
 		self.config.displayGameIcons and {align = 'center'} or nil,
 		{align = 'left'},
-		{align = 'left', nowrap = false},
+		{align = 'left'},
 		(self.config.queryType ~= Opponent.team or Table.isNotEmpty(self.config.aliases)) and {
 			align = 'center',
 		} or self.config.playerResultsOfTeam and {

--- a/lua/wikis/commons/ResultsTable.lua
+++ b/lua/wikis/commons/ResultsTable.lua
@@ -36,7 +36,7 @@ function ResultsTable:buildColumnDefinitions()
 		self.config.showType and {align = 'center'} or nil,
 		self.config.displayGameIcons and {align = 'center'} or nil,
 		{align = 'left'},
-		{align = 'left'},
+		{align = 'left', nowrap = false},
 		(self.config.queryType ~= Opponent.team or Table.isNotEmpty(self.config.aliases)) and {
 			align = 'center',
 		} or self.config.playerResultsOfTeam and {

--- a/lua/wikis/commons/ResultsTable/Base.lua
+++ b/lua/wikis/commons/ResultsTable/Base.lua
@@ -607,6 +607,7 @@ function BaseResultsTable:createTournamentCells(placement)
 			attributes = {
 				['data-sort-value'] = tournamentDisplayName
 			},
+			nowrap = false,
 			children = LinkWidget{
 				children = tournamentDisplayName,
 				link = placement.pagename,


### PR DESCRIPTION
## Summary
Allows tournament names to wrap in ResultsTable.
On desktop, this avoids the results table being too wide to fit on a screen without scrolling while only breaking very long names;
on mobile, this reduces the amount of vertical scroll needed with the compromise of higher rows for most cases, as almost all names will wrap.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev/salt on https://liquipedia.net/ageofempires/TheViper
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
