### PR TITLE
fix: table2 ignores props when column definitions are not present

### DIFF
--- a/lua/wikis/commons/Widget/Table2/Cell.lua
+++ b/lua/wikis/commons/Widget/Table2/Cell.lua
@@ -43,7 +43,7 @@ local function Table2Cell(props, context)
 				props.align,
 				props.nowrap,
 				props.shrink,
-				props.attributes
+				ColumnUtil.buildAttributes(props)
 			),
 			classes = props.classes,
 			children = children,

--- a/lua/wikis/commons/Widget/Table2/CellHeader.lua
+++ b/lua/wikis/commons/Widget/Table2/CellHeader.lua
@@ -52,7 +52,7 @@ local function Table2CellHeader(props, context)
 	-- Skip context lookups and property merging if there are no column definitions
 	if #columns == 0 then
 		local align = props.align
-		local attributes = props.attributes or {}
+		local attributes = ColumnUtil.buildAttributes(props)
 		if align == 'right' or align == 'center' then
 			attributes['data-align'] = align
 		end


### PR DESCRIPTION
## Summary

_Cherry-picked from #7688 (572e2ad)_

Table2 cells ignore some values in `props` (`colspan` and `rowspan` to name a few) when the column definition is not present in the table. This PR fixes attributes processing in the "no column definition" branch of the code.

## How did you test this change?

as part of #7688