### PR TITLE
fix(TeamCard/Legacy): strip category links from qualifier parsing

### DIFF
--- a/lua/wikis/commons/TeamCard/Legacy.lua
+++ b/lua/wikis/commons/TeamCard/Legacy.lua
@@ -179,6 +179,10 @@ end
 ---@param rawQualifier string
 ---@return string?, string?, string? # (linkText, internalLink, externalLink)
 function LegacyTeamCard._parseQualifierLink(rawQualifier)
+	-- Some qualifier templates (e.g. {{VRS}}) categorise the page as a side effect, emitting a
+	-- [[Category:...]] link into the value. Strip it so it is not mistaken for the qualifier link.
+	rawQualifier = mw.text.trim((rawQualifier:gsub('%[%[:?[Cc]ategory:.-%]%]', '')))
+
 	-- A qualifier may be prefixed with an icon (e.g. {{LeagueIconSmall}}, which expands to
 	-- a File link / span before reaching here). Take the first internal wikilink that is not
 	-- such an embed; the new QualifierInfo widget renders its own tournament icon.


### PR DESCRIPTION
## Summary

- Qualifier templates such as `{{VRS}}` emit a `[[Category:...]]` link as a
  categorization side effect. `_parseQualifierLink` grabbed that as the
  qualifier's own internal link, so the card rendered a bare category wikilink
  (which silently categorizes the page and displays nothing) instead of the
  real external link — a link icon with no text.
- Strip `[[Category:...]]` / `[[:Category:...]]` from the raw qualifier before
  parsing so the actual tournament/external link is used.

## How did you test this change?

dev