### PR TITLE
fix(TeamParticipant): keep cards side by side inside wikitables

### DIFF
--- a/stylesheets/commons/TeamParticipantCard.scss
+++ b/stylesheets/commons/TeamParticipantCard.scss
@@ -73,6 +73,17 @@ $hover-selector: '[data-switch-group="team-cards-hover-roster"]';
 	}
 }
 
+// `auto-fill` collapses to one column inside a shrink-to-fit wikitable cell (indefinite width).
+// Flex-wrap with no shrink lets the cell size to the cards, so they sit side by side when they fit.
+table .team-participant__grid {
+	display: flex;
+	flex-wrap: wrap;
+
+	> * {
+		flex: 1 0 $participant-card-min-width;
+	}
+}
+
 .team-participant-card {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary

- Team participant `CardsGroup` uses a CSS grid with `repeat(auto-fill, minmax(280px, 1fr))`. Inside a shrink-to-fit wikitable cell the container width is indefinite, so `auto-fill` collapses to a single column and cards stacked vertically (a note-toggle reflow "fixed" it only by accident).
- Fall back to `flex-wrap` with `flex: 1 0` (no shrink) in that context: cards hold their min width, so the cell shrink-wraps to them and lays them side by side when they fit, wrapping when the viewport is narrow.
- Scoped to `table` descendants, so the normal (non-table) grid layout is unchanged.

## How did you test this change?

devtools

| <img width="598" height="445" alt="image" src="https://github.com/user-attachments/assets/1fb84716-57b6-4a8a-b639-ae159802c469" /> |