### PR TITLE
fix(TeamParticipants): render TBD players before staff in merged roster

### DIFF
--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -99,8 +99,9 @@ local function ParticipantsTeamRoster(props)
 		local isStaff = function(player) return player.extradata.type == 'staff' end
 		return Array.sortBy(players, FnUtil.identity, function(a, b)
 			-- Staff render after players (incl. TBD placeholders) within a tab
-			if isStaff(a) ~= isStaff(b) then
-				return isStaff(b)
+			local aIsStaff, bIsStaff = isStaff(a), isStaff(b)
+			if aIsStaff ~= bIsStaff then
+				return bIsStaff
 			end
 			local function getPlayerSortOrder(player)
 				local roles = player.extradata.roles or {}

--- a/lua/wikis/commons/Widget/Participants/Team/Roster.lua
+++ b/lua/wikis/commons/Widget/Participants/Team/Roster.lua
@@ -96,7 +96,12 @@ local function ParticipantsTeamRoster(props)
 	-- Used for making the sorting stable
 	local sortPlayers = function(players)
 		local playerToIndex = Table.map(players, function(index, player) return player, index end)
+		local isStaff = function(player) return player.extradata.type == 'staff' end
 		return Array.sortBy(players, FnUtil.identity, function(a, b)
+			-- Staff render after players (incl. TBD placeholders) within a tab
+			if isStaff(a) ~= isStaff(b) then
+				return isStaff(b)
+			end
 			local function getPlayerSortOrder(player)
 				local roles = player.extradata.roles or {}
 				return roles[1] and roles[1].sortOrder or math.huge


### PR DESCRIPTION
## Summary

- In a merged Main tab (lone staff promoted via `mergeStaffTabIfOnlyOneStaff`), coach/staff were rendering before TBD placeholders.
- Root cause: staff roles carry no `sortOrder` and TBD players have no roles, so both fell back to `math.huge` and tied — the stable sort then preserved array order, where coaches are appended before TBD fill.
- Fix: sort staff after all non-staff members (including TBD) within a tab, keeping role `sortOrder` as the secondary key.
- Result: `players → TBD → staff`.

## How did you test this change?

dev