### PR TITLE
fix(opponent): missing nil catch for chars in char player display

### DIFF
--- a/lua/wikis/commons/Widget/PlayerDisplay/Inline/Character.lua
+++ b/lua/wikis/commons/Widget/PlayerDisplay/Inline/Character.lua
@@ -34,12 +34,12 @@ local function InlineCharacterPlayer(props)
 				showFlag = props.showFlag,
 				useDefault = Logic.nilOr(Logic.readBoolOrNil(props.showTbd), true) or not Opponent.playerIsTbd(player)
 			},
-			Html.Fragment{children = Array.map(
+			player.chars and Html.Fragment{children = Array.map(
 				player.chars,
 				function (character)
 					return Characters.GetIconAndName{character, game = player.game}
 				end
-			)},
+			)} or nil,
 			InlineName(props)
 		)
 	}


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1522000905338359879

## How did you test this change?
live