### PR TITLE
fix(match2): blank return breaking Array.mapRange operation in LoL parser

### DIFF
--- a/lua/wikis/leagueoflegends/MatchGroup/Input/Custom/Normal.lua
+++ b/lua/wikis/leagueoflegends/MatchGroup/Input/Custom/Normal.lua
@@ -49,7 +49,7 @@ function CustomMatchGroupInputNormal.getParticipants(map, opponentIndex)
 	return Logic.nilIfEmpty(Array.mapRange(1, MAX_NUM_PICKS, function (playerIndex)
 		local playerData = Json.parseIfTable(map['t' .. opponentIndex .. 'p' .. playerIndex])
 		if Logic.isEmpty(playerData) then
-			return
+			return nil
 		end
 		---@cast playerData -nil
 		if Logic.isEmpty(playerData.role) then


### PR DESCRIPTION
## Summary

Reported on discord: https://discord.com/channels/93055209017729024/268719633366777856/1523636436027310201

Regression from #7677

## How did you test this change?

live