### PR TITLE
ci: fix deploy incorrectly uploading Main.css / Main.js

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,11 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files: |
-            stylesheets/commons/**/*.scss
-            javascript/commons/**/*.js
+            stylesheets/**/*.scss
+            javascript/**/*.js
+          files_ignore: |
+            stylesheets/Main.scss
+            javascript/Main.js
 
       - name: Setup Python
         if: steps.res-changed-files.outputs.any_changed == 'true' || steps.lua-changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,8 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files: |
-            stylesheets/**/*.scss
-            javascript/**/*.js
+            stylesheets/commons/**/*.scss
+            javascript/commons/**/*.js
 
       - name: Setup Python
         if: steps.res-changed-files.outputs.any_changed == 'true' || steps.lua-changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,8 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files: |
-            stylesheets/**/*.scss
-            javascript/**/*.js
-          files_ignore: |
-            stylesheets/Main.scss
-            javascript/Main.js
+            stylesheets/commons/**/*.scss
+            javascript/commons/**/*.js
 
       - name: Setup Python
         if: steps.res-changed-files.outputs.any_changed == 'true' || steps.lua-changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
## Summary

The current deploy script incorrectly picks up changes in `Main.{scss, js}` files and uploads them to Commons. Because these files are not added to RLA they do not create any trouble in wikis. Still, this is a flawed behavior that should be fixed.

## How did you test this change?

local deploy