### PR TITLE
fix(PrizePool): remove fit-content width causing mobile layout issue

### DIFF
--- a/stylesheets/commons/Prizepooltable.scss
+++ b/stylesheets/commons/Prizepooltable.scss
@@ -492,7 +492,6 @@ share the `prizepooltable` class.
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
-	width: fit-content;
 
 	.switch-pill-container {
 		align-self: flex-start;


### PR DESCRIPTION
## Summary

On pages that wrap the prizepool in a box, the table loses scrollability:
https://liquipedia.net/warcraft/Gladiator_Golden_Cup/2

This PR:
- Removes `width: fit-content` from the prize pool table container so it fills available width on mobile

## How did you test this change?

devtools