### PR TITLE
fix(Table2): reduce footer vertical padding

### DIFF
--- a/stylesheets/commons/Table2.scss
+++ b/stylesheets/commons/Table2.scss
@@ -44,7 +44,7 @@ $table2-cell-padding-x: 0.75rem;
 
 	&__footer {
 		font-weight: bold;
-		padding: 0.5rem 0.75rem;
+		padding: 0.25rem 0.75rem;
 		text-align: center;
 		border-top: 1px solid;
 		border-top-color: var( --clr-on-surface-light-primary-12 );


### PR DESCRIPTION
## Summary

- Reduce Table2 footer vertical padding from 0.5rem to 0.25rem to match designs

## How did you test this change?

devtools