### PR TITLE
feat: Add Flex role for IDV

### DIFF
--- a/lua/wikis/identityv/InGameRoles.lua
+++ b/lua/wikis/identityv/InGameRoles.lua
@@ -9,7 +9,7 @@
 local inGameRoles = {
 	['survivor'] = {category = 'Survivors', display = 'Survivor', sortOrder = 1},
 	['hunter'] = {category = 'Hunters', display = 'Hunter', sortOrder = 2},
-	['dual'] = {category = 'Dual Roles', display = 'Dual', sortOrder = 3},
+	['flex'] = {category = 'Flex Roles', display = 'Flex', sortOrder = 3},
 }
 
 return inGameRoles

--- a/lua/wikis/identityv/InGameRoles.lua
+++ b/lua/wikis/identityv/InGameRoles.lua
@@ -9,6 +9,7 @@
 local inGameRoles = {
 	['survivor'] = {category = 'Survivors', display = 'Survivor', sortOrder = 1},
 	['hunter'] = {category = 'Hunters', display = 'Hunter', sortOrder = 2},
+	['dual'] = {category = 'Dual Roles', display = 'Dual', sortOrder = 3},
 }
 
 return inGameRoles


### PR DESCRIPTION
## Summary
In some tournaments, players can compete under both role classes in one tournament, so a Flex logo need to be put as a 3rd in game role after the role icon changes (where for non IGRs the icons will no longer show)

<img width="684" height="575" alt="image" src="https://github.com/user-attachments/assets/deb4fcbc-bf09-4b59-ad36-4e9431f1a400" />


## How did you test this change?
Live
<img width="301" height="333" alt="image" src="https://github.com/user-attachments/assets/674efb6d-7213-4c43-8be7-83ed2843e6e4" />
