### PR TITLE
feat(GameAppearances): Make error explicit

### DIFF
--- a/lua/wikis/commons/Infobox/Extension/GameAppearances.lua
+++ b/lua/wikis/commons/Infobox/Extension/GameAppearances.lua
@@ -39,10 +39,14 @@ function Appearances.player(args)
 
 	local queriedGames = Table.map(mw.ext.LiquipediaDB.lpdb('placement', {
 		conditions = table.concat(conditions, ' OR '),
-		query = 'game',
+		query = 'game, pagename',
 		groupby = 'game asc',
 		limit = 1000,
-	}), function(_, item) return Game.toIdentifier{game = item.game, useDefault = false}, true end)
+	}), function(_, item)
+		local game = assert(Game.toIdentifier{game = item.game, useDefault = false},
+			'Invalid game supplied on page "' .. item.pagename .. '"')
+		return game, true
+	end)
 
 	local orderedGames = Array.filter(Game.listGames{ordered = true}, function(game)
 		return queriedGames[game]


### PR DESCRIPTION
## Summary
currently `Module:Infobox/Extension/GameAppearances` errors on invalid games with an error message that does not tell one what the real cause of the error is
this pr adjusts it so that we get an explicit error that tells the contributor from which page we get supplied an invalid game

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1523226483773018152

## How did you test this change?
trivial (and did something similar to help fix the issue reported on discord (see link above))