### PR TITLE
feat: vscode task config for launching dev proxy

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,6 +31,25 @@
 				}
 			},
 			"problemMatcher": []
+		},
+		{
+			"label": "Launch proxy",
+			"type": "process",
+			"command": "${command:python.interpreterPath}",
+			"args": [
+				"scripts${/}proxy_lp.py"
+			],
+			"isBackground": true,
+			"presentation": {
+				"reveal": "always",
+				"panel": "dedicated"
+			},
+			"problemMatcher": [],
+			"detail": "python3 scripts/proxy_lp.py",
+			"runOptions": {
+				"instanceLimit": 1,
+				"instancePolicy": "terminateOldest"
+			}
 		}
 	],
 	"inputs": [

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -1,5 +1,9 @@
+import asyncio
+
 from http import HTTPStatus
-from mitmproxy import http
+
+from mitmproxy import addons, http, master
+from mitmproxy.addons import dumper, errorcheck, keepserving, readfile
 
 
 class LiquipediaMapper:
@@ -41,4 +45,21 @@ class LiquipediaMapper:
             )
 
 
-addons = [LiquipediaMapper()]
+async def main():
+    m = master.Master()
+    m.addons.add(
+        *addons.default_addons(),
+        LiquipediaMapper(),
+        dumper.Dumper(),
+        keepserving.KeepServing(),
+        readfile.ReadFileStdin(),
+        errorcheck.ErrorCheck(),
+    )
+    try:
+        await m.run()
+    except asyncio.CancelledError:
+        await m.done()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -46,7 +46,7 @@ class LiquipediaMapper:
 
 
 async def main():
-    m = master.Master()
+    m = master.Master(None)
     m.addons.add(
         *addons.default_addons(),
         LiquipediaMapper(),

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -2,8 +2,8 @@ import asyncio
 
 from http import HTTPStatus
 
-from mitmproxy import addons, http, master
-from mitmproxy.addons import dumper, errorcheck, keepserving, readfile
+from mitmproxy import http, master
+from mitmproxy.addons import default_addons, dumper, errorcheck, keepserving, readfile
 
 
 class LiquipediaMapper:
@@ -48,7 +48,7 @@ class LiquipediaMapper:
 async def main():
     m = master.Master(None)
     m.addons.add(
-        *addons.default_addons(),
+        *default_addons(),
         LiquipediaMapper(),
         dumper.Dumper(),
         keepserving.KeepServing(),
@@ -63,3 +63,5 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
+else:
+    addons = [LiquipediaMapper()]

--- a/scripts/proxy_lp.py
+++ b/scripts/proxy_lp.py
@@ -58,7 +58,9 @@ async def main():
     try:
         await m.run()
     except asyncio.CancelledError:
-        await m.done()
+        pass
+    finally:
+        m.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

_Depends on #7391_

This PR adds `tasks.json` with preconfigured settings for VSCode to launch proxy for #7201.
Config assumes use of `venv`.

## How did you test this change?

local runs