### PR TITLE
fix: section header styling causing regression

### DIFF
--- a/stylesheets/commons/Headings.scss
+++ b/stylesheets/commons/Headings.scss
@@ -113,13 +113,13 @@ h1#firstHeading,
 .mw-heading h3,
 .mw-heading h4,
 .mw-heading h5,
-.mw-heading h6{
+.mw-heading h6 {
 	display: inline;
 	border: 0;
-    margin: 0;
-    padding: 0;
-    color: inherit;
-    font: inherit;
+	margin: 0;
+	padding: 0;
+	color: inherit;
+	font: inherit;
 }
 
 .mw-heading {

--- a/stylesheets/commons/Headings.scss
+++ b/stylesheets/commons/Headings.scss
@@ -36,7 +36,6 @@ h1#firstHeading,
 #mw-subcategories h2,
 .mw-category-group h3 {
 	font-weight: 500;
-	display: inline;
 
 	.theme--light & {
 		color: var( --clr-wiki-theme-20 );
@@ -107,6 +106,20 @@ h1#firstHeading,
 
 .mw-heading.mw-heading3 h3 .mw-editsection {
 	padding-top: 0.8125rem;
+}
+
+.mw-heading h1,
+.mw-heading h2,
+.mw-heading h3,
+.mw-heading h4,
+.mw-heading h5,
+.mw-heading h6{
+	display: inline;
+	border: 0;
+    margin: 0;
+    padding: 0;
+    color: inherit;
+    font: inherit;
 }
 
 .mw-heading {


### PR DESCRIPTION
## Summary

move `display: inline` to proper selector that don't mess other stuff.

## How did you test this change?

I override the production site css, and do the changes there, no regression visible
