### PR TITLE
feat: Increase matchWidth for match2 on deadlock wiki

### DIFF
--- a/lua/wikis/deadlock/Info.lua
+++ b/lua/wikis/deadlock/Info.lua
@@ -33,6 +33,7 @@ return {
 		},
 		match2 = {
 			status = 2,
+			matchWidth = 180,
 		},
 		participants = {
 			defaultPlayerNumber = 6,


### PR DESCRIPTION
## Summary

Increases matchWidth for match2 on deadlock wiki so that bracket name is used instead of short name

## How did you test this change?

N/A, same matchWidth as dota2 wiki
