### PR TITLE
fix: bracket designer styling colors

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -2,20 +2,12 @@
 * Styles shared between BracketDisplay, MatchlistDisplay, and MatchSummary
 */
 
-.theme--light {
-	--brackets-header-background-color: #cfcfcf;
-	--brackets-header-border-color: #aaaaaa;
-	--brackets-background-color: #f2f2f2;
-	--brackets-score-background-color: #ebebeb;
-	--brackets-border-color: #aaaaaa;
-}
-
-.theme--dark {
-	--brackets-header-background-color: var( --clr-secondary-16 );
-	--brackets-header-border-color: var( --clr-secondary-16 );
-	--brackets-background-color: var( --clr-secondary-9 );
-	--brackets-score-background-color: var( --clr-secondary-16 );
-	--brackets-border-color: var( --clr-secondary-16 );
+:root {
+	--brackets-header-background-color: var( --clr-surface-2 );
+	--brackets-header-border-color: var( --clr-surface-4 );
+	--brackets-background-color: var( --clr-surface-2 );
+	--brackets-score-background-color: var( --clr-surface-2 );
+	--brackets-border-color: var( --clr-surface-4 );
 }
 
 .brkts-match-has-details {
@@ -1371,9 +1363,10 @@ div.brkts-opponent-hover {
 	height: 22px;
 }
 
-.brkts-designer-small-button {
-	background-color: #e0e0e0;
-	border: solid 1px #c0c0c0;
+.brkts-match .brkts-designer-small-button {
+	background-color: var( --clr-surface-3 );
+	border: solid 1px var( --clr-surface-4 );
+	color: var( --clr-on-surface );
 	display: block;
 	font-size: 11px;
 	padding: 0;


### PR DESCRIPTION
## Summary

Bracket Designer has a weird styling and color issues on lighthouse and production. 

## Before State
<img width="570" height="468" alt="image" src="https://github.com/user-attachments/assets/ac8b9e80-dfd4-44b3-a5f5-12e9ac7da56c" />
<img width="599" height="472" alt="image" src="https://github.com/user-attachments/assets/3205c172-a349-4943-9b75-b1645ffbbcda" />


## How did you test this change?

I put the scss changes to the production page and override it, works without issues on dota2 main page.

## After State
<img width="561" height="418" alt="image" src="https://github.com/user-attachments/assets/2fa5fa61-6046-40b8-a0bd-95186a49dc05" />
<img width="659" height="438" alt="image" src="https://github.com/user-attachments/assets/30f78399-3bcb-4ba0-a541-cf87a6f571ae" />
