### PR TITLE
fix(prizepool): Missing W/L/DQ cell colors in Table2

### DIFF
--- a/stylesheets/commons/Prizepooltable.scss
+++ b/stylesheets/commons/Prizepooltable.scss
@@ -261,22 +261,22 @@ div.bg-lose > *.prizepooltable-place {
 	background-color: var( --clr-cinnabar-background-color, inherit );
 }
 
-tr.background-color-disqualified,
+tr.background-color-disqualified:not( .table2__row--body ),
 div.background-color-disqualified {
 	background-color: #dee3ef;
 }
 
-tr.background-color-win,
+tr.background-color-win:not( .table2__row--body ),
 div.background-color-win {
 	background-color: #ddf4dd;
 }
 
-tr.background-color-lose,
+tr.background-color-lose:not( .table2__row--body ),
 div.background-color-lose {
 	background-color: #fbdfdf;
 }
 
-tr.background-color-highlight,
+tr.background-color-highlight:not( .table2__row--body ),
 div.background-color-highlight {
 	background-color: #cce5ea;
 }


### PR DESCRIPTION
## Summary

Reported on discord: https://discordapp.com/channels/93055209017729024/1523680790716616794
<img width="615" height="170" alt="image" src="https://github.com/user-attachments/assets/af180d76-5de6-472e-a56d-d98fb9d5130f" />

Example page: https://liquipedia.net/warcraft/Gladiator_Cup/325

Conflict between css and table2.js. Table is correctly colored briefly after reloading page, but then overrided by the table2.js

Maybe there is better solution then this?

## How did you test this change?

N/A
