### PR TITLE
fix(match2): rollback unintended bracket color changes

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -2,12 +2,20 @@
 * Styles shared between BracketDisplay, MatchlistDisplay, and MatchSummary
 */
 
-:root {
-	--brackets-header-background-color: var( --clr-surface-2 );
-	--brackets-header-border-color: var( --clr-surface-4 );
-	--brackets-background-color: var( --clr-surface-2 );
-	--brackets-score-background-color: var( --clr-surface-2 );
-	--brackets-border-color: var( --clr-surface-4 );
+.theme--light {
+	--brackets-header-background-color: #cfcfcf;
+	--brackets-header-border-color: #aaaaaa;
+	--brackets-background-color: #f2f2f2;
+	--brackets-score-background-color: #ebebeb;
+	--brackets-border-color: #aaaaaa;
+}
+
+.theme--dark {
+	--brackets-header-background-color: var( --clr-secondary-16 );
+	--brackets-header-border-color: var( --clr-secondary-16 );
+	--brackets-background-color: var( --clr-secondary-9 );
+	--brackets-score-background-color: var( --clr-secondary-16 );
+	--brackets-border-color: var( --clr-secondary-16 );
 }
 
 .brkts-match-has-details {


### PR DESCRIPTION
## Summary

context: https://discord.com/channels/93055209017729024/372075546231832576/1526938114948599930

#7817 came with unintended bracket color changes. This PR partially reverts it, leaving only the part specific to bracket designer buttons.

## How did you test this change?

browser dev tools