### PR TITLE
feat(match2): add new params to brawlstars copypaste generator

### DIFF
--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -49,21 +49,21 @@ local INDENT = WikiCopyPaste.Indent
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 	local showScore = Logic.readBool(args.score)
-	local casters = tonumber(args.casters) or 2
-	local globals = tonumber(args.globals) or 2
+	local numberOfCasters = tonumber(args.casters) or 2
+	local numberOfGlobalBans = tonumber(args.globals) or 2
 
 	local lines = Array.extend(
 		'{{Match',
 		matchIndex == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, casters), function(casterNumber)
-			return INDENT .. '|caster' .. casterNumber .. '=|caster' .. casterNumber .. 'flag='
+		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
+			return INDENT .. '|caster' .. casterIndex .. '=|caster' .. casterIndex .. 'flag='
 		end) or {},
 		Logic.readBool(args.hasCasters) and (INDENT .. '|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Logic.readBool(args.hasGlobals) and WikiCopyPaste._globalBanParams(opponents, globals) or {}
+		Logic.readBool(args.hasGlobalBans) and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
 	)
 
 	Array.extendWith(lines, WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto))
@@ -119,9 +119,7 @@ function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
 	local vetoTypes = mapVeto == 'custom' and customVeto or mapVeto
 	vetoTypes = string.gsub(vetoTypes, '%-', ',')
 
-	local types = Array.map(String.split(vetoTypes, ','), function(vetoType)
-		return String.trim(vetoType)
-	end)
+	local types = Array.parseCommaSeparatedString(vetoTypes)
 	vetoTypes = table.concat(types, ',')
 
 	local lines = {
@@ -134,17 +132,15 @@ function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
 	local deciderAdded = false
 
 	Array.forEach(types, function(vetoType)
-		vetoType = String.trim(vetoType)
-
-			assert(
-				vetoType == 'pick'
-					or vetoType == 'ban'
-					or vetoType == 'default'
-					or vetoType == 'decider',
-				'Unknown map veto type "' .. vetoType ..
-					'". Expected a comma-separated list using only: pick, ban, decider, default. ' ..
-					'Example: pick,ban,decider,default'
-			)
+		assert(
+			vetoType == 'pick'
+				or vetoType == 'ban'
+				or vetoType == 'default'
+				or vetoType == 'decider',
+			'Unknown map veto type "' .. vetoType ..
+				'". Expected a comma-separated list using only: pick, ban, decider, default. ' ..
+				'Example: pick,ban,decider,default'
+		)
 
 		if vetoType == 'pick' or vetoType == 'ban' then
 			table.insert(lines,

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -56,14 +56,14 @@ function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 		'{{Match',
 		matchIndex == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
+		numberOfCasters ~= 0 and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
 			return INDENT .. '|caster' .. casterIndex .. '='
 		end) or {},
 		Logic.readBool(args.hasVod) and (INDENT .. '|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Logic.readBool(args.hasGlobalBans) and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
+		numberOfGlobalBans ~= 0 and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
 	)
 
 	Array.extendWith(lines, WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto))

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -179,7 +179,7 @@ function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 end
 
 ---@param numberOfOpponents integer
----@param globals integer
+---@param numberOfGlobals integer
 ---@return string[]
 function WikiCopyPaste._globalBanParams(numberOfOpponents, numberOfGlobals)
 	return {

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -49,15 +49,24 @@ local INDENT = WikiCopyPaste.Indent
 ---@return string
 function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 	local showScore = Logic.readBool(args.score)
+	local casters = tonumber(args.casters) or 2
+	local globals = tonumber(args.globals) or 2
 
 	local lines = Array.extend(
 		'{{Match',
 		matchIndex == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
+		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, casters), function(casterNumber)
+			return INDENT .. '|caster' .. casterNumber .. '=|caster' .. casterNumber .. 'flag='
+		end) or {},
+		Logic.readBool(args.hasCasters) and (INDENT .. '|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
-		end)
+		end),
+		Logic.readBool(args.hasGlobals) and WikiCopyPaste._globalBanParams(opponents, globals) or {}
 	)
+
+	Array.extendWith(lines, WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto))
 
 	Array.forEach(Array.range(1, bestof), function(mapIndex)
 		Array.extendWith(lines, WikiCopyPaste._getMapCode(args, matchIndex, opponents, mapIndex))
@@ -94,6 +103,67 @@ function WikiCopyPaste._getMapCode(args, matchIndex, numberOfOpponents, mapIndex
 	return Array.append(lines, INDENT .. '}}')
 end
 
+---@param mapVeto string
+---@param customVeto string
+---@return string[]
+function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
+	if mapVeto == 'none' then
+		return {}
+	end
+
+	assert(
+		mapVeto ~= 'custom' or String.isNotEmpty(customVeto),
+		'Custom map veto is empty. Example: pick,ban,decider,default'
+	)
+
+	local vetoTypes = mapVeto == 'custom' and customVeto or mapVeto
+	vetoTypes = string.gsub(vetoTypes, '%-', ',')
+
+	local types = Array.map(String.split(vetoTypes, ','), function(vetoType)
+		return String.trim(vetoType)
+	end)
+	vetoTypes = table.concat(types, ',')
+
+	local lines = {
+		INDENT .. '|mapveto={{MapVeto',
+		INDENT .. INDENT .. '|firstpick=1',
+		INDENT .. INDENT .. '|types=' .. vetoTypes,
+	}
+
+	local mapNumber = 1
+	local deciderAdded = false
+
+	Array.forEach(types, function(vetoType)
+		vetoType = String.trim(vetoType)
+
+			assert(
+				vetoType == 'pick'
+					or vetoType == 'ban'
+					or vetoType == 'default'
+					or vetoType == 'decider',
+				'Unknown map veto type "' .. vetoType ..
+					'". Expected a comma-separated list using only: pick, ban, decider, default. ' ..
+					'Example: pick,ban,decider,default'
+			)
+
+		if vetoType == 'pick' or vetoType == 'ban' then
+			table.insert(lines,
+				INDENT .. INDENT .. '|t1map' .. mapNumber .. '=|t2map' .. mapNumber .. '='
+			)
+			mapNumber = mapNumber + 1
+		elseif vetoType == 'default' or vetoType == 'decider' then
+			if not deciderAdded then
+				table.insert(lines, INDENT .. INDENT .. '|decider=')
+				deciderAdded = true
+			end
+		end
+	end)
+
+	table.insert(lines, INDENT .. '}}')
+
+	return lines
+end
+
 ---@param key string
 ---@param numberOfOpponents integer
 ---@return string[]
@@ -106,6 +176,19 @@ function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 			return '|t' .. opponentIndex .. shortKey .. keyIndex .. '='
 		end))
 	end)
+end
+
+---@param numberOfOpponents integer
+---@param globals integer
+---@return string[]
+function WikiCopyPaste._globalBanParams(numberOfOpponents, numberOfGlobals)
+	return {
+		INDENT .. table.concat(Array.map(Array.range(1, numberOfOpponents), function(opponentIndex)
+			return table.concat(Array.map(Array.range(1, numberOfGlobals), function(globalIndex)
+				return '|t' .. opponentIndex .. 'b' .. globalIndex .. '='
+			end))
+		end))
+	}
 end
 
 return WikiCopyPaste

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -56,14 +56,14 @@ function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 		'{{Match',
 		matchIndex == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		numberOfCasters ~= 0 and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
+		numberOfCasters > 0 and Array.mapRange(1, numberOfCasters, function(casterIndex)
 			return INDENT .. '|caster' .. casterIndex .. '='
 		end) or {},
 		Logic.readBool(args.hasVod) and (INDENT .. '|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		numberOfGlobalBans ~= 0 and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
+		numberOfGlobalBans > 0 and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
 	)
 
 	Array.extendWith(lines, WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto))
@@ -167,8 +167,8 @@ function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 	local shortKey = PARAM_TO_SHORT[key]
 	local limit = LIMIT_OF_PARAM[key]
 
-	return Array.map(Array.range(1, numberOfOpponents), function(opponentIndex)
-		return INDENT .. INDENT .. table.concat(Array.map(Array.range(1, limit), function(keyIndex)
+	return Array.mapRange(1, numberOfOpponents, function(opponentIndex)
+		return INDENT .. INDENT .. table.concat(Array.mapRange(1, limit, function(keyIndex)
 			return '|t' .. opponentIndex .. shortKey .. keyIndex .. '='
 		end))
 	end)
@@ -179,8 +179,8 @@ end
 ---@return string[]
 function WikiCopyPaste._globalBanParams(numberOfOpponents, numberOfGlobals)
 	return {
-		INDENT .. table.concat(Array.map(Array.range(1, numberOfOpponents), function(opponentIndex)
-			return table.concat(Array.map(Array.range(1, numberOfGlobals), function(globalIndex)
+		INDENT .. table.concat(Array.mapRange(1, numberOfOpponents, function(opponentIndex)
+			return table.concat(Array.mapRange(1, numberOfGlobals, function(globalIndex)
 				return '|t' .. opponentIndex .. 'b' .. globalIndex .. '='
 			end))
 		end))

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -59,7 +59,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
 			return INDENT .. '|caster' .. casterIndex .. '='
 		end) or {},
-		Logic.readBool(args.hasCasters) and (INDENT .. '|vod=') or nil,
+		Logic.readBool(args.hasVod) and (INDENT .. '|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -57,7 +57,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 		matchIndex == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
 		Logic.readBool(args.hasCasters) and Array.map(Array.range(1, numberOfCasters), function(casterIndex)
-			return INDENT .. '|caster' .. casterIndex .. '=|caster' .. casterIndex .. 'flag='
+			return INDENT .. '|caster' .. casterIndex .. '='
 		end) or {},
 		Logic.readBool(args.hasCasters) and (INDENT .. '|vod=') or nil,
 		Array.map(Array.range(1, opponents), function(opponentIndex)

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -63,10 +63,9 @@ function WikiCopyPaste.getMatchCode(bestof, mode, matchIndex, opponents, args)
 		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		numberOfGlobalBans > 0 and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {}
+		numberOfGlobalBans > 0 and WikiCopyPaste._globalBanParams(opponents, numberOfGlobalBans) or {},
+		WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto)
 	)
-
-	Array.extendWith(lines, WikiCopyPaste._getMapVetoCode(args.mapVeto, args.customVeto))
 
 	Array.forEach(Array.range(1, bestof), function(mapIndex)
 		Array.extendWith(lines, WikiCopyPaste._getMapCode(args, matchIndex, opponents, mapIndex))
@@ -146,11 +145,10 @@ function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
 				INDENT .. INDENT .. '|t1map' .. mapNumber .. '=|t2map' .. mapNumber .. '='
 			)
 			mapNumber = mapNumber + 1
-		elseif vetoType == 'default' or vetoType == 'decider' then
-			if not deciderAdded then
-				table.insert(lines, INDENT .. INDENT .. '|decider=')
-				deciderAdded = true
-			end
+		end
+		if not deciderAdded then
+			table.insert(lines, INDENT .. INDENT .. '|decider=')
+			deciderAdded = true
 		end
 	end)
 
@@ -174,12 +172,12 @@ function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 end
 
 ---@param numberOfOpponents integer
----@param numberOfGlobals integer
+---@param numberOfGlobalBans integer
 ---@return string[]
-function WikiCopyPaste._globalBanParams(numberOfOpponents, numberOfGlobals)
+function WikiCopyPaste._globalBanParams(numberOfOpponents, numberOfGlobalBans)
 	return {
 		INDENT .. table.concat(Array.mapRange(1, numberOfOpponents, function(opponentIndex)
-			return table.concat(Array.mapRange(1, numberOfGlobals, function(globalIndex)
+			return table.concat(Array.mapRange(1, numberOfGlobalBans, function(globalIndex)
 				return '|t' .. opponentIndex .. 'b' .. globalIndex .. '='
 			end))
 		end))

--- a/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlstars/GetMatchGroupCopyPaste/wiki.lua
@@ -104,7 +104,7 @@ function WikiCopyPaste._getMapCode(args, matchIndex, numberOfOpponents, mapIndex
 end
 
 ---@param mapVeto string
----@param customVeto string
+---@param customVeto string?
 ---@return string[]
 function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
 	if mapVeto == 'none' then
@@ -120,7 +120,6 @@ function WikiCopyPaste._getMapVetoCode(mapVeto, customVeto)
 	vetoTypes = string.gsub(vetoTypes, '%-', ',')
 
 	local types = Array.parseCommaSeparatedString(vetoTypes)
-	vetoTypes = table.concat(types, ',')
 
 	local lines = {
 		INDENT .. '|mapveto={{MapVeto',


### PR DESCRIPTION
## Summary

Our wiki have many params which not used in CopyPaste generators so I added support to:
- New Global Bans feature
- Casters
- VODs
- MapVeto (some main values + custom input)

## How did you test this change?

dev
https://liquipedia.net/brawlstars/Special:RunQuery/BracketCopyPaste/polandbot
https://liquipedia.net/brawlstars/Special:RunQuery/MatchListCopyPaste/polandbot