### PR TITLE
feat: add option to allow nil inputs in team displays

### DIFF
--- a/lua/wikis/commons/Widget/TeamDisplay/Block.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Block.lua
@@ -29,11 +29,16 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field style teamStyle
 ---@field dq boolean?
 ---@field note string|number?
+---@field nilIfEmpty boolean? only for usage from wikicode
 
 local BlockTeamWidget = {}
 
 ---@param props BlockTeamParameters
+---@return VNode?
 function BlockTeamWidget.render(props)
+	if Logic.readBool(props.nilIfEmpty) and (not props.teamTemplate) and (not props.name) then
+		return
+	end
 	local teamTemplate = props.teamTemplate or TeamTemplate.getRawOrNil(props.name, props.date)
 
 	if not teamTemplate then

--- a/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
+++ b/lua/wikis/commons/Widget/TeamDisplay/Inline.lua
@@ -56,13 +56,17 @@ local TEAM_INLINE_TYPES = {
 ---@field teamTemplate teamTemplateData?
 ---@field flip boolean?
 ---@field displayType teamStyle
+---@field nilIfEmpty boolean? only for usage from wikicode
 
 local TeamInlineWidget = {}
 
 ---@param props TeamInlineParameters
----@return VNode
+---@return VNode?
 function TeamInlineWidget.render(props)
 	local displayType = assert(TEAM_INLINE_TYPES[props.displayType], 'Invalid display type')
+	if Logic.readBool(props.nilIfEmpty) and (not props.teamTemplate) and (not props.name) then
+		return
+	end
 	local teamTemplate = props.teamTemplate or TeamTemplate.getRawOrNil(props.name, props.date)
 	if not teamTemplate then
 		mw.ext.TeamLiquidIntegration.add_category('Pages with missing team templates')


### PR DESCRIPTION
## Summary
if we want to be able to use them from wiki code we need to add an option to suppress the `Missing template for team=nil` errors...

alternative solution 1: return nil upon nil input generally
alternative solution 2: let the template do the empty check

## How did you test this change?
https://liquipedia.net/starcraft2/User:Hjpalpha/wip22

before:
<img width="1329" height="343" alt="image" src="https://github.com/user-attachments/assets/5be43d77-9c1d-438c-b7ec-50847edbf92d" />

after:
<img width="1353" height="338" alt="image" src="https://github.com/user-attachments/assets/7a9f2404-23be-4207-bcfb-07aa1e013424" />