### PR TITLE
feat: add ENC Team History to RL Infobox

### DIFF
--- a/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
@@ -131,7 +131,8 @@ function CustomInjector:parse(id, widgets)
 			getHistoryCells('history_gfinity', '[[Gfinity/Elite_Series|Gfinity Elite Series]] History'),
 			getHistoryCells('history_odl', '[[Oceania Draft League|Oceania Draft League]] History'),
 			getHistoryCells('history_irc', '[[Italian Rocket Championship]] History'),
-			getHistoryCells('history_elite_series', '[[Elite Series]] History')
+			getHistoryCells('history_elite_series', '[[Elite Series]] History'),
+			getHistoryCells('history_enc', '[[Esports Nations Cup]] History')
 		)
 	elseif id == 'nationality' then
 		return {


### PR DESCRIPTION
Players are wanting ENC nation  history shown like FIFAe is on their pages 

Tested: https://liquipedia.net/rocketleague/User:Reidthesloth/ENC/Player_Card/Test

Test Module: https://liquipedia.net/rocketleague/Module:Infobox/Person/Player/Custom/dev/Reidthesloth (can be nuked after if needed)