### PR TITLE
feat(infobox): collapse Team History in person infoboxes

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -12,7 +12,10 @@ local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local TeamHistoryAuto = Lua.import('Module:Infobox/Extension/TeamHistory/Auto')
 
+local CollapsibleToggle = Lua.import('Module:Widget/GeneralCollapsible/Toggle')
+local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local Html = Lua.import('Module:Widget/Html')
+local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Widget = Lua.import('Module:Widget')
 local Widgets = Lua.import('Module:Widget/All')
 
@@ -43,9 +46,27 @@ function TeamHistory:render()
 		return {}
 	end
 
-	return {
-		Widgets.Title{children = 'History'},
-		Widgets.Center{children = {teamHistory}},
+	return GeneralCollapsible{
+		shouldCollapse = true,
+		titleWidget = Widgets.Title{
+			children = {
+				'Team History',
+				'&nbsp;',
+				CollapsibleToggle{
+					showButtonChildren = {
+						'Expand',
+						' ',
+						Icon{iconName = 'expand'}
+					},
+					hideButtonChildren = {
+						'Collapse',
+						' ',
+						Icon{iconName = 'collapse'}
+					}
+				}
+			},
+		},
+		children = Widgets.Center{children = {teamHistory}},
 	}
 end
 


### PR DESCRIPTION
still to be discussed if wanted

## Summary
as per idea in #7830

## How did you test this change?
dev

before:
<img width="371" height="499" alt="image" src="https://github.com/user-attachments/assets/065da7f6-cb81-4ead-b14f-bb32e1fecce8" />

after - collapsed:
<img width="398" height="260" alt="image" src="https://github.com/user-attachments/assets/fe0f3d61-489a-4825-b737-f9cbafd41764" />

after - expanded:
<img width="392" height="585" alt="image" src="https://github.com/user-attachments/assets/c7f6974f-11a4-4773-8d95-47154a02a04b" />
