### PR TITLE
feat(infobox): collapsible team history display

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -12,10 +12,8 @@ local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local TeamHistoryAuto = Lua.import('Module:Infobox/Extension/TeamHistory/Auto')
 
-local CollapsibleToggle = Lua.import('Module:Widget/GeneralCollapsible/Toggle')
 local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local Html = Lua.import('Module:Widget/Html')
-local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Widget = Lua.import('Module:Widget')
 local Widgets = Lua.import('Module:Widget/All')
 
@@ -38,7 +36,7 @@ local DEFAULT_MODE = 'manual'
 ---@field props {player: string, manualInput: string?}
 local TeamHistory = Class.new(Widget)
 
----@return Widget[]
+---@return VNode[]
 function TeamHistory:render()
 	local teamHistory = self:_getHistory()
 
@@ -49,21 +47,9 @@ function TeamHistory:render()
 	return GeneralCollapsible{
 		shouldCollapse = true,
 		titleWidget = Widgets.Title{
+			isCollapsibleToggle = true,
 			children = {
 				'Team History',
-				'&nbsp;',
-				CollapsibleToggle{
-					showButtonChildren = {
-						'Expand',
-						' ',
-						Icon{iconName = 'expand'}
-					},
-					hideButtonChildren = {
-						'Collapse',
-						' ',
-						Icon{iconName = 'collapse'}
-					}
-				}
 			},
 		},
 		children = Widgets.Center{children = {teamHistory}},

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -36,12 +36,12 @@ local DEFAULT_MODE = 'manual'
 ---@field props {player: string, manualInput: string?}
 local TeamHistory = Class.new(Widget)
 
----@return VNode[]
+---@return VNode?
 function TeamHistory:render()
 	local teamHistory = self:_getHistory()
 
 	if Logic.isEmpty(teamHistory) then
-		return {}
+		return
 	end
 
 	return GeneralCollapsible{

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -56,7 +56,7 @@ function TeamHistory:render()
 	}
 end
 
----@return Widget|string?
+---@return Renderable?
 function TeamHistory:_getHistory()
 	local config = (Info.config.infoboxPlayer or {}).automatedHistory or {}
 	local manualInput = self.props.manualInput

--- a/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
+++ b/lua/wikis/commons/Widget/Infobox/TeamHistory.lua
@@ -12,7 +12,10 @@ local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
 local TeamHistoryAuto = Lua.import('Module:Infobox/Extension/TeamHistory/Auto')
 
+local CollapsibleToggle = Lua.import('Module:Widget/GeneralCollapsible/Toggle')
+local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local Html = Lua.import('Module:Widget/Html')
+local Icon = Lua.import('Module:Widget/Image/Icon/Fontawesome')
 local Widget = Lua.import('Module:Widget')
 local Widgets = Lua.import('Module:Widget/All')
 
@@ -43,9 +46,27 @@ function TeamHistory:render()
 		return {}
 	end
 
-	return {
-		Widgets.Title{children = 'History'},
-		Widgets.Center{children = {teamHistory}},
+	return GeneralCollapsible{
+		shouldCollapse = true,
+		titleWidget = Widgets.Title{
+			children = {
+				'Team History',
+				'&nbsp;',
+				CollapsibleToggle{
+					showButtonChildren = {
+						'Expand',
+						' ',
+						Icon{iconName = 'expand'}
+					},
+					hideButtonChildren = {
+						'Collapse',
+						' ',
+						Icon{iconName = 'collapse'}
+					}
+				}
+			},
+		},
+		children = Widgets.Center{children = {teamHistory}},
 	}
 end
 

--- a/lua/wikis/commons/Widget/Infobox/Title.lua
+++ b/lua/wikis/commons/Widget/Infobox/Title.lua
@@ -7,16 +7,37 @@
 
 local Lua = require('Module:Lua')
 
+local ChevronToggle = Lua.import('Module:Widget/GeneralCollapsible/ChevronToggle')
 local Component = Lua.import('Module:Widget/Component')
 local Html = Lua.import('Module:Widget/Html')
+local WidgetUtil = Lua.import('Module:Widget/Util')
 
----@param props {children: Renderable|Renderable[]?}
+---@class InfoboxTitleProps
+---@field isCollapsibleToggle boolean?
+---@field children Renderable|Renderable[]?
+
+---@param props InfoboxTitleProps
 ---@return VNode
 local function Title(props)
-	return Html.Div{children = {Html.Div{
-		children = props.children,
-		classes = {'infobox-header', 'wiki-backgroundcolor-light', 'infobox-header-2'}
-	}}}
+	if props.isCollapsibleToggle then
+		return Html.Div{
+			attributes = {
+				['data-collapsible-click-region'] = 'true'
+			},
+			children = WidgetUtil.collect(
+				props.children,
+				ChevronToggle{}
+			),
+			classes = {'infobox-header', 'wiki-backgroundcolor-light', 'infobox-header-2'}
+		}
+	end
+
+	return Html.Div{
+		children = Html.Div{
+			children = props.children,
+			classes = {'infobox-header', 'wiki-backgroundcolor-light', 'infobox-header-2'}
+		}
+	}
 end
 
 return Component.component(Title)


### PR DESCRIPTION
## Summary

Inspired by #7831

This PR makes the team history displays on player infoboxes collapsible.

## How did you test this change?

preview with dev

collapsed:
<img width="351" height="150" alt="image" src="https://github.com/user-attachments/assets/0bdf166e-27b1-4f02-87a8-e53dd25741fd" />
expanded:
<img width="349" height="377" alt="image" src="https://github.com/user-attachments/assets/ad3677eb-7989-49ed-9b91-3c6bee26d986" />
