### PR TITLE
feat(match2): damage dealt graphs in LoL matchpages

### DIFF
--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -589,7 +589,7 @@ function MatchPage:_renderPlayersPerformance(game)
 				self:_renderTeamPerformance(game, 2)
 			}
 		},
-		self:_renderDamageDistribution(game)
+		self:_renderDamageDealt(game)
 	)
 end
 
@@ -763,14 +763,14 @@ end)
 ---@private
 ---@param game LoLMatchPageGame
 ---@return VNode[]?
-function MatchPage:_renderDamageDistribution(game)
+function MatchPage:_renderDamageDealt(game)
 	if not game.finished or Array.any(game.teams, function (team)
 		return Logic.isDeepEmpty(team.players)
 	end) then
 		return
 	end
 	return {
-		Html.H4{children = 'Damage Distribution'},
+		Html.H4{children = 'Damage Dealt'},
 		Html.Div{
 			classes = {'table-responsive'},
 			css = {

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -749,6 +749,18 @@ function MatchPage._buildPlayerLoadout(player)
 	}
 end
 
+---@param side 'red'|'blue'
+---@return string
+---@overload fun(side: nil): nil
+local function sideToColor(side)
+	if side == 'red' then
+		return '#b12a2a'
+	elseif side == 'blue' then
+		return '#31519c'
+	end
+	return nil
+end
+
 ---@private
 ---@param game LoLMatchPageGame
 function MatchPage:_renderDamageDistribution(game)
@@ -778,7 +790,10 @@ function MatchPage:_renderDamageDistribution(game)
 					type = 'bar',
 					data = Array.map(team.players, function (player)
 						return player.damagedone
-					end)
+					end),
+					itemStyle = {
+						color = sideToColor(team.side)
+					}
 				}
 			end),
 		}

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -588,7 +588,9 @@ function MatchPage:_renderPlayersPerformance(game)
 				self:_renderTeamPerformance(game, 1),
 				self:_renderTeamPerformance(game, 2)
 			}
-		}
+		},
+		Html.H4{children = 'Damage Distribution'},
+		self:_renderDamageDistribution(game)
 	}
 end
 
@@ -743,6 +745,42 @@ function MatchPage._buildPlayerLoadout(player)
 				classes = {'match-bm-players-player-loadout-items'},
 				children = Array.map(player.items, MatchPage._generateItemImage)
 			}
+		}
+	}
+end
+
+---@private
+---@param game LoLMatchPageGame
+function MatchPage:_renderDamageDistribution(game)
+	return Html.Div{
+		classes = {'table-responsive'},
+		css = {
+			width = '100%'
+		},
+		children = mw.ext.Charts.chart{
+			size = {
+				width = 640,
+				height = 480
+			},
+			tooltip = {
+				trigger = 'axis'
+			},
+			xAxis = {
+				data = {'Top', 'Jungle', 'Mid', 'Bot', 'Support'},
+				type = 'category',
+			},
+			yAxis = {
+				name = 'Damage dealt',
+				type = 'value',
+			},
+			series = Array.map(game.teams, function (team)
+				return {
+					type = 'bar',
+					data = Array.map(team.players, function (player)
+						return player.damagedone
+					end)
+				}
+			end),
 		}
 	}
 end

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -580,7 +580,7 @@ end
 ---@param game LoLMatchPageGame
 ---@return VNode[]
 function MatchPage:_renderPlayersPerformance(game)
-	return {
+	return WidgetUtil.collect(
 		Html.H3{children = 'Player Performance'},
 		Div{
 			classes = {'match-bm-players-wrapper'},
@@ -589,9 +589,8 @@ function MatchPage:_renderPlayersPerformance(game)
 				self:_renderTeamPerformance(game, 2)
 			}
 		},
-		Html.H4{children = 'Damage Distribution'},
 		self:_renderDamageDistribution(game)
-	}
+	)
 end
 
 ---@private
@@ -752,50 +751,59 @@ end
 ---@param side 'red'|'blue'
 ---@return string
 ---@overload fun(side: nil): nil
-local function sideToColor(side)
+local sideToColor = FnUtil.memoize(function (side)
 	if side == 'red' then
 		return '#b12a2a'
 	elseif side == 'blue' then
 		return '#31519c'
 	end
 	return nil
-end
+end)
 
 ---@private
 ---@param game LoLMatchPageGame
+---@return VNode[]?
 function MatchPage:_renderDamageDistribution(game)
-	return Html.Div{
-		classes = {'table-responsive'},
-		css = {
-			width = '100%'
-		},
-		children = mw.ext.Charts.chart{
-			size = {
-				width = 640,
-				height = 480
+	if not game.finished or Array.any(game.teams, function (team)
+		return Logic.isDeepEmpty(team.players)
+	end) then
+		return
+	end
+	return {
+		Html.H4{children = 'Damage Distribution'},
+		Html.Div{
+			classes = {'table-responsive'},
+			css = {
+				width = '100%'
 			},
-			tooltip = {
-				trigger = 'axis'
-			},
-			xAxis = {
-				data = {'Top', 'Jungle', 'Mid', 'Bot', 'Support'},
-				type = 'category',
-			},
-			yAxis = {
-				name = 'Damage dealt',
-				type = 'value',
-			},
-			series = Array.map(game.teams, function (team)
-				return {
-					type = 'bar',
-					data = Array.map(team.players, function (player)
-						return player.damagedone
-					end),
-					itemStyle = {
-						color = sideToColor(team.side)
+			children = mw.ext.Charts.chart{
+				size = {
+					width = 640,
+					height = 480
+				},
+				tooltip = {
+					trigger = 'axis'
+				},
+				xAxis = {
+					data = {'Top', 'Jungle', 'Mid', 'Bot', 'Support'},
+					type = 'category',
+				},
+				yAxis = {
+					name = 'Damage dealt',
+					type = 'value',
+				},
+				series = Array.map(game.teams, function (team)
+					return {
+						type = 'bar',
+						data = Array.map(team.players, function (player)
+							return player.damagedone
+						end),
+						itemStyle = {
+							color = sideToColor(team.side)
+						}
 					}
-				}
-			end),
+				end),
+			}
 		}
 	}
 end

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -81,6 +81,13 @@ local ROLES = Array.map(
 	Operator.property('display')
 )
 
+local SIDE_COLORS = {
+	-- clr-cinnabar-40
+	red = '#b81414',
+	-- clr-sapphire-40
+	blue = '#0d71bf',
+}
+
 local DEFAULT_ITEM = 'EmptyIcon'
 local LOADOUT_ICON_SIZE = '64px'
 local ITEMS_TO_SHOW = 6
@@ -753,20 +760,6 @@ function MatchPage._buildPlayerLoadout(player)
 	}
 end
 
----@param side 'red'|'blue'
----@return string
----@overload fun(side: nil): nil
-local sideToColor = FnUtil.memoize(function (side)
-	if side == 'red' then
-		-- clr-cinnabar-40
-		return '#b81414'
-	elseif side == 'blue' then
-		-- clr-sapphire-40
-		return '#0d71bf'
-	end
-	return nil
-end)
-
 ---@private
 ---@param game LoLMatchPageGame
 ---@return VNode[]?
@@ -806,7 +799,7 @@ function MatchPage:_renderDamageDealt(game)
 							return player.damagedone
 						end),
 						itemStyle = {
-							color = sideToColor(team.side)
+							color = SIDE_COLORS[team.side]
 						}
 					}
 				end),

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -76,6 +76,11 @@ local KEYSTONES = Table.map({
 	return value, true
 end)
 
+local ROLES = Array.map(
+	Array.sortBy(Array.unique(Array.extractValues(InGameRoles)), Operator.property('sortOrder')),
+	Operator.property('display')
+)
+
 local DEFAULT_ITEM = 'EmptyIcon'
 local LOADOUT_ICON_SIZE = '64px'
 local ITEMS_TO_SHOW = 6
@@ -787,7 +792,7 @@ function MatchPage:_renderDamageDealt(game)
 					trigger = 'axis'
 				},
 				xAxis = {
-					data = {'Top', 'Jungle', 'Mid', 'Bot', 'Support'},
+					data = ROLES,
 					type = 'category',
 				},
 				yAxis = {

--- a/lua/wikis/leagueoflegends/MatchPage.lua
+++ b/lua/wikis/leagueoflegends/MatchPage.lua
@@ -753,9 +753,11 @@ end
 ---@overload fun(side: nil): nil
 local sideToColor = FnUtil.memoize(function (side)
 	if side == 'red' then
-		return '#b12a2a'
+		-- clr-cinnabar-40
+		return '#b81414'
 	elseif side == 'blue' then
-		return '#31519c'
+		-- clr-sapphire-40
+		return '#0d71bf'
 	end
 	return nil
 end)


### PR DESCRIPTION
## Summary

Inspiration: https://discord.com/channels/93055209017729024/276340346831765504/1529080963597074462

This PR adds damage dealt graphs to each game in LoL match pages.

## How did you test this change?

<https://liquipedia.net/leagueoflegends/Match:ID_User_ElectricalBoy_zqx7pe0nDj_R01-M001>