### PR TITLE
fix(prizepool): imported placements incorrectly use default date without fallback

### DIFF
--- a/lua/wikis/commons/PrizePool/Import.lua
+++ b/lua/wikis/commons/PrizePool/Import.lua
@@ -337,7 +337,7 @@ end
 ---@return {date: string, matchId: string, opponent: standardOpponent?, vsOpponent: standardOpponent?}
 function Import._makeEntryFromMatch(placementEntry, match)
 	local entry = {
-		date = DateExt.nilIfDefaultTimestamp(match.date) or DateExt.getContextualDate(),
+		date = match.date,
 		matchId = match.matchId,
 	}
 
@@ -732,7 +732,7 @@ end
 ---@param entry BasePlacementOpponent
 ---@return BasePlacementOpponent
 function Import._removeDefaultDate(entry)
-	local date = DateExt.nilIfDefaultTimestamp(entry.date)
+	local date = DateExt.nilIfDefaultTimestamp(entry.date) or DateExt.getContextualDate()
 	---as input was not integer can not get integer back
 	---@cast date -integer
 	entry.date = date

--- a/lua/wikis/commons/PrizePool/Import.lua
+++ b/lua/wikis/commons/PrizePool/Import.lua
@@ -337,7 +337,7 @@ end
 ---@return {date: string, matchId: string, opponent: standardOpponent?, vsOpponent: standardOpponent?}
 function Import._makeEntryFromMatch(placementEntry, match)
 	local entry = {
-		date = match.date,
+		date = DateExt.nilIfDefaultTimestamp(match.date) or DateExt.getContextualDate(),
 		matchId = match.matchId,
 	}
 


### PR DESCRIPTION
## Summary

Fixes #7835

## How did you test this change?

preview with dev (with extra log outputs)