### PR TITLE
chore: move deploy cookie storage to subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /luacov.stats.out
 **/__pycache__/
 .env
-*.ck
+**/*.ck

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/cookies
 /node_modules
 /lua/output
 /lua/spec/snapshots/diffs

--- a/scripts/mediawiki_session.py
+++ b/scripts/mediawiki_session.py
@@ -45,7 +45,7 @@ class MediaWikiSession(contextlib.AbstractContextManager):
         self.__session.headers.update(HEADER)
 
     def __read_cookie_jar(self) -> http.cookiejar.FileCookieJar:
-        ckf = f"cookie_{self.wiki}.ck"
+        ckf = f"cookies/cookie_{self.wiki}.ck"
         cookie_jar = http.cookiejar.LWPCookieJar(filename=ckf)
         with contextlib.suppress(OSError):
             cookie_jar.load(ignore_discard=True)


### PR DESCRIPTION
## Summary

Cookies from deploy scripts are currently saved in the root directory of the repository. This PR moves them to `cookies/` subdirectory to keep the root directory clean.

This does not affect contents of the repository as the cookie files are already being filtered with `gitignore`.

## How did you test this change?

trivial