### PR TITLE
refactor: remove mw.html dependency from Html.Fragment

### DIFF
--- a/lua/wikis/commons/Widget/Html.lua
+++ b/lua/wikis/commons/Widget/Html.lua
@@ -48,7 +48,13 @@ Html.Em = ComponentCore.tag('em')
 Html.Figcaption = ComponentCore.tag('figcaption')
 Html.Figure = ComponentCore.tag('figure')
 Html.Font = ComponentCore.tag('font')
-Html.Fragment = ComponentCore.tag('fragment')
+Html.Fragment = ComponentCore.component(
+	---@param props HtmlNodeProps
+	---@return Renderable|Renderable[]?
+	function(props)
+		return props.children
+	end
+)
 Html.H1 = ComponentCore.tag('h1')
 Html.H2 = ComponentCore.tag('h2')
 Html.H3 = ComponentCore.tag('h3')

--- a/lua/wikis/commons/Widget/Renderer.lua
+++ b/lua/wikis/commons/Widget/Renderer.lua
@@ -106,12 +106,7 @@ function Renderer.render(vNode, context)
 		---@cast vNode HtmlNode
 		local props = vNode.props
 		local tagName = renderFn
-		local tag
-		if tagName == 'fragment' then
-			tag = mw.html.create()
-		else
-			tag = mw.html.create(tagName)
-		end
+		local tag = mw.html.create(tagName)
 
 		if props.classes then
 			tag:addClass(table.concat(props.classes, ' '))


### PR DESCRIPTION
## Summary

`Html.Fragment` is a thin container of its children that requires no extra processing, i.e., it can be implemented as a simple render function that directly returns its `children`.

## How did you test this change?

busted