### PR TITLE
fix(TeamParticipants): store secured points in placement extradata

### DIFF
--- a/lua/spec/team_participant_spec.lua
+++ b/lua/spec/team_participant_spec.lua
@@ -1051,6 +1051,46 @@ describe('Team Participants Repository', function()
 				assert.are_same({'Team Liquid', 'Team BDS'}, extradata.potentialQualifiers)
 			end)
 
+			it('stores minimum_secured as securedpoints when no prizepool record exists', function()
+				Variables.varDefine('minimum_secured', '1')
+
+				TeamParticipantsRepository.save(createBasicParticipant())
+
+				local data = Json.parseIfString(LpdbPlacementStore.calls[1].vals[2])
+				local extradata = Json.parseIfString(data.extradata)
+
+				Variables.varDefine('minimum_secured', nil)
+
+				assert.are_equal('1', extradata.securedpoints)
+			end)
+
+			it('does not overwrite real prizepoints with securedpoints', function()
+				Variables.varDefine('minimum_secured', '1')
+
+				local getRecordsStub = stub(TeamParticipantsRepository, 'getPrizepoolRecordsForTeam')
+				getRecordsStub.returns({createPrizepoolRecord({extradata = {prizepoints = 20}})})
+
+				TeamParticipantsRepository.save(createBasicParticipant())
+
+				local data = Json.parseIfString(LpdbPlacementStore.calls[1].vals[2])
+				local extradata = Json.parseIfString(data.extradata)
+
+				getRecordsStub:revert()
+				Variables.varDefine('minimum_secured', nil)
+
+				assert.are_equal(20, extradata.prizepoints)
+				assert.is_nil(extradata.securedpoints)
+			end)
+
+			it('stores no securedpoints when minimum_secured is unset', function()
+				TeamParticipantsRepository.save(createBasicParticipant())
+
+				local data = Json.parseIfString(LpdbPlacementStore.calls[1].vals[2])
+				local extradata = Json.parseIfString(data.extradata)
+
+				assert.is_nil(extradata.securedpoints)
+			end)
+
 			it('excludes staff when splitting prizemoney (subs still count)', function()
 				local getRecordsStub = stub(TeamParticipantsRepository, 'getPrizepoolRecordsForTeam')
 				getRecordsStub.returns({createPrizepoolRecord({prizemoney = 6000, opponenttemplate = 'bds'})})

--- a/lua/wikis/commons/TeamParticipants/Repository.lua
+++ b/lua/wikis/commons/TeamParticipants/Repository.lua
@@ -137,6 +137,13 @@ function TeamParticipantsRepository.save(participant)
 				local serializedQualifiers = Array.map(participant.potentialQualifiers, Opponent.toName)
 				lpdbData.extradata.potentialQualifiers = serializedQualifiers
 			end
+
+			-- Store the guaranteed minimum points (set by Module:PrizePool) for display in
+			-- Module:AutomaticPointsTable, without overwriting real prize points.
+			local minimumSecured = Variables.varDefault('minimum_secured')
+			if Logic.isNotEmpty(minimumSecured) and Logic.isEmpty(lpdbData.extradata.prizepoints) then
+				lpdbData.extradata.securedpoints = minimumSecured
+			end
 		end
 
 		mw.ext.LiquipediaDB.lpdb_placement(lpdbData.objectName, Json.stringifySubTables(lpdbData))


### PR DESCRIPTION
Restore `securedpoints` by copying the `minimum_secured` wiki variable into extradata, without overwriting real prize points. Fixes ranking pages showing "null" points (nothing) for ongoing tournaments.

## Summary

The `TeamCard` → `TeamParticipants` migration dropped the step that copied the `minimum_secured` wiki variable into `extradata.securedpoints`. Nothing writes `securedpoints` anymore, yet `Module:AutomaticPointsTable` still reads it. So ranking pages show empty cells for **ongoing** tournaments (while placements are TBD and no `prizepoints` exist yet). Resolved tournaments look fine because `prizepoints` takes over.

This restores the behaviour generically in commons `Repository.save()`: copy `minimum_secured` (set by `Module:PrizePool`) into `extradata.securedpoints`, guarded so it never overwrites real `prizepoints`. The single commons implementation covers every possible affected wiki.

## How did you test this change?

- [Dev  page (commons)](https://liquipedia.net/commons/Module:TeamParticipants/Repository/dev/Dyl_m)
- Tests on ongoing Rocket League tournaments with Point Systems:
  - **Polish Rocket Series** : [Rankings](https://liquipedia.net/rocketleague/All_Stars/Polish_Rocket_Series/Rankings) + ongoing [July Open](https://liquipedia.net/rocketleague/All_Stars/Polish_Rocket_Series/July_Open)
  - **BFBS Pro League Season 2** : [Rankings](https://liquipedia.net/rocketleague/BFBS_Esports/BFBS_Pro_League/Season_2/Rankings) + ongoing [Event 2](https://liquipedia.net/rocketleague/BFBS_Esports/BFBS_Pro_League/Season_2/Main_Event/2)

And 3 cases added to the `save` block in `team_participant_spec.lua`