### PR TITLE
fix: Only use localstorage filter when button exists

### DIFF
--- a/javascript/commons/FilterButtons.js
+++ b/javascript/commons/FilterButtons.js
@@ -122,7 +122,7 @@ liquipedia.filterButtons = {
 				buttons: [],
 				alwaysActive: buttonsDiv.dataset.filterAlwaysActive?.split( ',' ) ?? [],
 				effectClass: 'filter-effect-' + ( buttonsDiv.dataset.filterEffect ?? this.fallbackFilterEffect ),
-				filterStates: localStorage[ filterGroup ]?.filterStates ?? {},
+				filterStates: {},
 				curated: localStorage[ filterGroup ]?.curated ?? buttonsDiv.dataset.filterDefaultCurated === 'true',
 				filterableItems: [],
 				defaultStates: {},
@@ -150,7 +150,7 @@ liquipedia.filterButtons = {
 						default:
 							filterGroupEntry.buttons[ filterOn ] = button;
 							filterGroupEntry.filterStates[ filterOn ] =
-								filterGroupEntry.filterStates[ filterOn ] ?? defaultState;
+								localStorage[ filterGroup ]?.filterStates[ filterOn ] ?? defaultState;
 							filterGroupEntry.defaultStates[ filterOn ] = defaultState;
 					}
 					buttonElement.setAttribute( 'tabindex', '0' );


### PR DESCRIPTION
## Summary
When filterbuttons where changed (e.g. adjusting the region mapping on lol or valorant), the old values remained in localstorage, as the localstorage values were always restored without checking whether buttons exist for them.

This only restores the values from localstorage when the corresponding button exists.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
TODO
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
