### PR TITLE
refactor: clean up broadcaster cards implementation

### DIFF
--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Abbreviation = Lua.import('Module:Abbreviation')
 local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
+local DateExt = Lua.import('Module:Date/Ext')
 local Flags = Lua.import('Module:Flags')
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
@@ -85,6 +86,8 @@ function BroadcasterCard.create(frame)
 		outputList = outputList .. ' ' .. frame:callParserFunction{name = '#tag', args = {'ref', args.ref}}
 	end
 
+	local date = DateExt.getContextualDate()
+
 	-- Add people
 	local casters = {}
 	for prefix, caster, casterIndex in Table.iter.pairsByPrefix(args, 'b') do
@@ -92,7 +95,6 @@ function BroadcasterCard.create(frame)
 		args[prefix .. 'flag' ] = Flags.CountryName{flag = args[prefix .. 'flag' ]}
 
 		local name, nationality = BroadcasterCard.getData(args, prefix, link, restrictedQuery)
-		local date = Variables.varDefault('tournament_enddate')
 
 		local broadcaster = {
 			id = caster,

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -25,6 +25,11 @@ local Variables = Lua.import('Module:Variables')
 
 local Weight = Lua.requireIfExists('Module:BroadCasterWeight')
 
+local Html = Lua.import('Module:Widget/Html')
+local Link = Lua.import('Module:Widget/Basic/Link')
+local ListWidgets = Lua.import('Module:Widget/List')
+local WidgetUtil = Lua.import('Module:Widget/Util')
+
 local TBD = 'TBD'
 
 local BroadcasterCard = {}
@@ -84,14 +89,6 @@ function BroadcasterCard.create(frame)
 		title = table.concat(positions, '/') .. ':'
 	end
 
-	-- Html for header
-	local outputList = tostring(mw.html.create():wikitext('*'):tag('b'):wikitext(title):allDone())
-
-	-- Reference
-	if String.isNotEmpty(args.ref) then
-		outputList = outputList .. ' ' .. frame:extensionTag('ref', args.ref)
-	end
-
 	local date = DateExt.getContextualDate()
 
 	-- Add people
@@ -125,10 +122,6 @@ function BroadcasterCard.create(frame)
 		table.insert(casters, broadcaster)
 	end
 
-	if Table.isEmpty(casters) then
-		return outputList .. '\n**' .. Abbreviation.make{text = 'TBA', title = 'To Be Announced'}
-	end
-
 	Array.sortInPlaceBy(casters, FnUtil.identity,
 		---@param a broadCasterData
 		---@param b broadCasterData
@@ -141,28 +134,33 @@ function BroadcasterCard.create(frame)
 		end
 	)
 
-	for _, broadcaster in ipairs(casters) do
-		outputList = outputList .. BroadcasterCard._display(broadcaster, config)
-	end
-
-	return outputList
+	return ListWidgets.Unordered{children = {WidgetUtil.collect(
+		Html.B{children = title},
+		String.isNotEmpty(args.ref) and (' ' .. frame:extensionTag('ref', args.ref)) or nil,
+		ListWidgets.Unordered{
+			children = BroadcasterCard._displayCasters(casters, config)
+		}
+	)}}
 end
 
----@param broadcaster broadCasterData
+---@param broadcasters broadCasterData[]
 ---@param options {alwaysShowName: boolean}
----@return string
-function BroadcasterCard._display(broadcaster, options)
-	local displayName = broadcaster.displayName or broadcaster.name
-
-	if String.isNotEmpty(displayName) and (options.alwaysShowName or displayName ~= broadcaster.id) then
-		displayName = ('&nbsp;(' .. displayName ..')')
-	else
-		displayName = ''
+---@return (Renderable|Renderable[])[]
+function BroadcasterCard._displayCasters(broadcasters, options)
+	if Logic.isEmpty(broadcasters) then
+		return {Html.Abbr{children = 'TBA', title = 'To Be Announced'}}
 	end
-
-	return '\n**' .. Flags.Icon{flag = broadcaster.flag, shouldLink = true}
-		.. '&nbsp;[[' .. broadcaster.page .. '|'.. broadcaster.id .. ']]'
-		.. displayName
+	return Array.map(broadcasters, function (broadcaster)
+		local children = {
+			Flags.Icon{flag = broadcaster.flag, shouldLink = true},
+			Link{link = broadcaster.page, children = broadcaster.id},
+		}
+		local displayName = broadcaster.displayName or broadcaster.name
+		if String.isNotEmpty(displayName) and (options.alwaysShowName or displayName ~= broadcaster.id) then
+			Array.appendWith(children, '(' .. displayName .. ')')
+		end
+		return Array.interleave(children, '&nbsp;')
+	end)
 end
 
 ---@param position string

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -47,7 +47,11 @@ local BroadcasterCard = {}
 function BroadcasterCard.create(frame)
 	local args = Arguments.getArgs(frame)
 	local language = args.lang
-	local restrictedQuery = Logic.readBool(args.restrictedQuery)
+
+	local config = {
+		restrictedQuery = Logic.readBool(args.restrictedQuery),
+		alwaysShowName = Logic.readBool(args.alwaysShowName),
+	}
 
 	-- Get position & title from various input variants
 	local position, title
@@ -95,7 +99,7 @@ function BroadcasterCard.create(frame)
 		local link = Page.pageifyLink(args[prefix .. 'link'] or caster) --[[@as string]]
 		args[prefix .. 'flag' ] = Flags.CountryName{flag = args[prefix .. 'flag' ]}
 
-		local name, nationality = BroadcasterCard.getData(args, prefix, link, restrictedQuery)
+		local name, nationality = BroadcasterCard.getData(args, prefix, link, config.restrictedQuery)
 
 		local broadcaster = {
 			id = caster,
@@ -126,8 +130,7 @@ function BroadcasterCard.create(frame)
 	table.sort(casters, function(a, b) return a.sort < b.sort or (a.sort == b.sort and a.id:lower() < b.id:lower()) end)
 
 	for _, broadcaster in ipairs(casters) do
-		local alwaysShowName = Logic.readBool(args.alwaysShowName)
-		outputList = outputList .. BroadcasterCard._display(broadcaster, {alwaysShowName = alwaysShowName})
+		outputList = outputList .. BroadcasterCard._display(broadcaster, config)
 	end
 
 	return outputList

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -95,6 +95,7 @@ function BroadcasterCard.create(frame)
 	local date = DateExt.getContextualDate()
 
 	-- Add people
+	---@type broadCasterData[]
 	local casters = {}
 	for prefix, caster, casterIndex in Table.iter.pairsByPrefix(args, 'b') do
 		local link = Page.pageifyLink(args[prefix .. 'link'] or caster) --[[@as string]]

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -16,6 +16,7 @@ local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Lpdb = Lua.import('Module:Lpdb')
 local Operator = Lua.import('Module:Operator')
+local Page = Lua.import('Module:Page')
 local String = Lua.import('Module:StringUtils')
 local Table = Lua.import('Module:Table')
 local Template = Lua.import('Module:Template')
@@ -91,7 +92,7 @@ function BroadcasterCard.create(frame)
 	-- Add people
 	local casters = {}
 	for prefix, caster, casterIndex in Table.iter.pairsByPrefix(args, 'b') do
-		local link = mw.ext.TeamLiquidIntegration.resolve_redirect(args[prefix .. 'link'] or caster):gsub(' ','_')
+		local link = Page.pageifyLink(args[prefix .. 'link'] or caster) --[[@as string]]
 		args[prefix .. 'flag' ] = Flags.CountryName{flag = args[prefix .. 'flag' ]}
 
 		local name, nationality = BroadcasterCard.getData(args, prefix, link, restrictedQuery)

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -79,10 +79,7 @@ function BroadcasterCard.create(frame)
 		title = Abbreviation.make{text = TBD, title = 'To Be Determined'}
 	else
 		-- Create a title from the position.
-		local positions = Array.map(
-			mw.text.split(position, '/'),
-			String.trim
-		)
+		local positions = Array.parseCommaSeparatedString(position, '/')
 		if args.b2 then
 			positions = Array.map(positions, BroadcasterCard._pluralisePosition)
 		end

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -80,7 +80,7 @@ function BroadcasterCard.create(frame)
 	-- Html for header
 	local outputList = tostring(mw.html.create():wikitext('*'):tag('b'):wikitext(title):allDone())
 
-	-- Refence
+	-- Reference
 	if String.isNotEmpty(args.ref) then
 		outputList = outputList .. ' ' .. frame:callParserFunction{name = '#tag', args = {'ref', args.ref}}
 	end

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -83,7 +83,7 @@ function BroadcasterCard.create(frame)
 
 	-- Reference
 	if String.isNotEmpty(args.ref) then
-		outputList = outputList .. ' ' .. frame:callParserFunction{name = '#tag', args = {'ref', args.ref}}
+		outputList = outputList .. ' ' .. frame:extensionTag('ref', args.ref)
 	end
 
 	local date = DateExt.getContextualDate()

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -7,7 +7,6 @@
 
 local Lua = require('Module:Lua')
 
-local Abbreviation = Lua.import('Module:Abbreviation')
 local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
@@ -76,7 +75,7 @@ function BroadcasterCard.create(frame)
 	if args.title then
 		title = args.title
 	elseif position == TBD then
-		title = Abbreviation.make{text = TBD, title = 'To Be Determined'}
+		title = Html.Abbr{children = TBD, title = 'To Be Determined'}
 	else
 		-- Create a title from the position.
 		local positions = Array.parseCommaSeparatedString(position, '/')

--- a/lua/wikis/commons/BroadcasterCard.lua
+++ b/lua/wikis/commons/BroadcasterCard.lua
@@ -12,6 +12,7 @@ local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
 local Flags = Lua.import('Module:Flags')
+local FnUtil = Lua.import('Module:FnUtil')
 local Json = Lua.import('Module:Json')
 local Logic = Lua.import('Module:Logic')
 local Lpdb = Lua.import('Module:Lpdb')
@@ -127,7 +128,17 @@ function BroadcasterCard.create(frame)
 		return outputList .. '\n**' .. Abbreviation.make{text = 'TBA', title = 'To Be Announced'}
 	end
 
-	table.sort(casters, function(a, b) return a.sort < b.sort or (a.sort == b.sort and a.id:lower() < b.id:lower()) end)
+	Array.sortInPlaceBy(casters, FnUtil.identity,
+		---@param a broadCasterData
+		---@param b broadCasterData
+		---@return boolean
+		function (a, b)
+			if a.sort ~= b.sort then
+				return a.sort < b.sort
+			end
+			return a.id:lower() < b.id:lower()
+		end
+	)
 
 	for _, broadcaster in ipairs(casters) do
 		outputList = outputList .. BroadcasterCard._display(broadcaster, config)


### PR DESCRIPTION
## Summary

This PR:
- cleans up argument parsing in broadcaster cards
- replaces uses of `mw.html` in broadcaster cards with widget3

## How did you test this change?

preview with dev