### PR TITLE
refactor: clean up prizepooltable toggle building

### DIFF
--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -33,7 +33,23 @@ liquipedia.prizepooltable = {
 				const row = prizepooltable.querySelector( 'tr:nth-child(' + ( cutAfter + 2 ) + ')' );
 				if ( row !== null ) {
 					const rowNode = document.createElement( 'tr' );
-					rowNode.innerHTML = '<td colspan="' + Math.max( prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length, prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length ) + '" class="prizepooltabletoggle"><small class="prizepooltableshow">' + openText + '</small><small class="prizepooltablehide">' + closeText + '</small></td>';
+					const cellNode = document.createElement( 'td' );
+					cellNode.setAttribute( 'colspan', Math.max(
+						prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length,
+						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length )
+					);
+					cellNode.classList.add( 'prizepooltabletoggle' );
+
+					const showNode = document.createElement( 'small' );
+					showNode.classList.add( 'prizepooltableshow' );
+					showNode.innerHTML = openText;
+
+					const closeNode = document.createElement( 'small' );
+					closeNode.classList.add( 'prizepooltablehide' );
+					closeNode.innerHTML = closeText;
+
+					cellNode.append( showNode, closeNode );
+					rowNode.appendChild( cellNode );
 					row.parentNode.insertBefore( rowNode, row );
 				}
 			}

--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -39,6 +39,9 @@ liquipedia.prizepooltable = {
 						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length )
 					);
 					cellNode.classList.add( 'prizepooltabletoggle' );
+					cellNode.addEventListener( 'click', () => {
+						prizepooltable.classList.toggle( 'collapsed' );
+					} );
 
 					const showNode = document.createElement( 'small' );
 					showNode.classList.add( 'prizepooltableshow' );
@@ -53,11 +56,6 @@ liquipedia.prizepooltable = {
 					row.parentNode.insertBefore( rowNode, row );
 				}
 			}
-		} );
-		document.querySelectorAll( '.prizepooltabletoggle' ).forEach( ( prizepooltabletogglebutton ) => {
-			prizepooltabletogglebutton.onclick = function() {
-				this.closest( '.prizepooltable' ).classList.toggle( 'collapsed' );
-			};
 		} );
 	}
 };

--- a/javascript/commons/Prizepooltable.js
+++ b/javascript/commons/Prizepooltable.js
@@ -36,8 +36,8 @@ liquipedia.prizepooltable = {
 					const cellNode = document.createElement( 'td' );
 					cellNode.setAttribute( 'colspan', Math.max(
 						prizepooltable.querySelectorAll( 'tr:nth-child(1) th, tr:nth-child(1) td' ).length,
-						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length )
-					);
+						prizepooltable.querySelectorAll( 'tr:nth-child(2) th, tr:nth-child(2) td' ).length
+					) );
 					cellNode.classList.add( 'prizepooltabletoggle' );
 					cellNode.addEventListener( 'click', () => {
 						prizepooltable.classList.toggle( 'collapsed' );


### PR DESCRIPTION
## Summary

https://github.com/Liquipedia/Lua-Modules/blob/9b5c65f9b9ddc08405ea4b11c6d02451827375e5/javascript/commons/Prizepooltable.js#L36

The above code snippet has a length of 395, making eslint complain for exceeding the configured line length (120). This PR breaks this line up into more readable lines of code.

## How did you test this change?

dev proxy