### PR TITLE
chore: add image override to vertical align image in LH

### DIFF
--- a/stylesheets/commons/Images.scss
+++ b/stylesheets/commons/Images.scss
@@ -100,6 +100,6 @@ html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) {
 }
 
 img {
-    vertical-align: middle;
-    border-style: none;
+	vertical-align: middle;
+	border-style: none;
 }

--- a/stylesheets/commons/Images.scss
+++ b/stylesheets/commons/Images.scss
@@ -101,5 +101,5 @@ html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) {
 
 img {
 	vertical-align: middle;
-	border-style: none;
+	border-style: hidden;
 }

--- a/stylesheets/commons/Images.scss
+++ b/stylesheets/commons/Images.scss
@@ -98,3 +98,8 @@ html:not( [ data-darkreader-scheme="dark" ] ):not( .theme--dark ) {
 #file img[ src*="darkmode" ]:hover {
 	background: url( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAAAAAA6mKC9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAHElEQVQY02MUZoAADijNxIAG6CPAArP/x8C6AwCutQE9GsmfRAAAAABJRU5ErkJggg== ) repeat;
 }
+
+img {
+    vertical-align: middle;
+    border-style: none;
+}


### PR DESCRIPTION
## Summary

Add `img` styling so it appear to be in the middle of the center vertically if the image is taller than the text
