### PR TITLE
ci: add Content-Type in http header

### DIFF
--- a/scripts/deploy_util.py
+++ b/scripts/deploy_util.py
@@ -20,8 +20,9 @@ USER_AGENT = f"GitHub Autodeploy Bot/2.1.0 ({os.getenv('WIKI_UA_EMAIL')})"
 
 HEADER = {
     "User-Agent": USER_AGENT,
-    "accept": "application/json",
+    "Accept": "application/json",
     "Accept-Encoding": "gzip",
+    "Content-Type": "application/x-www-form-urlencoded",
 }
 SLEEP_DURATION = 4
 

--- a/scripts/deploy_util.py
+++ b/scripts/deploy_util.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 GITHUB_STEP_SUMMARY_FILE = os.getenv("GITHUB_STEP_SUMMARY")
-USER_AGENT = f"GitHub Autodeploy Bot/2.1.0 ({os.getenv('WIKI_UA_EMAIL')})"
+USER_AGENT = f"GitHub Autodeploy Bot/2.1.1 ({os.getenv('WIKI_UA_EMAIL')})"
 
 HEADER = {
     "User-Agent": USER_AGENT,


### PR DESCRIPTION
## Summary

Mediawiki [complains with warning](https://github.com/wikimedia/mediawiki/blob/1.43.9/includes/api/ApiMain.php#L1912-L1916) if `Content-Type` header is absent when `POST`ing requests.

## How did you test this change?

local run