### PR TITLE
feat(infobox): adding game categories for chess infobox league

### DIFF
--- a/lua/wikis/chess/Infobox/League/Custom.lua
+++ b/lua/wikis/chess/Infobox/League/Custom.lua
@@ -98,6 +98,12 @@ function CustomLeague:getWikiCategories(args)
 	return Array.map(CustomLeague.getRestrictions(args.restrictions), Operator.property('link'))
 end
 
+function CustomLeague:getWikiCategories(args)
+	return {
+		args.game and (Game.name{game = args.game} .. ' Tournaments') or nil,
+	}
+end
+
 ---@param lpdbData table
 ---@param args table
 ---@return table


### PR DESCRIPTION
## Summary

Setting categories for the chess variants - bughouse and chess960 for the convenience, no category for chess cause it is unnecessary. 
Code taken from other wiki, probably 2 calls of _getWikiCategories_ can be combined but I messed it

## How did you test this change?

3 pages: 2 with variants, 3rd - without
https://liquipedia.net/chess/Chess.com_Bughouse_Chess_Championship/2025
https://liquipedia.net/chess/FIDE_Freestyle_Chess_World_Championship/2027
https://liquipedia.net/chess/La_Bourdonnais-McDonnell_1834