### PR TITLE
feat(infobox): respect player participation for recent matches display in LoL

### DIFF
--- a/lua/wikis/leagueoflegends/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Person/Player/Custom.lua
@@ -125,13 +125,15 @@ function CustomPlayer:createBottomContent()
 	if self:shouldStoreData(self.args) and String.isNotEmpty(self.args.team) then
 		local teamPage = TeamTemplate.getPageName(self.args.team)
 		---@cast teamPage -nil
+
 		return Html.Fragment{
 			children = WidgetUtil.collect(
-				MatchTicker.recent{team = teamPage},
+				MatchTicker.player{recentLimit = 3},
 				UpcomingTournaments.team{name = teamPage}
 			)
 		}
 	end
 end
+
 
 return CustomPlayer


### PR DESCRIPTION
## Summary

Player infoboxes in LoL show recent matches of the _team_ that the player is a part of over the actual matches that the player participated in due to historic reasons.
With m2o now containing player participation data, it would be better to show matches that the player actually played.

## How did you test this change?

trivial (copy-pasted from VAL)