### PR TITLE
fix(match2): opponent style broken on bracket template pages

### DIFF
--- a/lua/wikis/commons/Bracket/Template.lua
+++ b/lua/wikis/commons/Bracket/Template.lua
@@ -63,13 +63,15 @@ function BracketTemplate.BracketContainer(props)
 	end)
 	local bracket = MatchGroupUtil.makeMatchGroup(matchRecords) --[[@as MatchGroupUtilBracket]]
 
-	return BracketDisplay.Bracket({
+	return BracketDisplay.Bracket{
 		bracket = bracket,
 		config = Table.merge(props.config, {
-			OpponentEntry = function() return Html.Div{classes = {'brkts-opponent-entry'}, css = {height = '26px'}} end,
+			OpponentEntry = function()
+				return Html.Div{classes = {'brkts-opponent-entry'}, css = {height = '26px'}}
+			end,
 			matchHasDetails = function() return false end,
 		})
-	})
+	}
 end
 
 ---@param argsList table[]

--- a/lua/wikis/commons/Bracket/Template.lua
+++ b/lua/wikis/commons/Bracket/Template.lua
@@ -66,7 +66,7 @@ function BracketTemplate.BracketContainer(props)
 	return BracketDisplay.Bracket({
 		bracket = bracket,
 		config = Table.merge(props.config, {
-			OpponentEntry = function() return Html.Div{classes = {'brkts-opponent-entry'}} end,
+			OpponentEntry = function() return Html.Div{classes = {'brkts-opponent-entry'}, css = {height = '26px'}} end,
 			matchHasDetails = function() return false end,
 		})
 	})


### PR DESCRIPTION
## Summary

reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1533510953667264512

## How did you test this change?

live (by @hjpalpha)