### PR TITLE
feat: allow using strings as column name in condition nodes

### DIFF
--- a/lua/spec/condition_spec.lua
+++ b/lua/spec/condition_spec.lua
@@ -21,6 +21,17 @@ describe('LPDB Condition Builder', function()
 			)
 		end)
 
+		it('test string column name', function ()
+			local conditionNode1 = ConditionNode(
+				'date', Comparator.lessThan, '2020-03-02T00:00:00.000'
+			)
+			assert.are_equal(
+				'[[date::<2020-03-02T00:00:00.000]]',
+				conditionNode1:toString(),
+				tostring(conditionNode1)
+			)
+		end)
+
 		it('test ge', function ()
 			local conditionNode2 = ConditionNode(
 				ColumnName('date'), Comparator.greaterThanOrEqualTo, '2020-03-02T00:00:00.000'
@@ -127,7 +138,8 @@ describe('LPDB Condition Builder', function()
 
 	describe('Condition utilities test', function ()
 		it('anyOf', function ()
-			local tierColumnName = ColumnName('liquipediatier')
+			local tierColumnName = 'liquipediatier'
+			local tierColumnNameObj = ColumnName(tierColumnName)
 
 			assert.is_nil(ConditionUtil.anyOf(tierColumnName, {}))
 
@@ -137,13 +149,28 @@ describe('LPDB Condition Builder', function()
 			)
 
 			assert.are_equal(
+				'[[liquipediatier::1]] OR [[liquipediatier::2]]',
+				tostring(ConditionUtil.anyOf(tierColumnNameObj, {1, 2}))
+			)
+
+			assert.are_equal(
 				'[[liquipediatier::1]] OR [[liquipediatier::2]] OR [[liquipediatier::3]]',
 				tostring(ConditionUtil.anyOf(tierColumnName, {1, 2, 3}))
 			)
 
 			assert.are_equal(
 				'[[liquipediatier::1]] OR [[liquipediatier::2]] OR [[liquipediatier::3]]',
+				tostring(ConditionUtil.anyOf(tierColumnNameObj, {1, 2, 3}))
+			)
+
+			assert.are_equal(
+				'[[liquipediatier::1]] OR [[liquipediatier::2]] OR [[liquipediatier::3]]',
 				tostring(ConditionUtil.anyOf(tierColumnName, {1, 2, 3, 2}))
+			)
+
+			assert.are_equal(
+				'[[liquipediatier::1]] OR [[liquipediatier::2]] OR [[liquipediatier::3]]',
+				tostring(ConditionUtil.anyOf(tierColumnNameObj, {1, 2, 3, 2}))
 			)
 		end)
 

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -16,7 +16,7 @@ local Table = Lua.import('Module:Table')
 local Condition = {}
 
 -- Abstract class, node of the conditions tree
----@class AbstractConditionNode:BaseClass
+---@class AbstractConditionNode: BaseClass
 local _ConditionNode = Class.new()
 
 ---Returns the string representation of this condition node.
@@ -102,7 +102,7 @@ Comparator.ge = Comparator.greaterThanOrEqualTo
 Comparator.le = Comparator.lessThanOrEqualTo
 
 ---A condition in a ConditionTree
----@class ConditionNode:AbstractConditionNode
+---@class ConditionNode: AbstractConditionNode
 ---@operator call(...): ConditionNode
 ---@field name ColumnName
 ---@field comparator lpdbComparator
@@ -145,7 +145,7 @@ local BooleanOperator = {
 }
 
 ---Represents a column name in LPDB, including an optional super key
----@class ColumnName
+---@class ColumnName: BaseClass
 ---@operator call(...): ColumnName
 ---@field name string
 ---@field superName string?

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -176,6 +176,11 @@ function ColumnName:toString()
 	return self.name
 end
 
+---@return string
+function ColumnName:__tostring()
+	return self:toString()
+end
+
 local ConditionUtil = {}
 
 ---Builds "matches any of" condition from the given collection of values.

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -104,7 +104,7 @@ Comparator.le = Comparator.lessThanOrEqualTo
 ---A condition in a ConditionTree
 ---@class ConditionNode: AbstractConditionNode
 ---@operator call(...): ConditionNode
----@field name ColumnName
+---@field name string|ColumnName
 ---@field comparator lpdbComparator
 ---@field value string|number
 local ConditionNode = Class.new(_ConditionNode,

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -127,7 +127,7 @@ function ConditionNode:toString()
 		return String.interpolate(
 			'[[${name}${comparator}${value}]]',
 			{
-				name = self.name:toString(),
+				name = tostring(self.name),
 				comparator = comp,
 				value = self.value
 			}

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -184,7 +184,7 @@ end
 local ConditionUtil = {}
 
 ---Builds "matches any of" condition from the given collection of values.
----@param column ColumnName
+---@param column string|ColumnName
 ---@param values (string|number)[]
 ---@return ConditionTree?
 function ConditionUtil.anyOf(column, values)
@@ -192,7 +192,7 @@ function ConditionUtil.anyOf(column, values)
 end
 
 ---Builds "matches none of" condition from the given collection of values.
----@param column ColumnName
+---@param column string|ColumnName
 ---@param values (string|number)[]
 ---@return ConditionTree?
 function ConditionUtil.noneOf(column, values)
@@ -200,7 +200,7 @@ function ConditionUtil.noneOf(column, values)
 end
 
 ---@package
----@param column ColumnName
+---@param column string|ColumnName
 ---@param booleanOperator lpdbBooleanOperator
 ---@param comparator lpdbComparator
 ---@param values (string|number)[]

--- a/lua/wikis/commons/Condition.lua
+++ b/lua/wikis/commons/Condition.lua
@@ -117,6 +117,7 @@ local ConditionNode = Class.new(_ConditionNode,
 
 ---@return string
 function ConditionNode:toString()
+	assert(self.name ~= nil, 'ConditionNode: nil cannot be used as a column name.')
 	assert(
 		Table.any(Comparator, function (_, value)
 			return self.comparator == value


### PR DESCRIPTION
## Summary

This PR adds support for passing a raw `string` as column name into `ConditionNode`s. See example below.

```lua
local conditionNode = ConditionNode('date', Comparator.lt, '2020-03-02T00:00:00.000')
```

## How did you test this change?

included tests