### PR TITLE
fix(match2): bracket opponent entries not using dynamic teamstyle

### DIFF
--- a/lua/wikis/commons/Widget/Match/Bracket/Opponent.lua
+++ b/lua/wikis/commons/Widget/Match/Bracket/Opponent.lua
@@ -25,7 +25,7 @@ local function BracketOpponent(props)
 		overflow = 'ellipsis',
 		showLink = false,
 		showTbd = props.showTbd,
-		teamStyle = props.forceShortName and 'short' or 'hybrid',
+		teamStyle = props.forceShortName and 'short' or 'dynamic',
 	}
 end
 

--- a/lua/wikis/commons/Widget/Match/Bracket/Opponent/Starcraft.lua
+++ b/lua/wikis/commons/Widget/Match/Bracket/Opponent/Starcraft.lua
@@ -25,7 +25,7 @@ local function StarcraftBracketOpponent(props)
 		playerClass = 'starcraft-bracket-block-player',
 		showLink = false,
 		showTbd = props.showTbd,
-		teamStyle = props.forceShortName and 'short' or 'hybrid',
+		teamStyle = props.forceShortName and 'short' or 'dynamic',
 	}
 end
 


### PR DESCRIPTION
## Summary

#7668 unintentionally rolled back a part of #7638 (probably due to a bad rebase?), so this PR restores the rolled back behavior.

## How did you test this change?

trivial