### PR TITLE
feat(match2): use dynamic team style in match summary headers

### DIFF
--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -178,7 +178,7 @@ function MatchSummary.createDefaultHeader(match, options)
 			},
 			MatchHeader{
 				match = match,
-				teamStyle = options.teamStyle,
+				teamStyle = options.teamStyle or 'dynamic',
 			}
 		}
 	}

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -29,7 +29,7 @@ local LoLMatchSummaryGameRow = MatchSummaryWidgets.GameRow.createComponent(GameR
 ---@param args table
 ---@return Renderable
 function CustomMatchSummary.getByMatchId(args)
-	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px', teamStyle = 'bracket'})
+	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '400px'})
 end
 
 ---@param match MatchGroupUtilMatch

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -1216,10 +1216,12 @@ div.brkts-popup-body-element-thumbs {
 		flex: 1 1;
 		min-width: 0;
 
-		&:has( > .team-name-dynamic ) {
+		&:has( > .team-name-dynamic ),
+		&:has( > a > .team-name-dynamic ) {
 			container: block-team-name / inline-size;
 
-			> .team-name-dynamic {
+			> .team-name-dynamic,
+			> a > .team-name-dynamic {
 				content: none;
 
 				@container block-team-name ( min-width: 15px ) and ( width < 100px ) {


### PR DESCRIPTION
## Summary

This PR updates match summary headers to default to using dynamic teamstyle (see #7635), i.e., makes team names in match summaries to adapt to the space available.
This does not affect wikis that already have `teamStyle` specified in their local `Module:MatchSummary` implementation (except LoL - see 97dd2aa).

## How did you test this change?

dev + browser dev tools