### PR TITLE
fix(Collapse): use button element for general-collapsible toggles

### DIFF
--- a/javascript/commons/Collapse.js
+++ b/javascript/commons/Collapse.js
@@ -66,21 +66,17 @@ liquipedia.collapse = {
 	// general-collapsible is a generalization of .collapsible that works for
 	// any layout, not just tables. It requires that the collapsible
 	// component supply its own expand/collapse buttons.
-	//
-	// Note that unlike .collapsible, the button is the anchor itself, instead
-	// of a wrapper around the anchor.
 	setupGeneralCollapsibleButtons: function() {
-		// Replaces the button (usually a <span>) with <a href="#">...</a>.
+		// Replaces the element (a <div>, as the MW parser does not allow <button>)
+		// with a real <button>.
 		// For xss safety, only the child nodes and class name are copied over.
-		function replaceWithAnchor( button ) {
-			const anchor = document.createElement( 'a' );
-			button.childNodes.forEach( ( node ) => {
-				anchor.append( node );
-			} );
-			anchor.className = button.className;
-			anchor.href = '#';
-			button.parentNode.replaceChild( anchor, button );
-			return anchor;
+		function replaceWithButton( element ) {
+			const button = document.createElement( 'button' );
+			button.append( ...element.childNodes );
+			button.className = element.className;
+			button.type = 'button';
+			element.parentNode.replaceChild( button, element );
+			return button;
 		}
 
 		document.querySelectorAll( '#mw-content-text .general-collapsible' ).forEach( ( collapsible ) => {
@@ -88,18 +84,14 @@ liquipedia.collapse = {
 			const expandButton = collapsible.querySelector( '.general-collapsible-expand-button' );
 
 			if ( expandButton ) {
-				const anchor = replaceWithAnchor( expandButton );
-				anchor.addEventListener( 'click', ( event ) => {
+				replaceWithButton( expandButton ).addEventListener( 'click', () => {
 					collapsible.classList.remove( 'collapsed' );
-					event.preventDefault();
 				} );
 			}
 
 			if ( collapseButton ) {
-				const anchor = replaceWithAnchor( collapseButton );
-				anchor.addEventListener( 'click', ( event ) => {
+				replaceWithButton( collapseButton ).addEventListener( 'click', () => {
 					collapsible.classList.add( 'collapsed' );
-					event.preventDefault();
 				} );
 			}
 		} );

--- a/stylesheets/commons/Legend.scss
+++ b/stylesheets/commons/Legend.scss
@@ -45,9 +45,7 @@
 			min-width: unset;
 
 			.general-collapsible-expand-button,
-			.general-collapsible-expand-button:visited,
-			.general-collapsible-collapse-button,
-			.general-collapsible-collapse-button:visited {
+			.general-collapsible-collapse-button {
 				outline: unset;
 				color: var( --clr-secondary-7 );
 


### PR DESCRIPTION
## Summary

- `.general-collapsible` toggles were rendered as `<a href="#">` carrying the
  `button` class, so a single click matched both of Analytics' click trackers
  and recorded a `Link clicked` *and* a `Button clicked` event. The
  `.button:not(a *)` guard only excludes elements *inside* an anchor, not an
  element that is itself both the anchor and the `.button`.
- Replace `replaceWithAnchor` with `replaceWithButton`, producing a real
  `<button type="button">`. The toggle does not navigate, so `Button clicked`
  is the event that should survive. Also gives native keyboard activation
  (Space as well as Enter) and stops `#` landing in the URL.
- Drop the now-redundant `event.preventDefault()` calls.
- Fix a latent bug in the node copy: `element.childNodes.forEach()` moved nodes
  out of a *live* NodeList while iterating it, skipping every other child.
  Currently harmless (the `Button` widget wraps its content in a single
  `<span>`), but wrong for any multi-child toggle. `button.append(
  ...element.childNodes )` spreads the list before mutating.
- Remove two dead `:visited` selectors in `Legend.scss` and a stale comment in
  `Collapse.js` that described markup which no longer exists.

Affects the three `general-collapsible` toggle producers:
`Widget/GeneralCollapsible/Toggle`, `Widget/GeneralCollapsible/ChevronToggle`
and `Widget/Match/VodsDropdownButton`. `.collapsible` / `.NavFrame` toggles
were already real `<button>`s and are unchanged.

## How did you test this change?

devtools