### PR TITLE
fix: Use value instead of identifier for CS tiertype filters

### DIFF
--- a/lua/wikis/counterstrike/FilterButtons/Config.lua
+++ b/lua/wikis/counterstrike/FilterButtons/Config.lua
@@ -34,9 +34,9 @@ Config.categories = {
 		property = 'liquipediaTierType',
 		expandable = true,
 		load = function(category)
-			category.items = {'Onlinestage', 'Monthly', 'Weekly', 'Qualifier', 'Showmatch'}
+			category.items = {'Online Stage', 'Monthly', 'Weekly', 'Qualifier', 'Showmatch'}
 		end,
-		defaultItems = {'Onlinestage'},
+		defaultItems = {'Online Stage'},
 		transform = function(tiertype)
 			return select(2, Tier.toName(1, tiertype))
 		end,

--- a/lua/wikis/counterstrike/FilterButtons/Config.lua
+++ b/lua/wikis/counterstrike/FilterButtons/Config.lua
@@ -34,9 +34,9 @@ Config.categories = {
 		property = 'liquipediaTierType',
 		expandable = true,
 		load = function(category)
-			category.items = {'onlinestage', 'monthly', 'weekly', 'qualifier', 'showmatch'}
+			category.items = {'Onlinestage', 'Monthly', 'Weekly', 'Qualifier', 'Showmatch'}
 		end,
-		defaultItems = {'onlinestage'},
+		defaultItems = {'Onlinestage'},
 		transform = function(tiertype)
 			return select(2, Tier.toName(1, tiertype))
 		end,


### PR DESCRIPTION
## Summary
Another issue related to #7857
CS excludes one tiertype (points), and thus manually listed the tiertypes.
Since #7850 adjusted the return of Tournament.liquipediaTierType to be the value instead converting to identifier, this caused a mismatch when the filterbuttons still used the identifier.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
live
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
