### PR TITLE
ci: add missing command line arg for scheduled deploy

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -42,4 +42,4 @@ jobs:
           WIKI_BASE_URL: ${{ secrets.LP_BASE_URL }}
           DEPLOY_TRIGGER: ${{ github.event_name }}
           PYTHONUNBUFFERED: 1
-        run: python3 ./scripts/deploy.py
+        run: python3 ./scripts/deploy.py -A


### PR DESCRIPTION
## Summary

Command line args for `deploy.py` was updated in #7798 but the GHA workflow itself wasn't.

## How did you test this change?

local dry run