### PR TITLE
feat: Add Module:CharacterStats/Custom for brawl stars wiki

### DIFF
--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -12,6 +12,7 @@ local Array = Lua.import('Module:Array')
 local BaseCharacterStats = Lua.import('Module:CharacterStats')
 local Class = Lua.import('Module:Class')
 local String = Lua.import('Module:StringUtils')
+local Logic = Lua.import('Module:Logic')
 
 local CharacterStatsWidget = Lua.import('Module:Widget/CharacterStats')
 
@@ -64,12 +65,7 @@ end
 ---@return string[]
 function BSCharacterStats:getTeamBans(game, opponentIndex)
 	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
-	local bans = {}
-	return Array.map(teamBans, function(ban)
-		if String.isNotEmpty(ban) then
-			return ban
-		end
-	end)
+	return Array.map(teamBans, Logic.nilIfEmpty)
 end
 
 return BSCharacterStats

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -11,25 +11,26 @@ local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local BaseCharacterStats = Lua.import('Module:CharacterStats')
 local Class = Lua.import('Module:Class')
-local String = Lua.import('Module:StringUtils')
 local Logic = Lua.import('Module:Logic')
+local Operator = Lua.import('Module:Operator')
+local String = Lua.import('Module:StringUtils')
 
 local CharacterStatsWidget = Lua.import('Module:Widget/CharacterStats')
 
----@class BSCharacterStats: CharacterStats
----@operator call(table): BSCharacterStats
-local BSCharacterStats = Class.new(BaseCharacterStats)
+---@class BrawlStarsCharacterStats: CharacterStats
+---@operator call(table): BrawlStarsCharacterStats
+local BrawlStarsCharacterStats = Class.new(BaseCharacterStats)
 
 ---@return string[]
-function BSCharacterStats:getSides()
+function BrawlStarsCharacterStats:getSides()
 	return {}
 end
 
 ---@param frame Frame
 ---@return Widget
-function BSCharacterStats.run(frame)
+function BrawlStarsCharacterStats.run(frame)
 	local args = Arguments.getArgs(frame)
-	local stats = BSCharacterStats(args)
+	local stats = BrawlStarsCharacterStats(args)
 
 	local games = stats:queryGames()
 	local processedData = stats:processGames(games)
@@ -51,21 +52,17 @@ end
 ---@param game CharacterStatsGame
 ---@param opponentIndex integer
 ---@return string[]
-function BSCharacterStats:getTeamCharacters(game, opponentIndex)
+function BrawlStarsCharacterStats:getTeamCharacters(game, opponentIndex)
 	local players = ((game.opponents or {})[opponentIndex] or {}).players or {}
-	return Array.map(players, function(player)
-		if type(player) == 'table' and String.isNotEmpty(player.brawler) then
-			return player.brawler
-		end
-	end)
+	return Array.filter(Array.map(players, Operator.property('brawler')), String.isNotEmpty)
 end
 
 ---@param game CharacterStatsGame
 ---@param opponentIndex integer
 ---@return string[]
-function BSCharacterStats:getTeamBans(game, opponentIndex)
+function BrawlStarsCharacterStats:getTeamBans(game, opponentIndex)
 	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
-	return Array.map(teamBans, Logic.nilIfEmpty)
+	return Array.filter(teamBans, String.isNotEmpty)
 end
 
-return BSCharacterStats
+return BrawlStarsCharacterStats

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -52,13 +52,11 @@ end
 ---@return string[]
 function BSCharacterStats:getTeamCharacters(game, opponentIndex)
 	local players = ((game.opponents or {})[opponentIndex] or {}).players or {}
-	local characters = {}
-	Array.map(players, function(player)
+	return Array.map(players, function(player)
 		if type(player) == 'table' and String.isNotEmpty(player.brawler) then
-			table.insert(characters, player.brawler)
+			return player.brawler
 		end
 	end)
-	return characters
 end
 
 ---@param game CharacterStatsGame
@@ -67,12 +65,11 @@ end
 function BSCharacterStats:getTeamBans(game, opponentIndex)
 	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
 	local bans = {}
-	Array.map(teamBans, function(ban)
+	return Array.map(teamBans, function(ban)
 		if String.isNotEmpty(ban) then
-			table.insert(bans, ban)
+			return ban
 		end
 	end)
-	return bans
 end
 
 return BSCharacterStats

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -1,0 +1,78 @@
+---
+-- @Liquipedia
+-- page=Module:CharacterStats/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Arguments = Lua.import('Module:Arguments')
+local Array = Lua.import('Module:Array')
+local BaseCharacterStats = Lua.import('Module:CharacterStats')
+local Class = Lua.import('Module:Class')
+local String = Lua.import('Module:StringUtils')
+
+local CharacterStatsWidget = Lua.import('Module:Widget/CharacterStats')
+
+---@class BSCharacterStats: CharacterStats
+---@operator call(table): BSCharacterStats
+local BSCharacterStats = Class.new(BaseCharacterStats)
+
+---@return string[]
+function BSCharacterStats:getSides()
+	return {}
+end
+
+---@param frame Frame
+---@return Widget
+function BSCharacterStats.run(frame)
+	local args = Arguments.getArgs(frame)
+	local stats = BSCharacterStats(args)
+
+	local games = stats:queryGames()
+	local processedData = stats:processGames(games)
+	return CharacterStatsWidget{
+		characterType = 'Champion',
+		data = processedData.characterData,
+		includeBans = Array.any(processedData.characterData, function (data)
+			return data.bans > 0
+		end),
+		numGames = #games,
+		sides = stats:getSides(),
+		sideWins = processedData.overall.wins,
+		statspage = args.statspage
+	}
+end
+
+-- Override functions from BaseCharacterStats
+
+---@param game CharacterStatsGame
+---@param opponentIndex integer
+---@return string[]
+function BSCharacterStats:getTeamCharacters(game, opponentIndex)
+	local players = ((game.opponents or {})[opponentIndex] or {}).players or {}
+	local characters = {}
+	for _, player in ipairs(players) do
+		if type(player) == 'table' and String.isNotEmpty(player.brawler) then
+			table.insert(characters, player.brawler)
+		end
+	end
+	return characters
+end
+
+---@param game CharacterStatsGame
+---@param opponentIndex integer
+---@return string[]
+function BSCharacterStats:getTeamBans(game, opponentIndex)
+	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
+	local bans = {}
+	for _, ban in pairs(teamBans) do
+		if String.isNotEmpty(ban) then
+			table.insert(bans, ban)
+		end
+	end
+	return bans
+end
+
+return BSCharacterStats

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -11,7 +11,6 @@ local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local BaseCharacterStats = Lua.import('Module:CharacterStats')
 local Class = Lua.import('Module:Class')
-local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local String = Lua.import('Module:StringUtils')
 

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -33,7 +33,7 @@ function BSCharacterStats.run(frame)
 	local games = stats:queryGames()
 	local processedData = stats:processGames(games)
 	return CharacterStatsWidget{
-		characterType = 'Champion',
+		characterType = 'Brawler',
 		data = processedData.characterData,
 		includeBans = Array.any(processedData.characterData, function (data)
 			return data.bans > 0
@@ -53,11 +53,11 @@ end
 function BSCharacterStats:getTeamCharacters(game, opponentIndex)
 	local players = ((game.opponents or {})[opponentIndex] or {}).players or {}
 	local characters = {}
-	for _, player in ipairs(players) do
+	Array.map(players, function(player)
 		if type(player) == 'table' and String.isNotEmpty(player.brawler) then
 			table.insert(characters, player.brawler)
 		end
-	end
+	end)
 	return characters
 end
 
@@ -67,11 +67,11 @@ end
 function BSCharacterStats:getTeamBans(game, opponentIndex)
 	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
 	local bans = {}
-	for _, ban in pairs(teamBans) do
+	Array.map(teamBans, function(ban)
 		if String.isNotEmpty(ban) then
 			table.insert(bans, ban)
 		end
-	end
+	end)
 	return bans
 end
 

--- a/lua/wikis/brawlstars/CharacterStats/Custom.lua
+++ b/lua/wikis/brawlstars/CharacterStats/Custom.lua
@@ -11,6 +11,7 @@ local Arguments = Lua.import('Module:Arguments')
 local Array = Lua.import('Module:Array')
 local BaseCharacterStats = Lua.import('Module:CharacterStats')
 local Class = Lua.import('Module:Class')
+local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
 local String = Lua.import('Module:StringUtils')
 
@@ -39,6 +40,7 @@ function BrawlStarsCharacterStats.run(frame)
 		includeBans = Array.any(processedData.characterData, function (data)
 			return data.bans > 0
 		end),
+		includeGlobalBans = true,
 		numGames = #games,
 		sides = stats:getSides(),
 		sideWins = processedData.overall.wins,
@@ -62,6 +64,14 @@ end
 function BrawlStarsCharacterStats:getTeamBans(game, opponentIndex)
 	local teamBans = ((game.extradata or {}).bans or {})['team' .. opponentIndex] or {}
 	return Array.filter(teamBans, String.isNotEmpty)
+end
+
+---@param game CharacterStatsGame
+---@param opponentIndex integer
+---@return string[]
+function BrawlStarsCharacterStats:getTeamGlobalBans(game, opponentIndex)
+	local teamGlobalBans = (game.globalBans or {})['team' .. opponentIndex] or {}
+	return Array.filter(teamGlobalBans, String.isNotEmpty)
 end
 
 return BrawlStarsCharacterStats

--- a/lua/wikis/commons/CharacterStats.lua
+++ b/lua/wikis/commons/CharacterStats.lua
@@ -27,6 +27,7 @@ local ConditionUtil = Condition.Util
 
 ---@class CharacterStatsGame: MatchGroupUtilGame
 ---@field matchOpponents standardOpponent[]
+---@field globalBans table<string, table<string, string>>?
 
 ---@alias CharacterAppearanceStats {pick: integer, win: integer, loss: integer}
 
@@ -35,6 +36,7 @@ local ConditionUtil = Condition.Util
 ---@field side table<string, {win: integer, loss: integer}> key is side
 ---@field total CharacterAppearanceStats
 ---@field bans integer
+---@field globalBans integer
 ---@field playedWith table<string, CharacterAppearanceStats> key is character name
 ---@field playedVs table<string, CharacterAppearanceStats> key is character name
 ---@field playedBy table<string, CharacterAppearanceStats> key is opponent name
@@ -92,6 +94,13 @@ function CharacterStats:queryGames()
 		if #matchOpponents > 2 then
 			return
 		end
+
+		local matchRecord = mw.ext.LiquipediaDB.lpdb('match2', {
+			conditions = tostring(ConditionNode(ColumnName('match2id'), Comparator.eq, matchId)),
+			limit = 1,
+		})[1]
+		local globalBans = (matchRecord or {}).extradata and matchRecord.extradata.globalbans or nil
+
 		local games = Array.map(
 			mw.ext.LiquipediaDB.lpdb('match2game', {
 				conditions = tostring(ConditionTree(BooleanOperator.all):add{
@@ -100,10 +109,13 @@ function CharacterStats:queryGames()
 				}),
 				order = 'match2gameid asc',
 			}),
-			function (gameRecord)
+			function (gameRecord, gameIndex)
 				local game = MatchGroupUtil.gameFromRecord(gameRecord)
 				---@cast game CharacterStatsGame
 				game.matchOpponents = matchOpponents
+				if gameIndex == 1 then
+					game.globalBans = globalBans
+				end
 				return game
 			end
 		)
@@ -127,6 +139,13 @@ function CharacterStats:getTeamBans(game, opponentIndex)
 	return Array.filter(Array.mapIndexes(function (characterIndex)
 		return game.extradata['team' .. opponentIndex .. 'ban' .. characterIndex]
 	end), String.isNotEmpty)
+end
+
+---@param game CharacterStatsGame
+---@param opponentIndex integer
+---@return string[]
+function CharacterStats:getTeamGlobalBans(game, opponentIndex)
+	return {}
 end
 
 ---@param game CharacterStatsGame
@@ -214,6 +233,11 @@ function CharacterStats:processGames(games)
 				local characterStats = self:_getCharacterStatTable(stats, ban)
 				characterStats.bans = characterStats.bans + 1
 			end)
+
+			Array.forEach(self:getTeamGlobalBans(game, opponentIndex), function (ban)
+				local characterStats = self:_getCharacterStatTable(stats, ban)
+				characterStats.globalBans = characterStats.globalBans + 1
+			end)
 		end)
 	end)
 
@@ -236,6 +260,7 @@ function CharacterStats:_getCharacterStatTable(stats, character)
 			end),
 			total = {pick = 0, win = 0, loss = 0},
 			bans = 0,
+			globalBans = 0,
 			playedWith = {},
 			playedVs = {},
 			playedBy = {}

--- a/lua/wikis/commons/Widget/CharacterStats.lua
+++ b/lua/wikis/commons/Widget/CharacterStats.lua
@@ -34,6 +34,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 ---@field characterType string
 ---@field data CharacterStatistic[]
 ---@field includeBans boolean?
+---@field includeGlobalBans boolean?
 ---@field numGames integer
 ---@field sides string[]
 ---@field sideWins table<string, integer>
@@ -45,6 +46,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local CharacterStatsWidget = Class.new(Widget)
 CharacterStatsWidget.defaultProps = {
 	characterSize = '25x25px',
+	includeGlobalBans = false,
 	numGames = 0,
 	statspage = mw.title.getCurrentTitle().prefixedText
 }

--- a/lua/wikis/commons/Widget/CharacterStats/Table.lua
+++ b/lua/wikis/commons/Widget/CharacterStats/Table.lua
@@ -68,7 +68,10 @@ function CharacterStatsTable:_buildHeaderRow()
 				return Html.Th{attributes = {colspan = 4}, children = String.upperCaseFirst(side)}
 			end),
 			self.props.includeBans and {
-				Html.Th{attributes = {colspan = 2}, children = 'Bans'},
+				Html.Th{
+					attributes = {colspan = self.props.includeGlobalBans and 4 or 2},
+					children = 'Bans'
+				},
 				Html.Th{
 					attributes = {colspan = 2},
 					css = {['white-space'] = 'nowrap'},
@@ -97,12 +100,19 @@ function CharacterStatsTable:_buildHeaderRow()
 					Html.Th{children = 'WR'},
 				}
 			end),
-			self.props.includeBans and {
+			self.props.includeBans and WidgetUtil.collect(
+				self.props.includeGlobalBans and {
+					Html.Th{children = '∑'},
+					Html.Th{children = Html.Abbr{title = 'Ban', children = 'B'}},
+					Html.Th{children = Html.Abbr{title = 'Global Ban', children = 'GB'}},
+					Html.Th{children = '%T'},
+				} or {
+					Html.Th{children = '∑'},
+					Html.Th{children = '%T'},
+				},
 				Html.Th{children = '∑'},
-				Html.Th{children = '%T'},
-				Html.Th{children = '∑'},
-				Html.Th{children = '%T'},
-			} or nil
+				Html.Th{children = '%T'}
+			) or nil
 		)}
 	}
 end
@@ -147,14 +157,23 @@ function CharacterStatsTable:_buildCharacterRow(characterData, characterIndex)
 					Html.Td{children = CharacterStatsTable._calculatePercentage(characterData.side[side].win, picks)}
 				}
 			end),
-			self.props.includeBans and {
-				Html.Td{children = characterData.bans},
-				Html.Td{children = CharacterStatsTable._calculatePercentage(characterData.bans, self.props.numGames)},
-				Html.Td{children = characterData.total.pick + characterData.bans},
+			self.props.includeBans and WidgetUtil.collect(
+				self.props.includeGlobalBans and {
+					Html.Td{children = characterData.bans + characterData.globalBans},
+					Html.Td{children = characterData.bans},
+					Html.Td{children = characterData.globalBans},
+					Html.Td{children = CharacterStatsTable._calculatePercentage(
+						characterData.bans + characterData.globalBans, self.props.numGames
+					)},
+				} or {
+					Html.Td{children = characterData.bans},
+					Html.Td{children = CharacterStatsTable._calculatePercentage(characterData.bans, self.props.numGames)},
+				},
+				Html.Td{children = characterData.total.pick + characterData.bans + characterData.globalBans},
 				Html.Td{children = CharacterStatsTable._calculatePercentage(
 					characterData.total.pick + characterData.bans, self.props.numGames
 				)}
-			} or nil,
+			) or nil,
 			Html.Td{children = Dialog{
 				trigger = Button{
 					children = 'Show',
@@ -304,7 +323,7 @@ function CharacterStatsTable:_buildFooterRow()
 			end),
 			Html.Th{
 				classes = {'sortbottom'},
-				attributes = {colspan = 5}
+				attributes = {colspan = self.props.includeBans and (self.props.includeGlobalBans and 7 or 5) or 1}
 			}
 		)},
 		self.props.statspage ~= mw.title.getCurrentTitle().prefixedText and Html.Tr{

--- a/lua/wikis/commons/Widget/CharacterStats/Table.lua
+++ b/lua/wikis/commons/Widget/CharacterStats/Table.lua
@@ -89,7 +89,7 @@ function CharacterStatsTable:_buildHeaderRow()
 			Html.Th{children = 'L'},
 			Html.Th{children = 'WR'},
 			Html.Th{children = '%T'},
-			Array.flatMap(Array.range(1, 2), function (_)
+			Array.flatMap(self.props.sides, function (_)
 				return {
 					Html.Th{children = '∑'},
 					Html.Th{children = 'W'},


### PR DESCRIPTION
## Summary
Wait for https://github.com/Liquipedia/Lua-Modules/pull/7911 is merged
Changing the one that the wiki use([Module:BrawlerStats](https://liquipedia.net/brawlstars/Module:BrawlerStats) to the more good standard module.

Also changing the Module:CharacterStats/Table to be able to not show the red and blue.
Tested on League Of Legends and seems to be fine, no need to add anything.

## How did you test this change?
Dev
https://liquipedia.net/brawlstars/Module:CharacterStats/Custom/dev/steve23
https://liquipedia.net/commons/Module:Widget/CharacterStats/Table/dev/steve23
