### PR TITLE
perf: optimize MathUtil.ilog2

### DIFF
--- a/lua/wikis/commons/MathUtil.lua
+++ b/lua/wikis/commons/MathUtil.lua
@@ -7,6 +7,9 @@
 
 local MathUtil = {}
 
+---Precalculated value of `ln(2)`
+local ln2 = math.log(2)
+
 --[[
 Converts the argument to an integer.
 ]]
@@ -44,7 +47,7 @@ MathUtil.ilog2(24) -- Returns 4
 ---@param x number
 ---@return integer
 function MathUtil.ilog2(x)
-	return math.floor(math.log(x) / math.log(2))
+	return math.floor(math.log(x) / ln2)
 end
 
 --[[


### PR DESCRIPTION
## Summary

This PR extracts $\ln(2)$ from `MathUtil.ilog2`, eliminating the need to calculate its value for every function call.

## How did you test this change?

trivial

### Performance Test

```lua
for i = 1, n --[[ n is a positive integer ]] do
	MathUtil.ilog2(i)
end
```

|                   | $n = 10^3$ | $n=10^4$ | $n=10^5$    | $n=10^6$ | $n=10^7$      |
|-------------------|----------|----------|-----------|------------|---------------|
| Runtime (Current)  | 18 ms | 19 ms | 36 ms | 215 ms  | 1.954 s|
| Runtime (PR)       | 17 ms | 18 ms | 29 ms  | 131 ms  | 1.186 s |

Observed memory differences were negligible.