### PR TITLE
fix(opponent): literal opponents not properly displayed on sc2

### DIFF
--- a/lua/wikis/commons/OpponentDisplay/Starcraft.lua
+++ b/lua/wikis/commons/OpponentDisplay/Starcraft.lua
@@ -42,9 +42,6 @@ function StarcraftOpponentDisplay.BlockOpponent(props)
 		)
 	end
 
-	if props.showTbd == false and Opponent.isTbd(opponent) then
-		return Html.Fragment{}
-	end
 	return OpponentDisplay.BlockOpponent(props)
 end
 


### PR DESCRIPTION
## Summary

Reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1532698736432644197

## How did you test this change?

untested