### PR TITLE
feat(match2): collapsible detail for LoL match summary

### DIFF
--- a/lua/wikis/commons/Widget/GeneralCollapsible/LabeledChevronToggle.lua
+++ b/lua/wikis/commons/Widget/GeneralCollapsible/LabeledChevronToggle.lua
@@ -17,14 +17,15 @@ local Span = Html.Span
 ---@param buttonType 'expand'|'collapse'
 ---@param text Renderable?
 ---@param iconName string
+---@param buttonSize 'xs'|'sm'|'md'|'lg'|nil
 ---@return VNode
-local function labeledButton(buttonType, text, iconName)
+local function labeledButton(buttonType, text, iconName, buttonSize)
 	return Button{
 		classes = {'general-collapsible-' .. buttonType .. '-button'},
 		children = Span{
 			children = WidgetUtil.collect(text, text and ' ' or nil, Icon{iconName = iconName}),
 		},
-		size = 'sm',
+		size = buttonSize,
 		variant = 'ghost',
 	}
 end
@@ -32,6 +33,7 @@ end
 ---@class LabeledChevronToggleProps
 ---@field expandText Renderable? label shown next to the expand chevron
 ---@field collapseText Renderable? label shown next to the collapse chevron
+---@field buttonSize 'xs'|'sm'|'md'|'lg'|nil
 
 ---@param props LabeledChevronToggleProps
 ---@return HtmlNode
@@ -39,10 +41,10 @@ local function LabeledChevronToggle(props)
 	return Span{
 		classes = {'general-collapsible-default-toggle'},
 		children = {
-			labeledButton('expand', props.expandText, 'expand'),
-			labeledButton('collapse', props.collapseText, 'collapse'),
+			labeledButton('expand', props.expandText, 'expand', props.buttonSize),
+			labeledButton('collapse', props.collapseText, 'collapse', props.buttonSize),
 		}
 	}
 end
 
-return Component.component(LabeledChevronToggle)
+return Component.component(LabeledChevronToggle, {buttonSize = 'sm'})

--- a/lua/wikis/commons/Widget/Match/Summary/GameRow.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GameRow.lua
@@ -55,28 +55,6 @@ function MatchSummaryGameRow.createComponent(implProps, defaultProps)
 		end
 		local createGameOpponentView = FnUtil.curry(implProps.createGameOpponentView, componentProps)
 
-		local function createDetailedOverview()
-			if not implProps.hasDetail then
-				return
-			elseif not implProps.hasDetail(componentProps) then
-				return
-			end
-			return GeneralCollapsible{
-				shouldCollapse = true,
-				classes = {'brkts-popup-body-grid-row-collapsible'},
-				titleWidget = Html.Div{
-					classes = {'brkts-popup-body-grid-row-collapsible-title'},
-					attributes = {['data-collapsible-click-region'] = 'true'},
-					children = LabeledChevronToggle{
-						expandText = 'Show Detail',
-						collapseText = 'Hide detail',
-						buttonSize = 'xs',
-					},
-				},
-				children = implProps.createGameDetail(componentProps)
-			}
-		end
-
 		return Html.Div{
 			classes = {'brkts-popup-body-grid-row'},
 			css = componentProps.css,
@@ -111,7 +89,7 @@ function MatchSummaryGameRow.createComponent(implProps, defaultProps)
 					}
 				},
 				MatchSummaryGameRow._renderGameComment(implProps, componentProps),
-				createDetailedOverview()
+				MatchSummaryGameRow._createDetailedOverview(implProps, componentProps)
 			),
 		}
 	end
@@ -166,6 +144,32 @@ function MatchSummaryGameRow._renderGameComment(implProps, componentProps)
 	return Html.Div{
 		classes = {'brkts-popup-comment'},
 		children = Array.interleave(comments, Html.Br{}),
+	}
+end
+
+---@package
+---@param implProps MatchSummaryGameRowComponentProps
+---@param componentProps MatchSummaryGameRowProps
+---@return VNode?
+function MatchSummaryGameRow._createDetailedOverview(implProps, componentProps)
+	if implProps.hasDetail == nil then
+		return
+	elseif not implProps.hasDetail(componentProps) then
+		return
+	end
+	return GeneralCollapsible{
+		shouldCollapse = true,
+		classes = {'brkts-popup-body-grid-row-collapsible'},
+		titleWidget = Html.Div{
+			classes = {'brkts-popup-body-grid-row-collapsible-title'},
+			attributes = {['data-collapsible-click-region'] = 'true'},
+			children = LabeledChevronToggle{
+				expandText = 'Show Detail',
+				collapseText = 'Hide detail',
+				buttonSize = 'xs',
+			},
+		},
+		children = implProps.createGameDetail(componentProps)
 	}
 end
 

--- a/lua/wikis/commons/Widget/Match/Summary/GameRow.lua
+++ b/lua/wikis/commons/Widget/Match/Summary/GameRow.lua
@@ -17,12 +17,16 @@ local Component = Lua.import('Module:Widget/Component')
 local Html = Lua.import('Module:Widget/Html')
 local GameCenter = Lua.import('Module:Widget/Match/Summary/GameCenter')
 local GameWinLossIndicator = Lua.import('Module:Widget/Match/Summary/GameWinLossIndicator')
+local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
+local LabeledChevronToggle = Lua.import('Module:Widget/GeneralCollapsible/LabeledChevronToggle')
 
 ---@class MatchSummaryGameRowComponentProps
 ---@field getGameOpponentViewCss? fun(props: MatchSummaryGameRowProps, opponentIndex: integer): HtmlStyleProps?
 ---@field createAdditionalComment? fun(props: MatchSummaryGameRowProps): string?
 ---@field createGameOpponentView fun(props: MatchSummaryGameRowProps, opponentIndex: integer): Renderable|Renderable[]?
 ---@field createGameOverview fun(props: MatchSummaryGameRowProps): Renderable|Renderable[]
+---@field hasDetail? fun(props: MatchSummaryGameRowProps): boolean
+---@field createGameDetail? fun(props: MatchSummaryGameRowProps): Renderable|Renderable[]?
 
 ---@class MatchSummaryGameRowProps
 ---@field allowWrappingInOverview boolean?
@@ -51,39 +55,64 @@ function MatchSummaryGameRow.createComponent(implProps, defaultProps)
 		end
 		local createGameOpponentView = FnUtil.curry(implProps.createGameOpponentView, componentProps)
 
+		local function createDetailedOverview()
+			if not implProps.hasDetail then
+				return
+			elseif not implProps.hasDetail(componentProps) then
+				return
+			end
+			return GeneralCollapsible{
+				shouldCollapse = true,
+				classes = {'brkts-popup-body-grid-row-collapsible'},
+				titleWidget = Html.Div{
+					classes = {'brkts-popup-body-grid-row-collapsible-title'},
+					attributes = {['data-collapsible-click-region'] = 'true'},
+					children = LabeledChevronToggle{
+						expandText = 'Show Detail',
+						collapseText = 'Hide detail',
+						buttonSize = 'xs',
+					},
+				},
+				children = implProps.createGameDetail(componentProps)
+			}
+		end
+
 		return Html.Div{
 			classes = {'brkts-popup-body-grid-row'},
 			css = componentProps.css,
-			children = {
-				GameWinLossIndicator{
-					opponentIndex = 1,
-					winner = componentProps.game.winner,
-				},
-				Html.Div{
-					classes = {'brkts-popup-body-grid-row-detail'},
-					children = {
-						GameCenter{
-							css = getGameOpponentViewCss(1),
-							children = createGameOpponentView(1)
-						},
-						GameCenter{
-							css = componentProps.allowWrappingInOverview and {
-								['white-space'] = 'wrap',
-							} or nil,
-							children = implProps.createGameOverview(componentProps)
-						},
-						GameCenter{
-							css = getGameOpponentViewCss(2),
-							children = createGameOpponentView(2)
-						}
+			children = Array.extendWith(
+				{
+						GameWinLossIndicator{
+						opponentIndex = 1,
+						winner = componentProps.game.winner,
 					},
+					Html.Div{
+						classes = {'brkts-popup-body-grid-row-detail'},
+						children = {
+							GameCenter{
+								css = getGameOpponentViewCss(1),
+								children = createGameOpponentView(1)
+							},
+							GameCenter{
+								css = componentProps.allowWrappingInOverview and {
+									['white-space'] = 'wrap',
+								} or nil,
+								children = implProps.createGameOverview(componentProps)
+							},
+							GameCenter{
+								css = getGameOpponentViewCss(2),
+								children = createGameOpponentView(2)
+							}
+						},
+					},
+					GameWinLossIndicator{
+						opponentIndex = 2,
+						winner = componentProps.game.winner,
+					}
 				},
-				GameWinLossIndicator{
-					opponentIndex = 2,
-					winner = componentProps.game.winner,
-				},
-				MatchSummaryGameRow._renderGameComment(implProps, componentProps)
-			},
+				MatchSummaryGameRow._renderGameComment(implProps, componentProps),
+				createDetailedOverview()
+			),
 		}
 	end
 

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -111,7 +111,15 @@ function GameRowComponentProps.createGameDetail(props)
 				end
 			)
 			local maxDamage = Array.max(
-				Array.map(gamePlayers, Operator.property('damagedone'))
+				Array.map(gamePlayers, Operator.property('damagedone')),
+				function (maxDamage, damage)
+					if maxDamage == nil then
+						return damage
+					elseif damage == nil then
+						return maxDamage
+					end
+					return maxDamage < damage
+				end
 			)
 			return Html.Div{
 				css = {

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -8,13 +8,26 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
+local Logic = Lua.import('Module:Logic')
+local MathUtil = Lua.import('Module:MathUtil')
+local Operator = Lua.import('Module:Operator')
+local String = Lua.import('Module:StringUtils')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 
+local Html = Lua.import('Module:Widget/Html')
+local Link = Lua.import('Module:Widget/Basic/Link')
+
 local MAX_NUM_BANS = 5
 local NUM_HEROES_PICK = 5
+local SIDE_COLORS = {
+	red = '--clr-cinnabar-40',
+	blue = '--clr-sapphire-40',
+}
 local STATUS_NOT_PLAYED = 'notplayed'
+local SPAN_SLASH = Html.Span{classes = {'slash'}, children = '/'}
 
 ---@class LoLCustomMatchSummary: CustomMatchSummaryInterface
 local CustomMatchSummary = {}
@@ -65,6 +78,101 @@ function GameRowComponentProps.createGameOpponentView(props, opponentIndex)
 		),
 		bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (extradata['team' .. opponentIndex .. 'side'] or ''),
 		date = game.date,
+	}
+end
+
+---@param props MatchSummaryGameRowProps
+---@return boolean
+function GameRowComponentProps.hasDetail(props)
+	return Array.any(props.game.opponents, function (gameOpponent)
+		return Logic.isNotDeepEmpty(gameOpponent.players)
+	end)
+end
+
+---@param props MatchSummaryGameRowProps
+---@return VNode
+function GameRowComponentProps.createGameDetail(props)
+	local game = props.game
+	return Html.Div{
+		css = {
+			display = 'grid',
+			['column-gap'] = '0.5rem',
+			['grid-template-columns'] = 'min-content 1fr 1fr min-content'
+		},
+		children = Array.map(game.opponents, function (gameOpponent, gameOpponentIndex)
+			local side = game.extradata['team' .. gameOpponentIndex .. 'side']
+			local gamePlayers = Array.sortBy(
+				Array.filter(gameOpponent.players, Logic.isNotEmpty),
+				function (gamePlayer)
+					return gamePlayer.role
+				end,
+				function (a, b)
+					return InGameRoles[a].sortOrder < InGameRoles[b].sortOrder
+				end
+			)
+			local totalDamage = Array.reduce(
+				Array.map(gamePlayers, Operator.property('damagedone')),
+				Operator.nilSafeAdd
+			)
+			return Html.Div{
+				css = {
+					display = 'grid',
+					['grid-column'] = 'span 2',
+					['grid-template-columns'] = 'subgrid',
+					['row-gap'] = '0.25rem',
+				},
+				children = Array.map(gamePlayers, function (gamePlayer)
+					local kda = {gamePlayer.kills, gamePlayer.deaths, gamePlayer.assists}
+					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
+					return Html.Div{
+						css = {
+							display = 'grid',
+							['grid-column'] = '1 / -1',
+							['grid-template-columns'] = 'subgrid',
+							['justify-items'] = 'start',
+							direction = gameOpponentIndex == 2 and 'rtl' or nil,
+						},
+						children = {
+							MatchSummaryWidgets.Character{
+								bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (side or ''),
+								date = game.date,
+								flipped = gameOpponentIndex == 2,
+								showName = false,
+								size = '16px',
+								character = gamePlayer.character
+							},
+							Link{link = gamePlayer.player, gamePlayer.displayName},
+							Html.Div{
+								css = {
+									['grid-column'] = '1 / -1',
+								},
+								children = Array.interleave(kda, SPAN_SLASH)
+							},
+							totalDamage and Html.Div{
+								css = {
+									['grid-column'] = '1 / -1',
+									background = String.interpolate(
+										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+										{
+											leftBarColor = gameOpponentIndex == 1 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											leftBarLength = MathUtil.formatPercentage(
+												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
+											),
+											rightBarColor = gameOpponentIndex == 2 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											rightBarLength = MathUtil.formatPercentage(
+												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
+											),
+										}
+									),
+									height = '0.125rem',
+									width = '100%'
+								}
+							} or nil
+						}
+					}
+				end)
+			}
+		end)
 	}
 end
 

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -23,8 +23,8 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 local MAX_NUM_BANS = 5
 local NUM_HEROES_PICK = 5
 local SIDE_COLORS = {
-	red = '--clr-cinnabar-40',
-	blue = '--clr-sapphire-40',
+	red = 'var( --clr-cinnabar-40 )',
+	blue = 'var( --clr-sapphire-40 )',
 }
 local STATUS_NOT_PLAYED = 'notplayed'
 local SPAN_SLASH = Html.Span{classes = {'slash'}, children = '/'}
@@ -154,11 +154,11 @@ function GameRowComponentProps.createGameDetail(props)
 									background = String.interpolate(
 										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
 										{
-											leftBarColor = gameOpponentIndex == 1 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
 											leftBarLength = MathUtil.formatPercentage(
 												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
 											),
-											rightBarColor = gameOpponentIndex == 2 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
 											rightBarLength = MathUtil.formatPercentage(
 												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
 											),

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -121,6 +121,36 @@ function GameRowComponentProps.createGameDetail(props)
 					return maxDamage < damage
 				end
 			)
+
+			---@param damageDone number
+			---@return VNode?
+			local function buildDamageBar(damageDone)
+				if maxDamage == nil then
+					return
+				end
+				local damageRatio = damageDone / maxDamage
+				return Html.Div{
+					css = {
+						['grid-column'] = '1 / -1',
+						background = String.interpolate(
+							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+							{
+								leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
+								leftBarLength = MathUtil.formatPercentage(
+									gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
+								),
+								rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
+								rightBarLength = MathUtil.formatPercentage(
+									gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
+								),
+							}
+						),
+						height = '0.25rem',
+						width = '90%'
+					}
+				}
+			end
+
 			return Html.Div{
 				css = {
 					display = 'grid',
@@ -138,7 +168,6 @@ function GameRowComponentProps.createGameDetail(props)
 							')'
 						}} or nil
 					}, ' ')
-					local damageRatio = maxDamage ~= nil and (gamePlayer.damagedone / maxDamage) or nil
 					return Html.Div{
 						css = {
 							display = 'grid',
@@ -165,26 +194,7 @@ function GameRowComponentProps.createGameDetail(props)
 								},
 								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
-							maxDamage and Html.Div{
-								css = {
-									['grid-column'] = '1 / -1',
-									background = String.interpolate(
-										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
-										{
-											leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
-											leftBarLength = MathUtil.formatPercentage(
-												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
-											),
-											rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
-											rightBarLength = MathUtil.formatPercentage(
-												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
-											),
-										}
-									),
-									height = '0.25rem',
-									width = '90%'
-								}
-							} or nil
+							buildDamageBar(gamePlayer.damagedone)
 						}
 					}
 				end)

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -133,7 +133,8 @@ function GameRowComponentProps.createGameDetail(props)
 					css = {
 						['grid-column'] = '1 / -1',
 						background = String.interpolate(
-							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ' ..
+							'${rightBarColor} ${leftBarLength} ${rightBarLength})',
 							{
 								leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
 								leftBarLength = MathUtil.formatPercentage(

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -123,6 +123,14 @@ function GameRowComponentProps.createGameDetail(props)
 				},
 				children = Array.map(gamePlayers, function (gamePlayer)
 					local kda = {gamePlayer.kills, gamePlayer.deaths, gamePlayer.assists}
+					local stats = Array.interleave({
+						Html.Div{children = Array.interleave(kda, SPAN_SLASH)},
+						gamePlayer.damagedone and Html.Div{children = {
+							'(',
+							string.format('%.1fK', gamePlayer.damagedone / 1000),
+							')'
+						}} or nil
+					}, ' ')
 					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
 					return Html.Div{
 						css = {
@@ -134,19 +142,21 @@ function GameRowComponentProps.createGameDetail(props)
 						},
 						children = {
 							MatchSummaryWidgets.Character{
-								bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (side or ''),
 								date = game.date,
 								flipped = gameOpponentIndex == 2,
 								showName = false,
 								size = '16px',
 								character = gamePlayer.character
 							},
-							Link{link = gamePlayer.player, gamePlayer.displayName},
+							Link{link = gamePlayer.player, children = gamePlayer.displayName},
 							Html.Div{
 								css = {
+									display = 'flex',
+									['flex-direction'] = gameOpponentIndex == 2 and 'row-reverse' or nil,
+									gap = '0.25rem',
 									['grid-column'] = '1 / -1',
 								},
-								children = Array.interleave(kda, SPAN_SLASH)
+								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
 							totalDamage and Html.Div{
 								css = {
@@ -164,8 +174,8 @@ function GameRowComponentProps.createGameDetail(props)
 											),
 										}
 									),
-									height = '0.125rem',
-									width = '100%'
+									height = '0.25rem',
+									width = '90%'
 								}
 							} or nil
 						}

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -110,9 +110,8 @@ function GameRowComponentProps.createGameDetail(props)
 					return InGameRoles[a].sortOrder < InGameRoles[b].sortOrder
 				end
 			)
-			local totalDamage = Array.reduce(
-				Array.map(gamePlayers, Operator.property('damagedone')),
-				Operator.nilSafeAdd
+			local maxDamage = Array.max(
+				Array.map(gamePlayers, Operator.property('damagedone'))
 			)
 			return Html.Div{
 				css = {
@@ -131,7 +130,7 @@ function GameRowComponentProps.createGameDetail(props)
 							')'
 						}} or nil
 					}, ' ')
-					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
+					local damageRatio = maxDamage ~= nil and (gamePlayer.damagedone / maxDamage) or nil
 					return Html.Div{
 						css = {
 							display = 'grid',
@@ -158,7 +157,7 @@ function GameRowComponentProps.createGameDetail(props)
 								},
 								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
-							totalDamage and Html.Div{
+							maxDamage and Html.Div{
 								css = {
 									['grid-column'] = '1 / -1',
 									background = String.interpolate(

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -127,7 +127,8 @@ function GameRowComponentProps.createGameDetail(props)
 					css = {
 						['grid-column'] = '1 / -1',
 						background = String.interpolate(
-							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ' ..
+							'${rightBarColor} ${leftBarLength} ${rightBarLength})',
 							{
 								leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
 								leftBarLength = MathUtil.formatPercentage(

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -105,7 +105,15 @@ function GameRowComponentProps.createGameDetail(props)
 				end
 			)
 			local maxDamage = Array.max(
-				Array.map(gamePlayers, Operator.property('damagedone'))
+				Array.map(gamePlayers, Operator.property('damagedone')),
+				function (maxDamage, damage)
+					if maxDamage == nil then
+						return damage
+					elseif damage == nil then
+						return maxDamage
+					end
+					return maxDamage < damage
+				end
 			)
 			return Html.Div{
 				css = {

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -117,6 +117,14 @@ function GameRowComponentProps.createGameDetail(props)
 				},
 				children = Array.map(gamePlayers, function (gamePlayer)
 					local kda = {gamePlayer.kills, gamePlayer.deaths, gamePlayer.assists}
+					local stats = Array.interleave({
+						Html.Div{children = Array.interleave(kda, SPAN_SLASH)},
+						gamePlayer.damagedone and Html.Div{children = {
+							'(',
+							string.format('%.1fK', gamePlayer.damagedone / 1000),
+							')'
+						}} or nil
+					}, ' ')
 					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
 					return Html.Div{
 						css = {
@@ -128,19 +136,21 @@ function GameRowComponentProps.createGameDetail(props)
 						},
 						children = {
 							MatchSummaryWidgets.Character{
-								bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (side or ''),
 								date = game.date,
 								flipped = gameOpponentIndex == 2,
 								showName = false,
 								size = '16px',
 								character = gamePlayer.character
 							},
-							Link{link = gamePlayer.player, gamePlayer.displayName},
+							Link{link = gamePlayer.player, children = gamePlayer.displayName},
 							Html.Div{
 								css = {
+									display = 'flex',
+									['flex-direction'] = gameOpponentIndex == 2 and 'row-reverse' or nil,
+									gap = '0.25rem',
 									['grid-column'] = '1 / -1',
 								},
-								children = Array.interleave(kda, SPAN_SLASH)
+								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
 							totalDamage and Html.Div{
 								css = {
@@ -158,8 +168,8 @@ function GameRowComponentProps.createGameDetail(props)
 											),
 										}
 									),
-									height = '0.125rem',
-									width = '100%'
+									height = '0.25rem',
+									width = '90%'
 								}
 							} or nil
 						}

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -8,13 +8,26 @@
 local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
+local InGameRoles = Lua.import('Module:InGameRoles', {loadData = true})
+local Logic = Lua.import('Module:Logic')
+local MathUtil = Lua.import('Module:MathUtil')
+local Operator = Lua.import('Module:Operator')
+local String = Lua.import('Module:StringUtils')
 
 local MatchSummary = Lua.import('Module:MatchSummary/Base')
 local MatchSummaryWidgets = Lua.import('Module:Widget/Match/Summary/All')
 
+local Html = Lua.import('Module:Widget/Html')
+local Link = Lua.import('Module:Widget/Basic/Link')
+
 local MAX_NUM_BANS = 5
 local NUM_HEROES_PICK = 5
+local SIDE_COLORS = {
+	red = '--clr-cinnabar-40',
+	blue = '--clr-sapphire-40',
+}
 local STATUS_NOT_PLAYED = 'notplayed'
+local SPAN_SLASH = Html.Span{classes = {'slash'}, children = '/'}
 
 ---@class LoLCustomMatchSummary: CustomMatchSummaryInterface
 local CustomMatchSummary = {}
@@ -59,6 +72,101 @@ function GameRowComponentProps.createGameOpponentView(props, opponentIndex)
 		),
 		bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (extradata['team' .. opponentIndex .. 'side'] or ''),
 		date = game.date,
+	}
+end
+
+---@param props MatchSummaryGameRowProps
+---@return boolean
+function GameRowComponentProps.hasDetail(props)
+	return Array.any(props.game.opponents, function (gameOpponent)
+		return Logic.isNotDeepEmpty(gameOpponent.players)
+	end)
+end
+
+---@param props MatchSummaryGameRowProps
+---@return VNode
+function GameRowComponentProps.createGameDetail(props)
+	local game = props.game
+	return Html.Div{
+		css = {
+			display = 'grid',
+			['column-gap'] = '0.5rem',
+			['grid-template-columns'] = 'min-content 1fr 1fr min-content'
+		},
+		children = Array.map(game.opponents, function (gameOpponent, gameOpponentIndex)
+			local side = game.extradata['team' .. gameOpponentIndex .. 'side']
+			local gamePlayers = Array.sortBy(
+				Array.filter(gameOpponent.players, Logic.isNotEmpty),
+				function (gamePlayer)
+					return gamePlayer.role
+				end,
+				function (a, b)
+					return InGameRoles[a].sortOrder < InGameRoles[b].sortOrder
+				end
+			)
+			local totalDamage = Array.reduce(
+				Array.map(gamePlayers, Operator.property('damagedone')),
+				Operator.nilSafeAdd
+			)
+			return Html.Div{
+				css = {
+					display = 'grid',
+					['grid-column'] = 'span 2',
+					['grid-template-columns'] = 'subgrid',
+					['row-gap'] = '0.25rem',
+				},
+				children = Array.map(gamePlayers, function (gamePlayer)
+					local kda = {gamePlayer.kills, gamePlayer.deaths, gamePlayer.assists}
+					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
+					return Html.Div{
+						css = {
+							display = 'grid',
+							['grid-column'] = '1 / -1',
+							['grid-template-columns'] = 'subgrid',
+							['justify-items'] = 'start',
+							direction = gameOpponentIndex == 2 and 'rtl' or nil,
+						},
+						children = {
+							MatchSummaryWidgets.Character{
+								bg = 'brkts-popup-side-color brkts-popup-side-color--' .. (side or ''),
+								date = game.date,
+								flipped = gameOpponentIndex == 2,
+								showName = false,
+								size = '16px',
+								character = gamePlayer.character
+							},
+							Link{link = gamePlayer.player, gamePlayer.displayName},
+							Html.Div{
+								css = {
+									['grid-column'] = '1 / -1',
+								},
+								children = Array.interleave(kda, SPAN_SLASH)
+							},
+							totalDamage and Html.Div{
+								css = {
+									['grid-column'] = '1 / -1',
+									background = String.interpolate(
+										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+										{
+											leftBarColor = gameOpponentIndex == 1 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											leftBarLength = MathUtil.formatPercentage(
+												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
+											),
+											rightBarColor = gameOpponentIndex == 2 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											rightBarLength = MathUtil.formatPercentage(
+												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
+											),
+										}
+									),
+									height = '0.125rem',
+									width = '100%'
+								}
+							} or nil
+						}
+					}
+				end)
+			}
+		end)
 	}
 end
 

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -23,8 +23,8 @@ local Link = Lua.import('Module:Widget/Basic/Link')
 local MAX_NUM_BANS = 5
 local NUM_HEROES_PICK = 5
 local SIDE_COLORS = {
-	red = '--clr-cinnabar-40',
-	blue = '--clr-sapphire-40',
+	red = 'var( --clr-cinnabar-40 )',
+	blue = 'var( --clr-sapphire-40 )',
 }
 local STATUS_NOT_PLAYED = 'notplayed'
 local SPAN_SLASH = Html.Span{classes = {'slash'}, children = '/'}
@@ -148,11 +148,11 @@ function GameRowComponentProps.createGameDetail(props)
 									background = String.interpolate(
 										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
 										{
-											leftBarColor = gameOpponentIndex == 1 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
 											leftBarLength = MathUtil.formatPercentage(
 												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
 											),
-											rightBarColor = gameOpponentIndex == 2 and ('var(' .. SIDE_COLORS[side] .. ')') or 'transparent',
+											rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
 											rightBarLength = MathUtil.formatPercentage(
 												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
 											),

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -104,9 +104,8 @@ function GameRowComponentProps.createGameDetail(props)
 					return InGameRoles[a].sortOrder < InGameRoles[b].sortOrder
 				end
 			)
-			local totalDamage = Array.reduce(
-				Array.map(gamePlayers, Operator.property('damagedone')),
-				Operator.nilSafeAdd
+			local maxDamage = Array.max(
+				Array.map(gamePlayers, Operator.property('damagedone'))
 			)
 			return Html.Div{
 				css = {
@@ -125,7 +124,7 @@ function GameRowComponentProps.createGameDetail(props)
 							')'
 						}} or nil
 					}, ' ')
-					local damageRatio = totalDamage ~= nil and (gamePlayer.damagedone / totalDamage) or nil
+					local damageRatio = maxDamage ~= nil and (gamePlayer.damagedone / maxDamage) or nil
 					return Html.Div{
 						css = {
 							display = 'grid',
@@ -152,7 +151,7 @@ function GameRowComponentProps.createGameDetail(props)
 								},
 								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
-							totalDamage and Html.Div{
+							maxDamage and Html.Div{
 								css = {
 									['grid-column'] = '1 / -1',
 									background = String.interpolate(

--- a/lua/wikis/leagueoflegends/MatchSummary.lua
+++ b/lua/wikis/leagueoflegends/MatchSummary.lua
@@ -115,6 +115,36 @@ function GameRowComponentProps.createGameDetail(props)
 					return maxDamage < damage
 				end
 			)
+
+			---@param damageDone number
+			---@return VNode?
+			local function buildDamageBar(damageDone)
+				if maxDamage == nil then
+					return
+				end
+				local damageRatio = damageDone / maxDamage
+				return Html.Div{
+					css = {
+						['grid-column'] = '1 / -1',
+						background = String.interpolate(
+							'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
+							{
+								leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
+								leftBarLength = MathUtil.formatPercentage(
+									gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
+								),
+								rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
+								rightBarLength = MathUtil.formatPercentage(
+									gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
+								),
+							}
+						),
+						height = '0.25rem',
+						width = '90%'
+					}
+				}
+			end
+
 			return Html.Div{
 				css = {
 					display = 'grid',
@@ -132,7 +162,6 @@ function GameRowComponentProps.createGameDetail(props)
 							')'
 						}} or nil
 					}, ' ')
-					local damageRatio = maxDamage ~= nil and (gamePlayer.damagedone / maxDamage) or nil
 					return Html.Div{
 						css = {
 							display = 'grid',
@@ -159,26 +188,7 @@ function GameRowComponentProps.createGameDetail(props)
 								},
 								children = gameOpponentIndex == 1 and stats or Array.reverse(stats)
 							},
-							maxDamage and Html.Div{
-								css = {
-									['grid-column'] = '1 / -1',
-									background = String.interpolate(
-										'linear-gradient(to right, ${leftBarColor} ${leftBarLength}, ${rightBarColor} ${leftBarLength} ${rightBarLength})',
-										{
-											leftBarColor = gameOpponentIndex == 1 and SIDE_COLORS[side] or 'transparent',
-											leftBarLength = MathUtil.formatPercentage(
-												gameOpponentIndex == 1 and damageRatio or (1 - damageRatio)
-											),
-											rightBarColor = gameOpponentIndex == 2 and SIDE_COLORS[side] or 'transparent',
-											rightBarLength = MathUtil.formatPercentage(
-												gameOpponentIndex == 2 and damageRatio or (1 - damageRatio)
-											),
-										}
-									),
-									height = '0.25rem',
-									width = '90%'
-								}
-							} or nil
+							buildDamageBar(gamePlayer.damagedone)
 						}
 					}
 				end)

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -687,8 +687,16 @@ div.brkts-popup-body-element-thumbs {
 		&:nth-of-type( even ) {
 			background-color: var( --clr-on-surface-light-primary-4 );
 
+			.brkts-popup-body-grid-row-collapsible {
+				background-color: var( --clr-secondary-100 );
+			}
+
 			.theme--dark & {
 				background-color: var( --clr-on-surface-dark-primary-4 );
+
+				.brkts-popup-body-grid-row-collapsible {
+					background-color: var( --clr-secondary-16 );
+				}
 			}
 		}
 
@@ -715,6 +723,42 @@ div.brkts-popup-body-element-thumbs {
 			> .brkts-popup-spaced:nth-last-of-type( 1 ) {
 				flex-direction: row-reverse;
 				justify-content: flex-start;
+			}
+		}
+
+		&-collapsible {
+			display: grid;
+			grid-column: 1 / -1;
+			grid-template-columns: subgrid;
+			background-color: var( --clr-on-surface-light-primary-4 );
+			border-radius: 0.5rem;
+			padding: 0.25rem;
+
+			.theme--dark & {
+				background-color: var( --clr-on-surface-dark-primary-4 );
+			}
+
+			&-title {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				grid-column: 1 / -1;
+			}
+
+			&:not( .collapsed ) .should-collapse {
+				display: grid;
+				grid-column: 1 / -1;
+				grid-template-columns: subgrid;
+				padding: 0.25rem;
+
+				&:has( > :only-child ) {
+					display: contents;
+
+					> :only-child {
+						grid-column: 1 / -1;
+						padding: 0.25rem;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

_pending designer feedback_

Discussion on discord: https://discord.com/channels/93055209017729024/276340346831765504/1534483291787493537

This PR adds collapsible detail to game summaries in LoL.

<img width="409" height="929" alt="image" src="https://github.com/user-attachments/assets/9eec0990-5863-4440-9593-04e388a61c3b" />

## How did you test this change?

<https://liquipedia.net/leagueoflegends/Special:PermanentLink/1039488> + browser dev tools