### PR TITLE
feat: show a different transfer query link for lighthouse users

### DIFF
--- a/lua/wikis/commons/Widget/MainPage/TransfersList.lua
+++ b/lua/wikis/commons/Widget/MainPage/TransfersList.lua
@@ -88,7 +88,7 @@ local function TransfersList(props)
 								},
 							}
 						} or nil,
-						Div {
+						Html.Span {
 							classes = { 'show-when-logged-in' },
 							children = Link {
 								children = 'Input Form',

--- a/lua/wikis/commons/Widget/MainPage/TransfersList.lua
+++ b/lua/wikis/commons/Widget/MainPage/TransfersList.lua
@@ -70,16 +70,16 @@ local function TransfersList(props)
 					},
 					children = ListWidgets.Unordered{children = WidgetUtil.collect(
 						Link { children = 'See more transfers', link = props.transferPortal },
-						Logic.readBool(props.transferQuery) and Div {
+						Logic.readBool(props.transferQuery) and Html.Span {
 							children = {
-								Div {
+								Html.Span {
 									classes = { 'hide-when-lighthouse' },
 									children = Link {
 										children = 'Transfer query',
 										link = 'Special:RunQuery/Transfer history'
 									}
 								},
-								Div {
+								Html.Span {
 									classes = { 'hide-when-mediawiki' },
 									children = Link {
 										children = 'Transfer query',

--- a/lua/wikis/commons/Widget/MainPage/TransfersList.lua
+++ b/lua/wikis/commons/Widget/MainPage/TransfersList.lua
@@ -70,13 +70,30 @@ local function TransfersList(props)
 					},
 					children = ListWidgets.Unordered{children = WidgetUtil.collect(
 						Link { children = 'See more transfers', link = props.transferPortal },
-						Logic.readBool(props.transferQuery) and Link {
-							children = 'Transfer query',
-							link = 'Special:RunQuery/Transfer history'
+						Logic.readBool(props.transferQuery) and Div {
+							children = {
+								Div {
+									classes = { 'hide-when-lighthouse' },
+									children = Link {
+										children = 'Transfer query',
+										link = 'Special:RunQuery/Transfer history'
+									}
+								},
+								Div {
+									classes = { 'hide-when-mediawiki' },
+									children = Link {
+										children = 'Transfer query',
+										link = 'Special:RunQuery/Transfer query'
+									}
+								},
+							}
 						} or nil,
-						Link {
-							children = 'Input Form',
-							link = (Page.exists('Form:Transfer') and '' or 'lpcommons:') .. 'Special:RunQuery/Transfer'
+						Div {
+							classes = { 'show-when-logged-in' },
+							children = Link {
+								children = 'Input Form',
+								link = (Page.exists('Form:Transfer') and '' or 'lpcommons:') .. 'Special:RunQuery/Transfer'
+							}
 						},
 						Logic.readBool(props.rumours) and Link { children = 'Rumours', link = 'Portal:Rumours' } or nil
 					)}

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -9,6 +9,27 @@ Author(s): FO-nTTaX
 }
 
 /*******************************************************************************
+Temporary show/hide during MW/LH Migrations
+*******************************************************************************/
+body:not( .mediawiki ) .hide-when-mediawiki {
+	display: none;
+}
+
+body.mediawiki .hide-when-lighthouse {
+	display: none;
+}
+
+/*******************************************************************************
+Hide/show content based on user login status
+*******************************************************************************/
+body.logged-in .hide-when-logged-in,
+body.logged-in .show-when-logged-out,
+body.logged-out .hide-when-logged-out,
+body.logged-out .show-when-logged-in {
+	display: none;
+}
+
+/*******************************************************************************
 Template(s): Documentation
 Author(s): FO-nTTaX
 *******************************************************************************/

--- a/stylesheets/commons/Miscellaneous.scss
+++ b/stylesheets/commons/Miscellaneous.scss
@@ -11,11 +11,11 @@ Author(s): FO-nTTaX
 /*******************************************************************************
 Temporary show/hide during MW/LH Migrations
 *******************************************************************************/
-body:not( .mediawiki ) .hide-when-mediawiki {
+body:not( .mediawiki ) .hide-when-lighthouse {
 	display: none;
 }
 
-body.mediawiki .hide-when-lighthouse {
+body.mediawiki .hide-when-mediawiki {
 	display: none;
 }
 


### PR DESCRIPTION
## Summary
Makes the mainpage transfers query link go to a different RunQuery target if user is on Lighthouse.

Also hides  the Form:Transfer for logged out users, as it's an editor tool

Also adds the show-when-logged-in etc to this repo, so they can work in lighthouse.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
