### PR TITLE
chore: mark match1 javascript as deprecated

### DIFF
--- a/javascript/Main.js
+++ b/javascript/Main.js
@@ -47,6 +47,7 @@ const jsModules = [
 	'Analytics',
 	'BattleRoyale',
 	'Bracket',
+	'Brackets',
 	'Carousel',
 	'Collapse',
 	'Commons_mainpage',

--- a/javascript/commons/Bracket.js
+++ b/javascript/commons/Bracket.js
@@ -1,53 +1,12 @@
 /*******************************************************************************
- * Template(s): Popups and highlighting for all Brackets
+ * Template(s): Legacy match1 brackets
+ * DEPRECATED: DO NOT USE ON NEW COMPONENTS
  * Author(s): FO-nTTaX, Elysienna
  ******************************************************************************/
 liquipedia.bracket = {
 	init: function() {
 		liquipedia.bracket.popup.init();
 		liquipedia.bracket.highlighting.init();
-		liquipedia.bracket.headers.init();
-	},
-	headers: {
-		init: function() {
-			liquipedia.bracket.headers.updateAll();
-			window.addEventListener( 'resize', liquipedia.bracket.headers.debounce( () => {
-				liquipedia.bracket.headers.updateAll();
-			}, 100 ) );
-		},
-		debounce: function( callback, wait ) {
-			let timeout;
-			return function( e ) {
-				clearTimeout( timeout );
-				timeout = setTimeout( () => {
-					callback( e );
-				}, wait );
-			};
-		},
-		updateAll: function() {
-			document.querySelectorAll( '.brkts-header-div' ).forEach( ( element ) => {
-				const optionsDivs = Array.from( element.querySelectorAll( '.brkts-header-option' ) );
-				if ( optionsDivs.length === 0 ) {
-					return;
-				}
-				const options = optionsDivs.map( ( div ) => div.textContent );
-
-				Array.from( element.childNodes ).forEach( ( child ) => {
-					if ( !optionsDivs.includes( child ) ) {
-						element.removeChild( child );
-					}
-				} );
-
-				for ( let i = 0; i < options.length; i++ ) {
-					const textNode = document.createTextNode( options[ i ] );
-					element.insertBefore( textNode, element.firstChild );
-					if ( element.scrollWidth <= element.clientWidth || i === options.length - 1 ) {
-						break;
-					}
-					element.removeChild( textNode );
-				}
-			} );
-		}
 	},
 	highlighting: {
 		standardIcons: [

--- a/javascript/commons/Brackets.js
+++ b/javascript/commons/Brackets.js
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Template(s): Match2 brackets
+ ******************************************************************************/
+
+liquipedia.brackets = {
+	init: function() {
+		liquipedia.brackets.headers.init();
+	},
+	headers: {
+		init: function() {
+			liquipedia.brackets.headers.updateAll();
+			window.addEventListener( 'resize', liquipedia.bracket.headers.debounce( () => {
+				liquipedia.brackets.headers.updateAll();
+			}, 100 ) );
+		},
+		debounce: function( callback, wait ) {
+			let timeout;
+			return function( e ) {
+				clearTimeout( timeout );
+				timeout = setTimeout( () => {
+					callback( e );
+				}, wait );
+			};
+		},
+		updateAll: function() {
+			document.querySelectorAll( '.brkts-header-div' ).forEach( ( element ) => {
+				const optionsDivs = Array.from( element.querySelectorAll( '.brkts-header-option' ) );
+				if ( optionsDivs.length === 0 ) {
+					return;
+				}
+				const options = optionsDivs.map( ( div ) => div.textContent );
+
+				Array.from( element.childNodes ).forEach( ( child ) => {
+					if ( !optionsDivs.includes( child ) ) {
+						element.removeChild( child );
+					}
+				} );
+
+				for ( let i = 0; i < options.length; i++ ) {
+					const textNode = document.createTextNode( options[ i ] );
+					element.insertBefore( textNode, element.firstChild );
+					if ( element.scrollWidth <= element.clientWidth || i === options.length - 1 ) {
+						break;
+					}
+					element.removeChild( textNode );
+				}
+			} );
+		}
+	}
+};
+
+liquipedia.core.modules.push( 'brackets' );

--- a/javascript/commons/Brackets.js
+++ b/javascript/commons/Brackets.js
@@ -9,7 +9,7 @@ liquipedia.brackets = {
 	headers: {
 		init: function() {
 			liquipedia.brackets.headers.updateAll();
-			window.addEventListener( 'resize', liquipedia.bracket.headers.debounce( () => {
+			window.addEventListener( 'resize', liquipedia.brackets.headers.debounce( () => {
 				liquipedia.brackets.headers.updateAll();
 			}, 100 ) );
 		},


### PR DESCRIPTION
## Summary

_RLA ready_

This PR:
- extracts match2-specific javascript (from #7007) in `Bracket.js` to `Brackets.js`
- marks `Bracket.js` as deprecated

## How did you test this change?

N/A; simple copy-paste job