### PR TITLE
fix: drop gsub substitution count from condition values

### DIFF
--- a/lua/wikis/commons/ExternalMediaList.lua
+++ b/lua/wikis/commons/ExternalMediaList.lua
@@ -120,7 +120,7 @@ function MediaList._buildConditions(args)
 
 	if args.org then
 		additionalConditions:add{
-			ConditionUtil.anyOf(ColumnName('extradata_subject_organization'), {args.org, args.org:gsub(' ', '_')}),
+			ConditionUtil.anyOf(ColumnName('extradata_subject_organization'), {args.org, (args.org:gsub(' ', '_'))}),
 			MediaList._buildMultiKeyCondition(args.org, 'extradata_subject_organization', 5)
 		}
 	end
@@ -129,7 +129,7 @@ function MediaList._buildConditions(args)
 
 	if args.event then
 		additionalConditions:add(
-			ConditionUtil.anyOf(ColumnName('extradata_event_link'), {args.event, args.event:gsub(' ', '_')})
+			ConditionUtil.anyOf(ColumnName('extradata_event_link'), {args.event, (args.event:gsub(' ', '_'))})
 		)
 	end
 
@@ -149,7 +149,7 @@ function MediaList._buildMultiKeyCondition(value, prefix, limit)
 	end
 	return ConditionTree(BooleanOperator.any):add(
 		Array.mapRange(1, limit, function (index)
-			return ConditionUtil.anyOf(ColumnName(prefix .. index), {value, value:gsub(' ', '_')})
+			return ConditionUtil.anyOf(ColumnName(prefix .. index), {value, (value:gsub(' ', '_'))})
 		end)
 	)
 end

--- a/lua/wikis/commons/Infobox/Extension/UpcomingTournaments.lua
+++ b/lua/wikis/commons/Infobox/Extension/UpcomingTournaments.lua
@@ -60,7 +60,7 @@ function UpcomingTournaments.player(args)
 		function (playerIndex)
 			return ConditionUtil.anyOf(
 				ColumnName(prefix .. playerIndex, 'opponentplayers'),
-				{args.name, args.name:gsub(' ', '_')}
+				{args.name, (args.name:gsub(' ', '_'))}
 			)
 		end
 	))

--- a/lua/wikis/commons/Squad/Auto.lua
+++ b/lua/wikis/commons/Squad/Auto.lua
@@ -657,7 +657,7 @@ end
 function SquadAuto._fetchNextTeam(pagename, date)
 	local conditions = Condition.Tree(BooleanOperator.all)
 		:add{
-			Condition.Util.anyOf(Condition.ColumnName('player'), {pagename, string.gsub(pagename, ' ', '_')}),
+			Condition.Util.anyOf(Condition.ColumnName('player'), {pagename, (string.gsub(pagename, ' ', '_'))}),
 			Condition.Node(Condition.ColumnName('date'), Comparator.ge, date),
 			Condition.Node(Condition.ColumnName('toteamtemplate'), Comparator.neq, ''),
 		}


### PR DESCRIPTION
## Summary
`string.gsub` returns two values, the resulting string and the number of substitutions it made. A call in the last position of a table constructor expands to all of its return values, so

	{value, value:gsub(' ', '_')}

builds a three element table whose last element is the substitution count. `ConditionUtil.anyOf` turns every element into a condition, so each of these queries carried an extra condition matching the count as if it were a page name. That extra condition matched nothing, so no results changed, but it did widen the query to cause an additional pass over the data looking for something that didn't exist.

Wrapping the call in parentheses adjusts it to a single value, leaving the table with just the name and its underscored form.

## How did you test this change?
Locally tested gsub behavior before and after.