### PR TITLE
chore: better mw.uri mock

### DIFF
--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1088,7 +1088,7 @@ function mw.uri.localUrl(page, query)
 		{
 			__index = mw.uri,
 			__tostring = function (t)
-				return t.page .. '?' .. t.query
+				return t.path .. '?' .. t.query
 			end
 		}
 	)
@@ -1109,7 +1109,7 @@ function mw.uri.fullUrl(page, query)
 		{
 			__index = mw.uri,
 			__tostring = function (t)
-				return mw.site.server .. t.page .. '?' .. t.query
+				return mw.site.server .. t.path .. '?' .. t.query
 			end
 		}
 	)

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1143,9 +1143,12 @@ function mw.uri.decode(str, enctype) end
 ---@param query table<string, string|number|any[]|false>
 ---@return string
 function mw.uri.buildQueryString(query)
-	---@param str string
+	---@param str string|number|boolean
 	---@return string
 	local function encode(str)
+		if type(str) ~= 'string' then
+			return tostring(str)
+		end
 		return (str:gsub('([^%w_.~-])', function (character)
 			if character == ' ' then
 				return '+'

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1109,7 +1109,9 @@ function mw.uri.fullUrl(page, query)
 		{
 			__index = mw.uri,
 			__tostring = function (t)
-				return mw.site.server .. t.path .. '?' .. t.query
+				return mw.site.server .. t.path .. '?' .. (
+					type(t.query) == 'string' and t.query or mw.uri.buildQueryString(t.query)
+				)
 			end
 		}
 	)
@@ -1132,7 +1134,35 @@ function mw.uri.decode(str, enctype) end
 ---Encodes a table as a URI query string.
 ---@param query table<string, string|number|any[]|false>
 ---@return string
-function mw.uri.buildQueryString(query) end
+function mw.uri.buildQueryString(query)
+	---@param str string
+	---@return string
+	local function encode(str)
+		return (str:gsub('([^%w])', function (character)
+			if character == ' ' then
+				return '+'
+			end
+			return string.format('%%%02X', string.byte(character))
+		end))
+	end
+
+	local ret = {}
+
+	for k, v in pairs(query) do
+		if type(v) ~= 'table' then
+			v = {v}
+		end
+		for _, queryArg in ipairs(v) do
+			local argRet = {encode(k)}
+			if queryArg then
+				table.insert(argRet, encode(queryArg))
+			end
+			table.insert(ret, table.concat(argRet, '='))
+		end
+	end
+
+	return table.concat(ret, '&')
+end
 
 ---Decodes the query string `s` to a table. Optional arguments `i` and `j` may be used to specify
 ---the substring of `s` to be parsed.

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1146,7 +1146,7 @@ function mw.uri.buildQueryString(query)
 	---@param str string
 	---@return string
 	local function encode(str)
-		return (str:gsub('([^%w])', function (character)
+		return (str:gsub('([^%w_.~-])', function (character)
 			if character == ' ' then
 				return '+'
 			end

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1088,7 +1088,12 @@ function mw.uri.localUrl(page, query)
 		{
 			__index = mw.uri,
 			__tostring = function (t)
-				return t.path .. '?' .. t.query
+				if not t.query then
+					return t.path
+				end
+				return t.path .. '?' .. (
+					type(t.query) == 'string' and t.query or mw.uri.buildQueryString(t.query)
+				)
 			end
 		}
 	)
@@ -1109,6 +1114,9 @@ function mw.uri.fullUrl(page, query)
 		{
 			__index = mw.uri,
 			__tostring = function (t)
+				if not t.query then
+					return mw.site.server .. t.path
+				end
 				return mw.site.server .. t.path .. '?' .. (
 					type(t.query) == 'string' and t.query or mw.uri.buildQueryString(t.query)
 				)

--- a/lua/definitions/mw.lua
+++ b/lua/definitions/mw.lua
@@ -1080,7 +1080,18 @@ function mw.uri.new(str) end
 ---@param query string|table?
 ---@return URI
 function mw.uri.localUrl(page, query)
-	return ''
+	return setmetatable(
+		{
+			path = page,
+			query = query,
+		},
+		{
+			__index = mw.uri,
+			__tostring = function (t)
+				return t.page .. '?' .. t.query
+			end
+		}
+	)
 end
 
 ---Returns a URI object for the full URL for a page, with optional query string/table
@@ -1088,7 +1099,20 @@ end
 ---@param query string|table?
 ---@return URI
 function mw.uri.fullUrl(page, query)
-	return 'https://liquipedia.net/'
+	return setmetatable(
+		{
+			protocol = 'https',
+			host = 'liquipedia.net',
+			path = page,
+			query = query,
+		},
+		{
+			__index = mw.uri,
+			__tostring = function (t)
+				return mw.site.server .. t.page .. '?' .. t.query
+			end
+		}
+	)
 end
 
 ---@alias UriEncodeType 'QUERY'|'PATH'|'WIKI'


### PR DESCRIPTION
## Summary

LuaLS complained for type mismatch ever since the library specification for `mw.uri` was added with #5950.
This PR improves mw.uri mock just enough for LuaLS to be happy

## How did you test this change?

