### PR TITLE
feat(match2): support ligthouse h2h links

### DIFF
--- a/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/ageofempires/MatchGroup/Input/Custom.lua
@@ -181,7 +181,7 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	if opponents[1].type ~= Opponent.solo or opponents[2].type ~= Opponent.solo then
 		return
@@ -199,7 +199,14 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 
 	return tostring(mw.uri.fullUrl('Special:RunQuery/Match_history')) ..
 		'?pfRunQueryFormName=Match+history&Head_to_head_query%5Bplayer%5D=' ..player1 ..
-		'&Head_to_head_query%5Bopponent%5D=' .. player2 .. '&wpRunQuery=Run+query'
+		'&Head_to_head_query%5Bopponent%5D=' .. player2 .. '&wpRunQuery=Run+query',
+		tostring(mw.uri.fullUrl(
+			'Special:RunQuery/H2H',
+			{
+				['player'] = player1,
+				['opponent'] = player2,
+			}
+		))
 end
 
 ---@param map table

--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -532,6 +532,10 @@ local MATCH_ICONS = {
 		icon = 'Match Info Stats.png',
 		text = 'Head-to-head statistics'
 	},
+	headtohead_lh = {
+		icon = 'Match Info Stats.png',
+		text = 'Head-to-head statistics'
+	},
 	interview = {
 		icon = 'Interview32.png',
 		text = 'Interview'

--- a/lua/wikis/commons/Links/MatchPriorityGroups.lua
+++ b/lua/wikis/commons/Links/MatchPriorityGroups.lua
@@ -14,6 +14,7 @@ return {
 	'lrthread',
 	'recap',
 	'headtohead',
+	'headtohead_lh',
 
 	-- ageofempires
 	'mapdraft',

--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -185,12 +185,12 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		return
 	end
 
-	return (tostring(mw.uri.fullUrl('Special:RunQuery/Match_history'))
+	return ((tostring(mw.uri.fullUrl('Special:RunQuery/Match_history'))
 		.. '?pfRunQueryFormName=Match+history&Head_to_head_query%5Bplayer%5D='
 		.. opponents[1].match2players[1].name
 		.. '&Head_to_head_query%5Bopponent%5D='
 		.. opponents[2].match2players[1].name
-		.. '&wpRunQuery=Run+query'):gsub(' ', '_'),
+		.. '&wpRunQuery=Run+query'):gsub(' ', '_')),
 		tostring(mw.uri.fullUrl(
 			'Special:RunQuery/H2H',
 			{

--- a/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Starcraft.lua
@@ -174,7 +174,7 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	local showH2H = Logic.readBool(Logic.emptyOr(match.headtohead, Variables.varDefault('headtohead')))
 	Variables.varDefine('headtohead', tostring(showH2H))
@@ -190,7 +190,14 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		.. opponents[1].match2players[1].name
 		.. '&Head_to_head_query%5Bopponent%5D='
 		.. opponents[2].match2players[1].name
-		.. '&wpRunQuery=Run+query'):gsub(' ', '_')
+		.. '&wpRunQuery=Run+query'):gsub(' ', '_'),
+		tostring(mw.uri.fullUrl(
+			'Special:RunQuery/H2H',
+			{
+				['player'] = opponents[1].match2players[1].name,
+				['opponent'] = opponents[2].match2players[1].name,
+			}
+		))
 end
 
 ---@param extradata table

--- a/lua/wikis/commons/MatchGroup/Input/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Input/Util.lua
@@ -1092,7 +1092,7 @@ end
 ---@field getExtraData? fun(match: table, games: table[], opponents: MGIParsedOpponent[]): table?
 ---@field adjustOpponent? fun(opponent: MGIParsedOpponent, opponentIndex: integer)
 ---@field getLinks? fun(match: table, games: table[]): table
----@field getHeadToHeadLink? fun(match: table, opponents: MGIParsedOpponent[]): string?
+---@field getHeadToHeadLink? fun(match: table, opponents: MGIParsedOpponent[]): string?, string?
 ---@field getPatch? fun(match: table, games: table[]): string?
 ---@field readDate? readDateFunction
 ---@field getMode? fun(opponents: table[]): string
@@ -1115,7 +1115,7 @@ end
 --- - getExtraData(match, games, opponents): table?
 --- - adjustOpponent(opponent, opponentIndex)
 --- - getLinks(match, games): table?
---- - getHeadToHeadLink(match, opponents): string?
+--- - getHeadToHeadLink(match, opponents): string?, string?
 --- - getPatch(match, games): string?
 --- - readDate(match): table
 --- - getMode(opponents): string?
@@ -1160,7 +1160,9 @@ function MatchGroupInputUtil.standardProcessMatch(match, Parser, FfaParser, mapP
 
 	match.links = Parser.getLinks and Parser.getLinks(match, games) or MatchGroupInputUtil.getLinks(match)
 	if Parser.getHeadToHeadLink then
-		match.links.headtohead = Parser.getHeadToHeadLink(match, opponents)
+		local h2hLinkMediawiki, h2hLinkLighthouse = Parser.getHeadToHeadLink(match, opponents)
+		match.links.headtohead = h2hLinkMediawiki
+		match.links.headtohead_lh = h2hLinkLighthouse
 	end
 
 	local autoScoreFunction = (Parser.calculateMatchScore and MatchGroupInputUtil.canUseAutoScore(match, games))

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -162,7 +162,7 @@ end
 
 ---Constructs a submatch object whose properties are aggregated from that of its games.
 ---@param match StarcraftMatchGroupUtilMatch
----@param subgroup MatchGroupUtilSubgroup
+---@param subgroup StarcraftMatchGroupUtilSubmatch
 ---@return StarcraftMatchGroupUtilSubmatch
 function StarcraftMatchGroupUtil.constructSubmatch(match, subgroup)
 	local games = subgroup.games

--- a/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
+++ b/lua/wikis/commons/MatchGroup/Util/Starcraft.lua
@@ -221,7 +221,7 @@ end
 ---@return boolean
 function StarcraftMatchGroupUtil.matchHasDetails(match)
 	local linksWithoutH2H = Table.filterByKey(match.links, function(key)
-		return key ~= 'headtohead'
+		return key ~= 'headtohead' and key ~= 'headtohead_lh'
 	end)
 	return match.dateIsExact
 		or String.isNotEmpty(match.vod)

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -57,10 +57,11 @@ end
 ---@param icon string
 ---@param iconDark string?
 ---@param text string
+---@param class string?
 ---@return MatchSummaryFooter
-function Footer:addLink(link, icon, iconDark, text)
+function Footer:addLink(link, icon, iconDark, text, class)
 	table.insert(self.elements, Image.display(icon, iconDark, {
-		link = link, size = '32px', caption = text, alt = link
+		link = link, size = '32px', caption = text, alt = link, class = class
 	}))
 	return self
 end
@@ -78,7 +79,14 @@ function Footer:addLinks(links)
 				self:addLink(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
 			end
 		else
-			self:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text)
+			-- Temporary during MW/LH Migrations
+			local class
+			if linkType == 'headtohead_lh' then
+				class = 'hide-when-mediawiki'
+			elseif linkType == 'headtohead' then
+				class = 'hide-when-lighthouse'
+			end
+			self:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class)
 		end
 	end
 

--- a/lua/wikis/dota2/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/dota2/MatchGroup/Input/Custom.lua
@@ -143,7 +143,7 @@ end
 
 ---@param match table
 ---@param opponents MGIParsedOpponent[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	local isTeamGame = Array.all(opponents, function(opponent)
 		return opponent.type == Opponent.team
@@ -156,6 +156,12 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 				['Head to head query[player]'] = string.gsub(opponents[1].name, ' ', '_'),
 				['Head to head query[opponent]'] = string.gsub(opponents[2].name, ' ', '_'),
 				wpRunQuery = 'Run query'
+			}
+		)), tostring(mw.uri.fullUrl(
+			'Special:RunQuery/H2H',
+			{
+				['player'] = string.gsub(opponents[1].name, ' ', '_'),
+				['opponent'] = string.gsub(opponents[2].name, ' ', '_'),
 			}
 		))
 	end

--- a/lua/wikis/halo/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/halo/MatchGroup/Input/Custom.lua
@@ -82,7 +82,7 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	if
 		opponents[1].type ~= Opponent.team or
@@ -101,6 +101,10 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		))
 	end
 
+	local buildQueryFormLinkLighthouse = function(form, arguments)
+		return tostring(mw.uri.fullUrl('Special:RunQuery/' .. form, arguments))
+	end
+
 	local headtoheadArgs = {
 		['[team1]'] = team1,
 		['[team2]'] = team2,
@@ -111,7 +115,11 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		['[fromdate][year]'] = string.sub(match.date,1,4)
 	}
 
-	return buildQueryFormLink('Head2head', 'Headtohead', headtoheadArgs)
+	return buildQueryFormLink('Head2head', 'Headtohead', headtoheadArgs),
+		buildQueryFormLinkLighthouse('H2H', {
+			['team1'] = team1,
+			['team2'] = team2,
+		})
 end
 
 ---@param match table

--- a/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/rocketleague/MatchGroup/Input/Custom.lua
@@ -96,7 +96,7 @@ end
 
 ---@param match table
 ---@param opponents MGIParsedOpponent[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	if not Logic.readBool(Logic.emptyOr(match.showh2h, Variables.varDefault('showh2h'))) or
 		opponents[1].type ~= Opponent.team or
@@ -112,6 +112,12 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 			pfRunQueryFormName = 'Head2head',
 			['Headtohead[team1]'] = opponents[1].name,
 			['Headtohead[team2]'] = opponents[2].name,
+		}
+	)), tostring(mw.uri.fullUrl(
+		'Special:RunQuery/H2H',
+		{
+			['team1'] = opponents[1].name,
+			['team2'] = opponents[2].name,
 		}
 	))
 end

--- a/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
+++ b/lua/wikis/warcraft/MatchGroup/Input/Custom.lua
@@ -185,7 +185,7 @@ end
 
 ---@param match table
 ---@param opponents table[]
----@return string?
+---@return string?, string?
 function MatchFunctions.getHeadToHeadLink(match, opponents)
 	if #opponents ~= 2 or Array.any(opponents, function(opponent)
 		return opponent.type ~= Opponent.solo or not ((opponent.match2players or {})[1] or {}).name end)
@@ -193,12 +193,19 @@ function MatchFunctions.getHeadToHeadLink(match, opponents)
 		return
 	end
 
-	return (tostring(mw.uri.fullUrl('Special:RunQuery/Head-to-Head'))
+	return ((tostring(mw.uri.fullUrl('Special:RunQuery/Head-to-Head'))
 		.. '?pfRunQueryFormName=Head-to-Head&Head+to+head+query%5Bplayer%5D='
 		.. opponents[1].match2players[1].name
 		.. '&Head_to_head_query%5Bopponent%5D='
 		.. opponents[2].match2players[1].name
-		.. '&wpRunQuery=Run+query'):gsub(' ', '_')
+		.. '&wpRunQuery=Run+query'):gsub(' ', '_')),
+		tostring(mw.uri.fullUrl(
+			'Special:RunQuery/H2H',
+			{
+				['player'] = opponents[1].match2players[1].name,
+				['opponent'] = opponents[2].match2players[1].name,
+			}
+		))
 end
 
 ---@param game table


### PR DESCRIPTION
## Summary
Lighthouse Forms are under a different name, so support having H2H Links in LH point somewhere else.

## How did you test this change?
dev on warcraft