### PR TITLE
feat(externalmedialink): use full event name over displayname

### DIFF
--- a/lua/wikis/commons/ExternalMediaLink.lua
+++ b/lua/wikis/commons/ExternalMediaLink.lua
@@ -113,7 +113,7 @@ function ExternalMediaLink._readArgs(args)
 	local extradata = {
 		translation = args.translation,
 		translator = args.translator,
-		event = tournament.displayName or args.event,
+		event = tournament.fullName or args.event,
 		event_link = tournament.pageName or Page.pageifyLink(Logic.emptyOr(args['event-link'], args.event) or ''),
 		subject_organization = args.subject_organization1, --legacy
 	}


### PR DESCRIPTION
## Summary

relevant discussion: https://discord.com/channels/93055209017729024/268719633366777856/1531327782888407061

## How did you test this change?

trivial