### PR TITLE
feat(StageWinnings): Support gameWins when the match was a draw

### DIFF
--- a/lua/wikis/commons/StageWinningsCalculation.lua
+++ b/lua/wikis/commons/StageWinningsCalculation.lua
@@ -25,8 +25,9 @@ local StageWinningsCalculation = {}
 ---startValue: number, valuePerWin: number, valueByScore: table<string, number>?,
 ---pointsStart: number, pointsPerWin: number, pointsByScore: table<string, number>?,
 ---points2Start: number, points2PerWin: number, points2ByScore: table<string, number>?, hideWinnings: boolean}
----@return {opponent: standardOpponent, matchWins: integer, matchLosses: integer, matchDraws: integer, gameWins: integer,
----gameLosses: integer, winnings: number, scoreDetails: table<string, integer>, points: number, points2: number}[]
+---@return {opponent: standardOpponent, matchWins: integer, matchLosses: integer, matchDraws: integer,
+---gameWins: integer, gameLosses: integer, winnings: number, scoreDetails: table<string, integer>,
+---points: number, points2: number}[]
 function StageWinningsCalculation.run(props)
 	local matches = mw.ext.LiquipediaDB.lpdb('match2', {
 		conditions = StageWinningsCalculation._buildConditions(props),

--- a/lua/wikis/commons/StageWinningsCalculation.lua
+++ b/lua/wikis/commons/StageWinningsCalculation.lua
@@ -25,7 +25,7 @@ local StageWinningsCalculation = {}
 ---startValue: number, valuePerWin: number, valueByScore: table<string, number>?,
 ---pointsStart: number, pointsPerWin: number, pointsByScore: table<string, number>?,
 ---points2Start: number, points2PerWin: number, points2ByScore: table<string, number>?, hideWinnings: boolean}
----@return {opponent: standardOpponent, matchWins: integer, matchLosses: integer, gameWins: integer,
+---@return {opponent: standardOpponent, matchWins: integer, matchLosses: integer, matchDraws: integer, gameWins: integer,
 ---gameLosses: integer, winnings: number, scoreDetails: table<string, integer>, points: number, points2: number}[]
 function StageWinningsCalculation.run(props)
 	local matches = mw.ext.LiquipediaDB.lpdb('match2', {
@@ -51,6 +51,7 @@ function StageWinningsCalculation.run(props)
 				scoreDetails = {},
 				matchWins = 0,
 				matchLosses = 0,
+				matchDraws = 0,
 				gameWins = 0,
 				gameLosses = 0,
 				winnings = 0,
@@ -60,28 +61,34 @@ function StageWinningsCalculation.run(props)
 		end)
 
 		local winnerId = tonumber(match.winner)
-		if winnerId ~= 1 and winnerId ~= 2 then return end
-		local loserId = 3 - winnerId
 
-		local winner = match.opponents[winnerId]
-		local loser = match.opponents[loserId]
+		local opponent1 = match.opponents[1]
+		local opponent2 = match.opponents[2]
 
-		local winnerScore = OpponentDisplay.InlineScore(winner)
-		local loserScore = OpponentDisplay.InlineScore(loser)
+		local opponent1Score = OpponentDisplay.InlineScore(opponent1)
+		local opponent2Score = OpponentDisplay.InlineScore(opponent2)
 
-		local score = winnerScore .. '-' .. loserScore
-		local reversedScore = loserScore .. '-' .. winnerScore
+		local score = opponent1Score .. '-' .. opponent2Score
+		local reversedScore = opponent2Score .. '-' .. opponent1Score
 
-		byName[winner.name].scoreDetails[score] = (byName[winner.name].scoreDetails[score] or 0) + 1
-		byName[loser.name].scoreDetails[reversedScore] = (byName[loser.name].scoreDetails[reversedScore] or 0) + 1
+		byName[opponent1.name].scoreDetails[score] = (byName[opponent1.name].scoreDetails[score] or 0) + 1
+		byName[opponent2.name].scoreDetails[reversedScore] = (byName[opponent2.name].scoreDetails[reversedScore] or 0) + 1
 
-		byName[winner.name].matchWins = byName[winner.name].matchWins + 1
-		byName[loser.name].matchLosses = byName[loser.name].matchLosses + 1
+		if winnerId == 1 then
+			byName[opponent1.name].matchWins = byName[opponent1.name].matchWins + 1
+			byName[opponent2.name].matchLosses = byName[opponent2.name].matchLosses + 1
+		else if winnerId == 2 then
+			byName[opponent2.name].matchWins = byName[opponent2.name].matchWins + 1
+			byName[opponent1.name].matchLosses = byName[opponent1.name].matchLosses + 1
+		else
+			byName[opponent1.name].matchDraws = byName[opponent1.name].matchDraws + 1
+			byName[opponent2.name].matchDraws = byName[opponent2.name].matchDraws + 1
+		end
 
-		byName[winner.name].gameWins = byName[winner.name].gameWins + (tonumber(winner.score) or 0)
-		byName[loser.name].gameLosses = byName[loser.name].gameLosses + (tonumber(winner.score) or 0)
-		byName[winner.name].gameLosses = byName[winner.name].gameLosses + (tonumber(loser.score) or 0)
-		byName[loser.name].gameWins = byName[loser.name].gameWins + (tonumber(loser.score) or 0)
+		byName[opponent1.name].gameWins = byName[opponent1.name].gameWins + (tonumber(opponent1.score) or 0)
+		byName[opponent2.name].gameLosses = byName[opponent2.name].gameLosses + (tonumber(opponent1.score) or 0)
+		byName[opponent1.name].gameLosses = byName[opponent1.name].gameLosses + (tonumber(opponent2.score) or 0)
+		byName[opponent2.name].gameWins = byName[opponent2.name].gameWins + (tonumber(opponent2.score) or 0)
 	end)
 
 	local opponents = Array.extractValues(byName)

--- a/lua/wikis/commons/StageWinningsCalculation.lua
+++ b/lua/wikis/commons/StageWinningsCalculation.lua
@@ -77,7 +77,7 @@ function StageWinningsCalculation.run(props)
 		if winnerId == 1 then
 			byName[opponent1.name].matchWins = byName[opponent1.name].matchWins + 1
 			byName[opponent2.name].matchLosses = byName[opponent2.name].matchLosses + 1
-		else if winnerId == 2 then
+		elseif winnerId == 2 then
 			byName[opponent2.name].matchWins = byName[opponent2.name].matchWins + 1
 			byName[opponent1.name].matchLosses = byName[opponent1.name].matchLosses + 1
 		else


### PR DESCRIPTION
## Summary
Previous calculation would just ignore the match when it was a draw, even when winnings were to be calculated per game.

This adjusts the logic to no longer ignore match draws, and also tracks the number of draws. The latter is not yet used, but adding it to the calculation can be done when it is requested.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
