### PR TITLE
feat: Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,6 @@ FROM mcr.microsoft.com/playwright:v1.61.1-noble
 ARG LUA_VERSION=5.1.5
 ARG LUAROCKS_VERSION=3.11.1
 ARG LUALS_VERSION=3.18.2
-ARG RUFF_VERSION=0.15.22
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -57,11 +56,10 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& ln -s /opt/luals/bin/lua-language-server /usr/local/bin/lua-language-server
 
 # Python lives in a venv so it is writable without fighting PEP 668. The
-# scripts/ requirements themselves are installed by post-create.sh, so that
-# changing requirements.txt does not need an image rebuild.
+# requirements themselves, ruff included, are installed by post-create.sh, so
+# that changing requirements.txt does not need an image rebuild.
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=/opt/venv/bin:${PATH}
 RUN python3 -m venv "${VIRTUAL_ENV}" \
 	&& pip install --no-cache-dir --upgrade pip \
-	&& pip install --no-cache-dir "ruff==${RUFF_VERSION}" \
 	&& chmod -R a+rwX "${VIRTUAL_ENV}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,67 @@
+# Same image CI uses for visual snapshot tests (see ".github/workflows/update
+# visual snapshots.yml"), so snapshots rendered in here match the ones CI
+# commits back to the branch. Keep the tag in sync with the playwright version
+# in package.json.
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
+
+# Keep these in sync with the versions used by the GitHub workflows
+ARG LUA_VERSION=5.1.5
+ARG LUAROCKS_VERSION=3.11.1
+ARG LUALS_VERSION=3.18.2
+ARG RUFF_VERSION=0.15.22
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		ca-certificates \
+		curl \
+		libreadline-dev \
+		python3 \
+		python3-venv \
+		unzip \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Lua 5.1, built from source the same way Liquipedia/gh-actions-lua does in CI.
+# Anything newer than 5.1 is unsupported, see the README.
+RUN curl -fsSL "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" -o /tmp/lua.tar.gz \
+	&& tar -xzf /tmp/lua.tar.gz -C /tmp \
+	&& make -C "/tmp/lua-${LUA_VERSION}" linux MYCFLAGS="-O2 -fPIC" \
+	&& make -C "/tmp/lua-${LUA_VERSION}" install \
+	&& rm -rf /tmp/lua.tar.gz "/tmp/lua-${LUA_VERSION}"
+
+RUN curl -fsSL "https://luarocks.org/releases/luarocks-${LUAROCKS_VERSION}.tar.gz" -o /tmp/luarocks.tar.gz \
+	&& tar -xzf /tmp/luarocks.tar.gz -C /tmp \
+	&& cd "/tmp/luarocks-${LUAROCKS_VERSION}" \
+	&& ./configure --lua-version=5.1 --with-lua=/usr/local \
+	&& make \
+	&& make install \
+	&& rm -rf /tmp/luarocks.tar.gz "/tmp/luarocks-${LUAROCKS_VERSION}"
+
+# busted = test framework, luacheck = linter
+RUN luarocks install --lua-version=5.1 busted \
+	&& luarocks install --lua-version=5.1 luacheck
+
+# lua-language-server, used by the "luals-code-style" CI job and by the Lua
+# editor extension
+RUN arch="$(dpkg --print-architecture)" \
+	&& case "${arch}" in \
+		amd64) luals_arch=x64 ;; \
+		arm64) luals_arch=arm64 ;; \
+		*) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+	esac \
+	&& mkdir -p /opt/luals \
+	&& curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/lua-language-server-${LUALS_VERSION}-linux-${luals_arch}.tar.gz" \
+		| tar -xz -C /opt/luals \
+	&& ln -s /opt/luals/bin/lua-language-server /usr/local/bin/lua-language-server
+
+# Python lives in a venv so it is writable without fighting PEP 668. The
+# scripts/ requirements themselves are installed by post-create.sh, so that
+# changing requirements.txt does not need an image rebuild.
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH=/opt/venv/bin:${PATH}
+RUN python3 -m venv "${VIRTUAL_ENV}" \
+	&& pip install --no-cache-dir --upgrade pip \
+	&& pip install --no-cache-dir "ruff==${RUFF_VERSION}" \
+	&& chmod -R a+rwX "${VIRTUAL_ENV}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,3 +63,14 @@ ENV PATH=/opt/venv/bin:${PATH}
 RUN python3 -m venv "${VIRTUAL_ENV}" \
 	&& pip install --no-cache-dir --upgrade pip \
 	&& chmod -R a+rwX "${VIRTUAL_ENV}"
+
+# Runs before the features do, which is where the user we run as gets created.
+# Noble ships `ubuntu` on uid 1000 and this image adds `pwuser` on 1001, which
+# pushes that user to 1002 and stops the CLI renumbering it to match the host,
+# leaving the bind mount unwritable on linux. Docker Desktop hides this by
+# fudging bind mount ownership. /ms-playwright is root owned and world readable,
+# so moving pwuser costs nothing, and it is renumbered rather than left on 1001
+# so hosts with that uid work too.
+RUN userdel -r ubuntu 2>/dev/null || true \
+	&& usermod -u 60001 pwuser 2>/dev/null || true \
+	&& groupmod -g 60001 pwuser 2>/dev/null || true

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+	"name": "Liquipedia Lua-Modules",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "."
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": true,
+			"installOhMyZsh": false,
+			"username": "vscode",
+			"userUid": "automatic",
+			"userGid": "automatic",
+			"upgradePackages": false
+		},
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "os-provided"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"remoteUser": "vscode",
+	// node_modules lives in a container-only volume so the Linux binaries
+	// installed in here (sass, playwright, ...) do not overwrite the ones a
+	// native host setup installed for macOS/Windows, and vice versa.
+	"mounts": [
+		{
+			"source": "lua-modules-node-modules",
+			"target": "${containerWorkspaceFolder}/node_modules",
+			"type": "volume"
+		}
+	],
+	"containerEnv": {
+		"PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright"
+	},
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"sumneko.lua",
+				"stylelint.vscode-stylelint",
+				"dbaeumer.vscode-eslint",
+				"ms-python.python",
+				"charliermarsh.ruff"
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/venv/bin/python",
+				"terminal.integrated.defaultProfile.linux": "zsh"
+			}
+		}
+	}
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing npm dependencies"
+# node_modules is a named volume, which docker creates owned by root
+sudo chown "$(id -u):$(id -g)" node_modules
+npm install
+
+echo "==> Installing python dependencies"
+pip install --no-cache-dir -r requirements.txt
+
+if [ ! -f .env ]; then
+	echo "==> Creating .env from .env.example (fill in your bot credentials before deploying)"
+	cp .env.example .env
+fi
+
+echo "==> Done. Try: npm run lua-test"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,7 +13,10 @@ pip install --no-cache-dir -r requirements.txt
 
 if [ ! -f .env ]; then
 	echo "==> Creating .env from .env.example (fill in your bot credentials before deploying)"
-	cp .env.example .env
+	# Nobody chose these settings, we generated them, so start in dry-run and
+	# leave turning off DRY_RUN as a deliberate act
+	sed 's/^DRY_RUN=.*/DRY_RUN=1/' .env.example > .env
+	echo "    DRY_RUN=1 is set, deploys are simulated until you change it"
 fi
 
 echo "==> Done. Try: npm run lua-test"

--- a/.github/workflows/pythoncheck.yml
+++ b/.github/workflows/pythoncheck.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run linter
         uses: astral-sh/ruff-action@v4.0.0
         with:
-          version: 0.15.22
+          version-file: requirements.txt
           src: scripts/
       - name: Check styling
         run: ruff format --check --diff scripts/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ If you want to contribute you may do that in any way you wish. We use the follow
 
 Clone the repository. This requires [git](https://git-scm.com/downloads) to be installed on your system.
 
+##### Devcontainer (any platform)
+
+The repository ships a [devcontainer](https://containers.dev/) that has everything preinstalled: Lua 5.1, LuaRocks, busted, luacheck, lua-language-server, Node, Python with ruff, and the Playwright browsers used for the visual snapshot tests. It is built on the same Playwright image CI uses, so the visual snapshot tests render the same way they do in CI. (On Apple Silicon a couple of snapshots come out a few pixels off CI's — well under the comparison threshold, but one more reason to leave snapshot updates to CI as described below.)
+
+Open the repository in VS Code and pick *Dev Containers: Reopen in Container* (requires Docker and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension), or run `devcontainer up --workspace-folder .` with the [devcontainer CLI](https://github.com/devcontainers/cli). `npm install`, `pip install -r requirements.txt` and creating `.env` from `.env.example` are done for you on first start.
+
+If you prefer a native setup, follow the platform instructions below instead.
+
 ##### Windows
 
 Recommended to use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Then follow the Unix instructions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.34.2
 python-dotenv==1.2.2
+ruff==0.15.22


### PR DESCRIPTION
## What

Adds a devcontainer so contributors get the whole toolchain — Lua 5.1, LuaRocks, busted, luacheck, lua-language-server, Node, Python with ruff, and the Playwright browsers — without assembling it by hand. On macOS that currently means overriding a Homebrew block on the deprecated `lua@5.1` formula.

Built on the Playwright image the "Update Visual Snapshots" workflow uses, with versions pinned to match the other workflows.

## How it was tested

Built and brought up with the devcontainer CLI against a clean clone, then ran inside the container:

- `npm run lua-test` — 761 successes / 0 failures
- `luacheck lua --config lua/.luacheckrc` — 0 warnings / 0 errors in 1725 files
- `npm run lint:scss`, `npm run lint:js` — clean
- `ruff format --check scripts/` and `ruff check scripts/` — clean
- `npm run build` — CSS and JS both produced
- Snapshot rendering with `UPDATE_SNAPSHOTS=true`: 49 of 51 byte-identical to the committed ones; the other two differ by ~200 sub-threshold pixels on arm64, so pixelmatch still reports 0 mismatches. Noted in the README.