### PR TITLE
feat(standings): exclusive/non-exclusive opponent filtering

### DIFF
--- a/lua/spec/standings_import_spec.lua
+++ b/lua/spec/standings_import_spec.lua
@@ -5,8 +5,8 @@ describe('Standings import from matches', function()
 	local StandingsParseLpdb = require('Module:Standings/Parse/Lpdb')
 	local Array = require('Module:Array')
 
-	---@param props {matchId: string, opponents: {template: string, name: string, score: integer,
-	---placement: integer}[], winner: integer?, finished: boolean?}
+	---@param props {matchId: string, opponents: {template: string?, name: string, score: integer,
+	---placement: integer, type: string?}[], winner: integer?, finished: boolean?}
 	---@return table
 	local function match2Record(props)
 		return {
@@ -21,7 +21,7 @@ describe('Standings import from matches', function()
 			match2games = {},
 			match2opponents = Array.map(props.opponents, function(opponentSpec)
 				return {
-					type = 'team',
+					type = opponentSpec.type or 'team',
 					template = opponentSpec.template,
 					name = opponentSpec.name,
 					score = opponentSpec.score,
@@ -76,7 +76,10 @@ describe('Standings import from matches', function()
 
 	it('returns no opponents without matches', function()
 		stubMatchQuery{}
-		assert.are_same({}, StandingsParseLpdb.importFromMatches({{roundNumber = 1, matches = {}}}, swissScoreMapper, {}))
+		local opponents = StandingsParseLpdb.importFromMatches(
+			{{roundNumber = 1, matches = {}}}, swissScoreMapper, {}, {importOpponents = true}
+		)
+		assert.are_same({}, opponents)
 	end)
 
 	it('builds opponents with per round scoreboards and accumulated matches', function()
@@ -94,7 +97,7 @@ describe('Standings import from matches', function()
 		local opponents = StandingsParseLpdb.importFromMatches({
 			{roundNumber = 1, matches = {'M1'}},
 			{roundNumber = 2, matches = {'M2'}},
-		}, swissScoreMapper, {})
+		}, swissScoreMapper, {}, {importOpponents = true})
 
 		assert.are_equal(3, #opponents)
 
@@ -135,7 +138,7 @@ describe('Standings import from matches', function()
 
 		local opponents = StandingsParseLpdb.importFromMatches({
 			{roundNumber = 1, matches = {'M1'}},
-		}, swissScoreMapper, {})
+		}, swissScoreMapper, {}, {importOpponents = true})
 
 		local heroic = findOpponent(opponents, 'Heroic')
 		assert.are_same({w = 0, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
@@ -152,7 +155,7 @@ describe('Standings import from matches', function()
 
 		local opponents = StandingsParseLpdb.importFromMatches({
 			{roundNumber = 1, matches = {'M1'}},
-		}, swissScoreMapper, {})
+		}, swissScoreMapper, {}, {importOpponents = true})
 
 		local heroic = findOpponent(opponents, 'Heroic')
 		assert.are_same({w = 0, d = 1, l = 0}, heroic.rounds[1].scoreboard.match)
@@ -169,7 +172,7 @@ describe('Standings import from matches', function()
 		local opponents = StandingsParseLpdb.importFromMatches({
 			{roundNumber = 1, matches = {'M1'}},
 			{roundNumber = 2, matches = {'M1'}},
-		}, swissScoreMapper, {})
+		}, swissScoreMapper, {}, {importOpponents = true})
 
 		local heroic = findOpponent(opponents, 'Heroic')
 		assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
@@ -186,7 +189,7 @@ describe('Standings import from matches', function()
 
 		local opponents = StandingsParseLpdb.importFromMatches({
 			{roundNumber = 1, matches = {'M1'}},
-		}, swissScoreMapper, {})
+		}, swissScoreMapper, {}, {importOpponents = true})
 
 		assert.are_equal(1, #opponents)
 		assert.are_equal('Heroic', opponents[1].opponent.name)
@@ -208,7 +211,7 @@ describe('Standings import from matches', function()
 			end
 			return nil
 		end,
-		{})
+		{}, {importOpponents = true})
 
 		assert.are_equal(13, findOpponent(opponents, 'Heroic').rounds[1].scoreboard.points)
 		assert.are_equal(7, findOpponent(opponents, 'Wolves Esports').rounds[1].scoreboard.points)
@@ -238,5 +241,121 @@ describe('Standings import from matches', function()
 		local heroic = findOpponent(opponents, 'Heroic')
 		assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
 		assert.are_equal('M1', heroic.rounds[1].matchId)
+	end)
+
+	describe('opponent based filtering', function()
+		---@param opponentName string
+		---@param template string
+		local function manualOpponent(opponentName, template)
+			return {opponent = {type = 'team', template = template, name = opponentName, extradata = {}}}
+		end
+
+		--- M1 is between two opponents of the standings, M2 only has one of them
+		local function stubInternalAndExternalMatch()
+			stubMatchQuery{
+				match2Record{matchId = 'M1', winner = 1, opponents = {
+					{template = 'heroic', name = 'Heroic', score = 2, placement = 1},
+					{template = 'wolves esports', name = 'Wolves Esports', score = 0, placement = 2},
+				}},
+				match2Record{matchId = 'M2', winner = 1, opponents = {
+					{template = 'heroic', name = 'Heroic', score = 2, placement = 1},
+					{template = 'tt9 esports 2022', name = 'TT9 Esports', score = 0, placement = 2},
+				}},
+			}
+		end
+
+		local rounds = {
+			{roundNumber = 1, matches = {'M1'}},
+			{roundNumber = 2, matches = {'M2'}},
+		}
+
+		local standingsOpponents = {
+			manualOpponent('Heroic', 'heroic'),
+			manualOpponent('Wolves Esports', 'wolves esports'),
+		}
+
+		it('counts matches with a single standings opponent when non-exclusive', function()
+			stubInternalAndExternalMatch()
+
+			local opponents = StandingsParseLpdb.importFromMatches(rounds, swissScoreMapper, standingsOpponents, {
+				exclusive = false,
+				importOpponents = false,
+			})
+
+			local heroic = findOpponent(opponents, 'Heroic')
+			assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
+			assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[2].scoreboard.match)
+			assert.are_equal('M2', heroic.rounds[2].matchId)
+		end)
+
+		it('ignores matches with a single standings opponent when exclusive', function()
+			stubInternalAndExternalMatch()
+
+			local opponents = StandingsParseLpdb.importFromMatches(rounds, swissScoreMapper, standingsOpponents, {
+				exclusive = true,
+				importOpponents = false,
+			})
+
+			local heroic = findOpponent(opponents, 'Heroic')
+			assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
+			assert.are_same({w = 0, d = 0, l = 0}, heroic.rounds[2].scoreboard.match)
+			assert.are_equal('nc', heroic.rounds[2].specialstatus)
+			assert.is_nil(heroic.rounds[2].matchId)
+			assert.is_nil(findOpponent(opponents, 'TT9 Esports'))
+		end)
+
+		it('resolves aliases before filtering when exclusive', function()
+			stubInternalAndExternalMatch()
+
+			local opponentsWithAlias = {
+				manualOpponent('Heroic', 'heroic'),
+				manualOpponent('Wolves Esports', 'wolves esports'),
+			}
+			opponentsWithAlias[2].aliases = {
+				{type = 'team', template = 'tt9 esports 2022', name = 'TT9 Esports', extradata = {}},
+			}
+
+			local opponents = StandingsParseLpdb.importFromMatches(rounds, swissScoreMapper, opponentsWithAlias, {
+				exclusive = true,
+				importOpponents = false,
+			})
+
+			local wolves = findOpponent(opponents, 'Wolves Esports')
+			assert.are_same({w = 0, d = 0, l = 1}, wolves.rounds[1].scoreboard.match)
+			assert.are_same({w = 0, d = 0, l = 1}, wolves.rounds[2].scoreboard.match)
+			assert.are_equal('M2', wolves.rounds[2].matchId)
+		end)
+
+		it('treats imported opponents as part of the standings when exclusive', function()
+			stubInternalAndExternalMatch()
+
+			local opponents = StandingsParseLpdb.importFromMatches(rounds, swissScoreMapper, {}, {
+				exclusive = true,
+				importOpponents = true,
+			})
+
+			local heroic = findOpponent(opponents, 'Heroic')
+			assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[1].scoreboard.match)
+			assert.are_same({w = 1, d = 0, l = 0}, heroic.rounds[2].scoreboard.match)
+			assert.is_not_nil(findOpponent(opponents, 'TT9 Esports'))
+		end)
+
+		it('ignores matches against literal opponents when exclusive', function()
+			stubMatchQuery{
+				match2Record{matchId = 'M1', winner = 1, opponents = {
+					{template = 'heroic', name = 'Heroic', score = 2, placement = 1},
+					{type = 'literal', name = 'Qualifier Winner', score = 0, placement = 2},
+				}},
+			}
+
+			local opponents = StandingsParseLpdb.importFromMatches({
+				{roundNumber = 1, matches = {'M1'}},
+			}, swissScoreMapper, {manualOpponent('Heroic', 'heroic')}, {
+				exclusive = true,
+				importOpponents = true,
+			})
+
+			assert.are_same({}, opponents)
+		end)
 	end)
 end)

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -25,7 +25,7 @@ local StandingsParseLpdb = {}
 
 ---@class StandingsImportOptions
 ---@field exclusive boolean? # If set, only matches where every opponent is part of the standings are imported
----@field importOpponents boolean? # If set, opponents not listed manually are added to the standings
+---@field importOpponents boolean? # If set, opponents not listed manually still count as part of the standings
 
 ---@param rounds {roundNumber: integer, matches: string[]}[]
 ---@param scoreMapper fun(opponent: match2opponent): number|nil

--- a/lua/wikis/commons/Standings/Parse/Lpdb.lua
+++ b/lua/wikis/commons/Standings/Parse/Lpdb.lua
@@ -23,11 +23,16 @@ local ColumnName = Condition.ColumnName
 
 local StandingsParseLpdb = {}
 
+---@class StandingsImportOptions
+---@field exclusive boolean? # If set, only matches where every opponent is part of the standings are imported
+---@field importOpponents boolean? # If set, opponents not listed manually are added to the standings
+
 ---@param rounds {roundNumber: integer, matches: string[]}[]
 ---@param scoreMapper fun(opponent: match2opponent): number|nil
 ---@param manualOpponents StandingTableOpponentData[]
+---@param options StandingsImportOptions?
 ---@return StandingTableOpponentData[]
-function StandingsParseLpdb.importFromMatches(rounds, scoreMapper, manualOpponents)
+function StandingsParseLpdb.importFromMatches(rounds, scoreMapper, manualOpponents, options)
 	local matchIds = Array.flatMap(rounds, function(round)
 		return round.matches
 	end)
@@ -63,7 +68,7 @@ function StandingsParseLpdb.importFromMatches(rounds, scoreMapper, manualOpponen
 		function(match2)
 			local roundNumbers = matchIdToRound[match2.match2id]
 			Array.forEach(roundNumbers, function(roundNumber)
-				StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds, manualOpponents)
+				StandingsParseLpdb.parseMatch(roundNumber, match2, opponents, scoreMapper, #rounds, manualOpponents, options)
 			end)
 		end
 	)
@@ -114,27 +119,71 @@ function StandingsParseLpdb.newOpponent(opponentData, maxRounds)
 	}
 end
 
+---Renames an opponent into the manual opponent it is an alias of, if any.
+---@param opponent standardOpponent
+---@param manualOpponents StandingTableOpponentData[]
+function StandingsParseLpdb.applyAliases(opponent, manualOpponents)
+	local opponentToUse = Array.find(manualOpponents, function(manualOpponent)
+		return Array.any(manualOpponent.aliases or {}, function(alias)
+			return Opponent.same(opponent, alias)
+		end)
+	end)
+
+	if not opponentToUse or not opponentToUse.opponent then
+		return
+	end
+
+	opponent.template = opponentToUse.opponent.template
+	opponent.name = opponentToUse.opponent.name
+end
+
+---Checks whether an opponent ends up in the standings table, either because it is listed manually
+---or because it gets imported from the matches.
+---@param opponent standardOpponent
+---@param manualOpponents StandingTableOpponentData[]
+---@param importOpponents boolean?
+---@return boolean
+function StandingsParseLpdb.isPartOfStandings(opponent, manualOpponents, importOpponents)
+	local isManualOpponent = Array.any(manualOpponents, function(manualOpponent)
+		return Opponent.same(manualOpponent.opponent, opponent)
+	end)
+	if isManualOpponent then
+		return true
+	end
+	if not importOpponents then
+		return false
+	end
+
+	---Imported opponents are part of the standings too, but literal (and tbd) opponents are never imported
+	return not Opponent.isTbd(opponent)
+end
+
 ---@param roundNumber integer
 ---@param match match2
 ---@param opponents StandingTableOpponentData[]
 ---@param scoreMapper fun(opponent: standardOpponent): number?
 ---@param maxRounds integer
 ---@param manualOpponents StandingTableOpponentData[]
-function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMapper, maxRounds, manualOpponents)
+---@param options StandingsImportOptions?
+function StandingsParseLpdb.parseMatch(roundNumber, match, opponents, scoreMapper, maxRounds, manualOpponents, options)
+	options = options or {}
 	local match2 = MatchGroupUtil.matchFromRecord(match)
+
 	Array.forEach(match2.opponents, function(opponent)
-		---Find matching opponent
-		local opponentToUse = Array.find(manualOpponents, function(manualOpponent)
-			return Array.any(manualOpponent.aliases or {}, function(alias)
-				return Opponent.same(opponent, alias)
-			end)
-		end)
+		StandingsParseLpdb.applyAliases(opponent, manualOpponents)
+	end)
 
-		if opponentToUse and opponentToUse.opponent then
-			opponent.template = opponentToUse.opponent.template
-			opponent.name = opponentToUse.opponent.name
-		end
+	--- In exclusive mode every opponent of the match has to be part of the standings,
+	--- otherwise the match is not counted at all. In non-exclusive mode a single one is enough.
+	local opponentCheck = options.exclusive and Array.all or Array.any
+	local isRelevantMatch = opponentCheck(match2.opponents, function(opponent)
+		return StandingsParseLpdb.isPartOfStandings(opponent, manualOpponents, options.importOpponents)
+	end)
+	if not isRelevantMatch then
+		return
+	end
 
+	Array.forEach(match2.opponents, function(opponent)
 		local standingsOpponentData = Array.find(opponents, function(opponentData)
 			return Opponent.same(opponentData.opponent, opponent)
 		end)

--- a/lua/wikis/commons/Standings/Table.lua
+++ b/lua/wikis/commons/Standings/Table.lua
@@ -49,7 +49,8 @@ function StandingsTable.fromTemplate(frame)
 	local importScoreFromMatches = Logic.nilOr(Logic.readBoolOrNil(args.import), true)
 	local importOpponentFromMatches = Logic.nilOr(Logic.readBoolOrNil(args.importopponents), importScoreFromMatches)
 	--- Exclusive standings only count matches where all opponents are part of the standings,
-	--- non-exclusive (the default) count matches where at least one opponent is part of the standings.
+	--- non-exclusive (the default) counts matches where at least one opponent is part of the standings.
+	--- Note that this is the reverse of the legacy GroupTableLeague default, on purpose.
 	local exclusiveOpponents = Logic.readBool(args.exclusive)
 
 	local parsedData = StandingsParseWiki.parseWikiInput(args)

--- a/lua/wikis/commons/Standings/Table.lua
+++ b/lua/wikis/commons/Standings/Table.lua
@@ -48,6 +48,9 @@ function StandingsTable.fromTemplate(frame)
 	local title = args.title
 	local importScoreFromMatches = Logic.nilOr(Logic.readBoolOrNil(args.import), true)
 	local importOpponentFromMatches = Logic.nilOr(Logic.readBoolOrNil(args.importopponents), importScoreFromMatches)
+	--- Exclusive standings only count matches where all opponents are part of the standings,
+	--- non-exclusive (the default) count matches where at least one opponent is part of the standings.
+	local exclusiveOpponents = Logic.readBool(args.exclusive)
 
 	local parsedData = StandingsParseWiki.parseWikiInput(args)
 	local rounds = parsedData.rounds
@@ -60,7 +63,10 @@ function StandingsTable.fromTemplate(frame)
 	if importScoreFromMatches then
 		local automaticScoreFunction = StandingsParseWiki.makeScoringFunction(tableType, args)
 
-		local importedOpponents = StandingsParseLpdb.importFromMatches(rounds, automaticScoreFunction, opponents)
+		local importedOpponents = StandingsParseLpdb.importFromMatches(rounds, automaticScoreFunction, opponents, {
+			exclusive = exclusiveOpponents,
+			importOpponents = importOpponentFromMatches,
+		})
 		opponents = StandingsTable.mergeOpponentsData(opponents, importedOpponents, importOpponentFromMatches)
 	end
 


### PR DESCRIPTION
Stacked on #7886 (`standings-alias-support`), retarget to `main` once that merges.

## What

Adds `|exclusive=` to standings tables. When set, a match is only counted if every opponent of that match is part of the standings. The default (non-exclusive) is the previous behaviour, where a single opponent being part of the standings is enough.

An opponent is part of the standings when it is listed manually, or — when `importopponents` is on — when it would be imported, which is every non-literal opponent. Aliases are resolved before the check.

## How it was tested

`busted` — new specs in `standings_import_spec.lua` cover non-exclusive counting a one-sided match, exclusive skipping it, alias resolution running first, imported opponents counting as part of the standings, and exclusive dropping a match against a literal opponent. Existing import specs updated for the new options argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)