### PR TITLE
ci: Fail snapshots that render without their resources

### DIFF
--- a/lua/snapshot.mjs
+++ b/lua/snapshot.mjs
@@ -35,8 +35,6 @@ const PIXELMATCH_OPTIONS = { threshold: 0.1 };
 	// does not arrive the page still renders, just unstyled, and we would
 	// happily screenshot that and treat it as the truth. Collect anything that
 	// failed so we can bail out instead.
-	// Keyed by url, because a bad response is usually followed by an aborted
-	// request for the same thing and reporting it twice is just noise
 	const missingResources = new Map();
 	const isRequired = (resourceType) => ['stylesheet', 'script', 'font'].includes(resourceType);
 	const recordMissing = (url, reason) => {

--- a/lua/snapshot.mjs
+++ b/lua/snapshot.mjs
@@ -30,9 +30,43 @@ const PIXELMATCH_OPTIONS = { threshold: 0.1 };
 		args: ['--disable-web-security']
 	});
 	const page = await browser.newPage({ viewport: VIEWPORT });
+
+	// The template pulls stylesheets and fonts over the network. If one of them
+	// does not arrive the page still renders, just unstyled, and we would
+	// happily screenshot that and treat it as the truth. Collect anything that
+	// failed so we can bail out instead.
+	// Keyed by url, because a bad response is usually followed by an aborted
+	// request for the same thing and reporting it twice is just noise
+	const missingResources = new Map();
+	const isRequired = (resourceType) => ['stylesheet', 'script', 'font'].includes(resourceType);
+	const recordMissing = (url, reason) => {
+		if (!missingResources.has(url)) {
+			missingResources.set(url, reason);
+		}
+	};
+
+	page.on('requestfailed', (request) => {
+		if (isRequired(request.resourceType())) {
+			const failure = request.failure();
+			recordMissing(request.url(), failure ? failure.errorText : 'request failed');
+		}
+	});
+	page.on('response', (response) => {
+		// 3xx is fine, the redirect target gets its own response event
+		if (isRequired(response.request().resourceType()) && response.status() >= 400) {
+			recordMissing(response.url(), `HTTP ${response.status()}`);
+		}
+	});
+
 	await page.goto(`file://${htmlPath}`, {waitUntil: "networkidle"});
 	const newScreenshotBuffer = await page.screenshot({ animations: 'disabled' });
 	await browser.close();
+
+	if (missingResources.size > 0) {
+		console.error(`Error: '${testName}' rendered without resources it needs, refusing to use the result.`);
+		missingResources.forEach((reason, url) => console.error(`  - ${url} (${reason})`));
+		process.exit(1);
+	}
 
 	if (shouldUpdate || !existsSync(referencePath)) {
 		// Update snapshot, either forced or previous snapshot doesn't exist yet


### PR DESCRIPTION
## What

`lua/spec/helpers/template.html` fetches the lakesideview skin styles, the custom icon module and fontawesome from liquipedia.net on every snapshot render. When that request doesn't arrive, the page still renders — just unstyled — and we screenshot it anyway. In update mode that unstyled render overwrites every baseline and gets committed back to the branch, so an intermittent network failure silently replaces the snapshots with wrong ones.

This collects stylesheet, script and font requests that fail or return 4xx/5xx, and exits non-zero instead of using the result. Redirects are ignored, since the redirect target reports its own response.

## How it was tested

Ran `snapshot.mjs` directly against purpose-built pages:

| case | result |
|---|---|
| no external resources | exit 0, snapshot written |
| unreachable host | exit 1, `net::ERR_NAME_NOT_RESOLVED` |
| stylesheet 404 | exit 1, `HTTP 404` |
| stylesheet 500 | exit 1, `HTTP 500` |
| stylesheet 302 → 200 | exit 0, not flagged |

The 404/500 cases were served from a local http server so the status codes are deterministic. Each failing resource is reported once — a bad response is normally followed by an aborted request for the same URL, which would otherwise be listed twice.

Not run locally: `npm run lint:js`, because this machine's `node_modules` has ESLint 8 against the repo's ESLint 9 config. `resources.yml` covers it here.