### PR TITLE
chore: Drop unused @playwright/test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 		"@csstools/stylelint-formatter-github": "^2.0.0",
 		"@eslint/eslintrc": "3.x.x",
 		"@eslint/js": "9.x.x",
-		"@playwright/test": "^1.61.1",
 		"@stylistic/stylelint-plugin": "^2.1.2",
 		"@typescript-eslint/eslint-plugin": "^8.56.1",
 		"eslint": "9.x.x",


### PR DESCRIPTION
## What

`@playwright/test` isn't imported anywhere, there's no playwright config file, and no script or workflow invokes it. The only playwright usage in the repo is the `playwright` import in `lua/snapshot.mjs`.

It isn't free to keep, though. It was declared `^1.61.1` while `playwright` is pinned to exactly `1.61.1`, so they resolve to different versions wanting different browser builds — currently 1.62.1/build 1234 against 1.61.1/build 1228. `@playwright/test` also ships the `playwright` binary and shadowed the pinned one, so `npx playwright install` fetched the browser for the wrong version, and `npm run lua-test` then failed with:

```
browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1228/...
```

pointing at a build that `playwright install` had just declined to download. CI doesn't hit this because the browsers come from the container image.

With it removed, the binary comes from the pinned package, and the browser it installs matches both `lua/snapshot.mjs` and the `mcr.microsoft.com/playwright:v1.61.1-noble` image the snapshot workflow runs in.

## How it was tested

Clean install from scratch (`rm -rf node_modules && npm install`):

- `node_modules/.bin/playwright` links to the pinned package and reports 1.61.1
- `playwright` and `playwright-core` both resolve to 1.61.1; `@playwright/test` is gone
- `snapshot.mjs` renders successfully, both a local page and one pulling the real liquipedia.net stylesheet