### PR TITLE
refactor(match2): remove MatchSummaryFooter class

### DIFF
--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -50,24 +50,14 @@ local KING_ICONS = {
 }
 
 ---@param args table
----@return Widget
+---@return VNode
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
----@param match table
----@param createGame fun(date: string, game: table, gameIndex: integer): Widget
----@return Widget[]
-function CustomMatchSummary.createBody(match, createGame)
-	return WidgetUtil.collect(
-		Array.map(match.games, createGame),
-		CustomMatchSummary._linksTable(match)
-	)
-end
-
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
----@return MatchSummaryRow
+---@return VNode
 function CustomMatchSummary.createGame(game, gameIndex)
 	return MatchSummaryWidgets.Row{
 		classes = {'brkts-popup-body-game'},
@@ -108,7 +98,7 @@ end
 
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
----@return Widget
+---@return VNode
 function CustomMatchSummary._getCenterContent(game, gameIndex)
 	return Div{
 		children = {
@@ -128,7 +118,7 @@ function CustomMatchSummary._getCenterContent(game, gameIndex)
 end
 
 ---@param gameOpponent table
----@return Widget
+---@return VNode
 function CustomMatchSummary._getSideIcon(gameOpponent)
 	return Div{
 		classes = {'brkts-popup-spaced'},
@@ -137,7 +127,7 @@ function CustomMatchSummary._getSideIcon(gameOpponent)
 end
 
 ---@param game MatchGroupUtilGame
----@return Widget?
+---@return VNode?
 function CustomMatchSummary._getHeader(game)
 	return String.isNotEmpty(game.header) and {
 		Div{
@@ -151,43 +141,58 @@ function CustomMatchSummary._getHeader(game)
 	} or nil
 end
 
----@param match any
----@return Widget?
-function CustomMatchSummary._linksTable(match)
-	if Logic.isDeepEmpty(match.links) then
-		return
-	end
-
-	local rows = Array.map(match.games, function(game, gameIndex)
-		local links = Table.mapValues(match.links, function(link)
-			if type(link) ~= 'table' then return nil end
-			return Table.extract(link, gameIndex)
+---@param match MatchGroupUtilMatch
+---@return VNode[]
+function CustomMatchSummary.createFooter(match)
+	local gameLinks = Array.map(match.games, function(game, gameIndex)
+		local linksForThisGame = {}
+		Table.iter.forEachPair(match.links, function(linkType, link)
+			if type(link) ~= 'table' then
+				return
+			end
+			linksForThisGame[linkType] = link[gameIndex]
 		end)
-		local vod = Table.extract(game, 'vod')
-		if not vod and Logic.isDeepEmpty(links) then return end
+		if not game.vod and Logic.isEmpty(linksForThisGame) then
+			return
+		end
 
-		local linksFooter = MatchSummary.Footer()
-		MatchSummary.addVodsToFooter({vod = vod, games = {}}, linksFooter)
-		linksFooter:addLinks(links)
+		local vods = MatchSummary.makeVodDisplay(game.vod, {})
+		local links = MatchSummary.makeLinksDisplay(linksForThisGame)
 
 		return Tr{children = {
 			Td{children = {'Game ', gameIndex}},
-			Td{classes = {'brkts-popup-spaced', 'vodlink'}, children = Array.map(linksFooter.elements, tostring)}
+			Td{classes = {'brkts-popup-spaced', 'vodlink'}, children = Array.extend(vods, links)}
 		}}
 	end)
 
-	if Logic.isEmpty(rows) then
-		return
+	local matchLinks = {}
+	if match.vod then
+		table.insert(matchLinks, MatchSummary.makeVodDisplay(match.vod, {}))
 	end
+	local rawLinksForMatch = {}
+	Table.iter.forEachPair(match.links, function(linkType, link)
+		if type(link) ~= 'string' then
+			return
+		end
+		rawLinksForMatch[linkType] = link
+	end)
 
-	return Collapsible{
-		tableClasses = {'wikitable-striped'},
-		header = Tr{children = {
-			Th{css = {width = '20%'}},
-			Th{css = {width = '80%'}, children = {'Additional Links'}},
-		}},
-		children = rows,
-	}
+	matchLinks = Array.extend(matchLinks, MatchSummary.makeLinksDisplay(rawLinksForMatch))
+
+	-- TODO Early return
+	return WidgetUtil.collect(
+		Logic.isNotEmpty(gameLinks) and MatchSummaryWidgets.Footer{children = {
+			Collapsible{
+				tableClasses = {'wikitable-striped'},
+				header = Tr{children = {
+					Th{css = {width = '20%'}},
+					Th{css = {width = '80%'}, children = {'Additional Links'}},
+				}},
+				children = gameLinks,
+			}
+		}} or nil,
+		Logic.isNotEmpty(matchLinks) and MatchSummaryWidgets.Footer{children = matchLinks} or nil
+	)
 end
 
 return CustomMatchSummary

--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -55,10 +55,11 @@ function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args)
 end
 
+---@param date string
 ---@param game MatchGroupUtilGame
 ---@param gameIndex integer
 ---@return VNode
-function CustomMatchSummary.createGame(game, gameIndex)
+function CustomMatchSummary.createGame(date, game, gameIndex)
 	return MatchSummaryWidgets.Row{
 		classes = {'brkts-popup-body-game'},
 		children = WidgetUtil.collect(
@@ -179,7 +180,6 @@ function CustomMatchSummary.createFooter(match)
 
 	matchLinks = Array.extend(matchLinks, MatchSummary.makeLinksDisplay(rawLinksForMatch))
 
-	-- TODO Early return
 	return WidgetUtil.collect(
 		Logic.isNotEmpty(gameLinks) and MatchSummaryWidgets.Footer{children = {
 			Collapsible{

--- a/lua/wikis/chess/MatchSummary.lua
+++ b/lua/wikis/chess/MatchSummary.lua
@@ -168,7 +168,7 @@ function CustomMatchSummary.createFooter(match)
 
 	local matchLinks = {}
 	if match.vod then
-		table.insert(matchLinks, MatchSummary.makeVodDisplay(match.vod, {}))
+		matchLinks = Array.extend(matchLinks, MatchSummary.makeVodDisplay(match.vod, {}))
 	end
 	local rawLinksForMatch = {}
 	Table.iter.forEachPair(match.links, function(linkType, link)

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -9,7 +9,6 @@ local Lua = require('Module:Lua')
 
 local Abbreviation = Lua.import('Module:Abbreviation')
 local Array = Lua.import('Module:Array')
-local Class = Lua.import('Module:Class')
 local FnUtil = Lua.import('Module:FnUtil')
 local Image = Lua.import('Module:Image')
 local Logic = Lua.import('Module:Logic')
@@ -34,89 +33,11 @@ local TBD = Abbreviation.make{text = 'TBD', title = 'To Be Determined'}
 ---@field createHeader? fun(match: MatchGroupUtilMatch, options: {teamStyle: teamStyle?}?): Renderable
 ---@field createBody? fun(match: MatchGroupUtilMatch): Renderable|Renderable[]
 ---@field createGame? fun(date: string, game: table, gameIndex: integer): Renderable|Renderable[]
----@field addToFooter? fun(match: MatchGroupUtilMatch, footer: MatchSummaryFooter): MatchSummaryFooter
+---@field createFooter? fun(match: MatchGroupUtilMatch): Renderable|Renderable[]
 ---@field createMatch? fun(matchData: MatchGroupUtilMatch): VNode?
 
----@class MatchSummaryFooter: BaseClass
----@operator call: MatchSummaryFooter
----@field elements Renderable[]
-local Footer = Class.new(
-	function(self)
-		self.elements = {}
-	end
-)
-
----@param element Renderable|nil
----@return self
-function Footer:addElement(element)
-	table.insert(self.elements, element)
-	return self
-end
-
----@param link string
----@param icon string
----@param iconDark string?
----@param text string
----@param class string?
----@return MatchSummaryFooter
-function Footer:addLink(link, icon, iconDark, text, class)
-	table.insert(self.elements, Image.display(icon, iconDark, {
-		link = link, size = '32px', caption = text, alt = link, class = class
-	}))
-	return self
-end
-
----@param links table<string, string|table>
----@return self
-function Footer:addLinks(links)
-	local processLink = function(linkType, link)
-		local currentLinkData = Links.getMatchIconData(linkType)
-		if not currentLinkData then
-			mw.log('Unknown link: ' .. linkType)
-		elseif type(link) == 'table' then
-			for gameIdx, gameLink in Table.iter.spairs(link) do
-				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
-				self:addLink(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
-			end
-		else
-			-- Temporary during MW/LH Migrations
-			local class
-			if linkType == 'headtohead_lh' then
-				class = 'hide-when-mediawiki'
-			elseif linkType == 'headtohead' then
-				class = 'hide-when-lighthouse'
-			end
-			self:addLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class)
-		end
-	end
-
-	local processedLinks = {}
-	Array.forEach(MATCH_LINK_PRIORITY, function(linkType)
-		for linkKey, link in Table.iter.pairsByPrefix(links, linkType, {requireIndex = false}) do
-			processLink(linkKey, link)
-			processedLinks[linkKey] = true
-		end
-	end)
-
-	for linkKey, link in Table.iter.spairs(links) do
-		-- Handle links not already processed via priority list
-		if not processedLinks[linkKey] then
-			processLink(linkKey, link)
-		end
-	end
-
-	return self
-end
-
----@return VNode
-function Footer:create()
-	return MatchSummaryWidgets.Footer{children = self.elements}
-end
-
 ---@class MatchSummary
-local MatchSummary = {
-	Footer = Footer,
-}
+local MatchSummary = {}
 
 ---Default header function
 ---@param match MatchGroupUtilMatch
@@ -151,35 +72,93 @@ function MatchSummary.createDefaultBody(match, createGame)
 end
 
 ---Default footer function
----@param match table
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function MatchSummary.createDefaultFooter(match, footer)
-	return MatchSummary.addVodsToFooter(match, footer):addLinks(match.links)
+---@param match MatchGroupUtilMatch
+---@return Renderable
+function MatchSummary.createDefaultFooter(match)
+	return MatchSummaryWidgets.Footer{children = {
+		MatchSummary.makeVodDisplay(match.vod, match.games),
+		MatchSummary.makeLinksDisplay(match.links),
+	}}
 end
 
----Creates a match footer with vods if vods are set
----@param match table
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function MatchSummary.addVodsToFooter(match, footer)
-	if match.vod then
-		footer:addElement(VodLink.display{
-			vod = match.vod,
+---@param matchVod string?
+---@param games MatchGroupUtilGame[]
+---@return Renderable
+function MatchSummary.makeVodDisplay(matchVod, games)
+	local vods = {}
+	if matchVod then
+		table.insert(vods, VodLink.display{
+			vod = matchVod,
 		})
 	end
 
-	Array.forEach(match.games, function(game, gameIndex)
+	Array.forEach(games, function(game, gameIndex)
 		if not game.vod then
 			return
 		end
-		footer:addElement(VodLink.display{
+		table.insert(vods, VodLink.display{
 			gamenum = gameIndex,
 			vod = game.vod,
 		})
 	end)
 
-	return footer
+	return vods
+end
+
+---@param icon string
+---@param iconDark string?
+---@param link string
+---@param text string?
+---@param class string?
+---@return string?
+function MatchSummary.makeLinkDisplay(icon, iconDark, link, text, class)
+	return Image.display(icon, iconDark, {
+		link = link, size = '32px', caption = text, alt = link, class = class
+	})
+end
+
+---@param links table<string, string|table>
+---@return Renderable
+function MatchSummary.makeLinksDisplay(links)
+	local linkDisplays = {}
+
+	local processLink = function(linkType, link)
+		local currentLinkData = Links.getMatchIconData(linkType)
+		if not currentLinkData then
+			mw.log('Unknown link: ' .. linkType)
+		elseif type(link) == 'table' then
+			for gameIdx, gameLink in Table.iter.spairs(link) do
+				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
+				table.insert(linkDisplays, MatchSummary.makeLinkDisplay(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText))
+			end
+		else
+			-- Temporary during MW/LH Migrations
+			local class
+			if linkType == 'headtohead_lh' then
+				class = 'hide-when-mediawiki'
+			elseif linkType == 'headtohead' then
+				class = 'hide-when-lighthouse'
+			end
+			table.insert(linkDisplays, MatchSummary.makeLinkDisplay(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class))
+		end
+	end
+
+	local processedLinks = {}
+	Array.forEach(MATCH_LINK_PRIORITY, function(linkType)
+		for linkKey, link in Table.iter.pairsByPrefix(links, linkType, {requireIndex = false}) do
+			processLink(linkKey, link)
+			processedLinks[linkKey] = true
+		end
+	end)
+
+	for linkKey, link in Table.iter.spairs(links) do
+		-- Handle links not already processed via priority list
+		if not processedLinks[linkKey] then
+			processLink(linkKey, link)
+		end
+	end
+
+	return linkDisplays
 end
 
 ---Default createMatch function for usage in Custom MatchSummary
@@ -194,7 +173,7 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 
 	local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
 	local createBody = CustomMatchSummary.createBody or MatchSummary.createDefaultBody
-	local createFooter = CustomMatchSummary.addToFooter or MatchSummary.createDefaultFooter
+	local createFooter = CustomMatchSummary.createFooter or MatchSummary.createDefaultFooter
 
 	return Html.Fragment{children = WidgetUtil.collect(
 		createHeader(matchData, options),
@@ -212,7 +191,7 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 						}
 					}
 				},
-				createFooter(matchData, MatchSummary.Footer()):create()
+				createFooter(matchData)
 			)
 		},
 		MatchButtonBar{match = matchData, showVods = false, variant = 'primary'} -- Vods are in the footer currently

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -129,7 +129,8 @@ function MatchSummary.makeLinksDisplay(links)
 		elseif type(link) == 'table' then
 			for gameIdx, gameLink in Table.iter.spairs(link) do
 				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
-				table.insert(linkDisplays, MatchSummary.makeLinkDisplay(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText))
+				local display = MatchSummary.makeLinkDisplay(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
+				table.insert(linkDisplays, display)
 			end
 		else
 			-- Temporary during MW/LH Migrations
@@ -139,7 +140,8 @@ function MatchSummary.makeLinksDisplay(links)
 			elseif linkType == 'headtohead' then
 				class = 'hide-when-lighthouse'
 			end
-			table.insert(linkDisplays, MatchSummary.makeLinkDisplay(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class))
+			local display = MatchSummary.makeLinkDisplay(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class)
+			table.insert(linkDisplays, display)
 		end
 	end
 

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -75,15 +75,15 @@ end
 ---@param match MatchGroupUtilMatch
 ---@return Renderable
 function MatchSummary.createDefaultFooter(match)
-	return MatchSummaryWidgets.Footer{children = {
+	return MatchSummaryWidgets.Footer{children = WidgetUtil.collect(
 		MatchSummary.makeVodDisplay(match.vod, match.games),
-		MatchSummary.makeLinksDisplay(match.links),
-	}}
+		MatchSummary.makeLinksDisplay(match.links)
+	)}
 end
 
 ---@param matchVod string?
 ---@param games MatchGroupUtilGame[]
----@return Renderable
+---@return Renderable[]
 function MatchSummary.makeVodDisplay(matchVod, games)
 	local vods = {}
 	if matchVod then
@@ -118,7 +118,7 @@ function MatchSummary.makeLinkDisplay(link, icon, iconDark, text, class)
 end
 
 ---@param links table<string, string|table>
----@return Renderable
+---@return Renderable[]
 function MatchSummary.makeLinksDisplay(links)
 	local linkDisplays = {}
 

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -122,6 +122,11 @@ end
 function MatchSummary.makeLinksDisplay(links)
 	local linkDisplays = {}
 
+	local makeAndSaveLink = function(link, icon, iconDark, text, class)
+		local display = MatchSummary.makeLinkDisplay(link, icon, iconDark, text, class)
+		table.insert(linkDisplays, display)
+	end
+
 	local processLink = function(linkType, link)
 		local currentLinkData = Links.getMatchIconData(linkType)
 		if not currentLinkData then
@@ -129,8 +134,7 @@ function MatchSummary.makeLinksDisplay(links)
 		elseif type(link) == 'table' then
 			for gameIdx, gameLink in Table.iter.spairs(link) do
 				local newText = currentLinkData.text .. ' on Game ' .. gameIdx
-				local display = MatchSummary.makeLinkDisplay(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
-				table.insert(linkDisplays, display)
+				makeAndSaveLink(gameLink, currentLinkData.icon, currentLinkData.iconDark, newText)
 			end
 		else
 			-- Temporary during MW/LH Migrations
@@ -140,8 +144,7 @@ function MatchSummary.makeLinksDisplay(links)
 			elseif linkType == 'headtohead' then
 				class = 'hide-when-lighthouse'
 			end
-			local display = MatchSummary.makeLinkDisplay(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class)
-			table.insert(linkDisplays, display)
+			makeAndSaveLink(link, currentLinkData.icon, currentLinkData.iconDark, currentLinkData.text, class)
 		end
 	end
 

--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -105,13 +105,13 @@ function MatchSummary.makeVodDisplay(matchVod, games)
 	return vods
 end
 
+---@param link string
 ---@param icon string
 ---@param iconDark string?
----@param link string
----@param text string?
+---@param text string
 ---@param class string?
 ---@return string?
-function MatchSummary.makeLinkDisplay(icon, iconDark, link, text, class)
+function MatchSummary.makeLinkDisplay(link, icon, iconDark, text, class)
 	return Image.display(icon, iconDark, {
 		link = link, size = '32px', caption = text, alt = link, class = class
 	})

--- a/lua/wikis/counterstrike/MatchSummary.lua
+++ b/lua/wikis/counterstrike/MatchSummary.lua
@@ -35,9 +35,8 @@ function CustomMatchSummary.getByMatchId(args)
 end
 
 ---@param match MatchGroupUtilMatch
----@param footer MatchSummaryFooter
----@return MatchSummaryFooter
-function CustomMatchSummary.addToFooter(match, footer)
+---@return Renderable
+function CustomMatchSummary.createFooter(match)
 	local vods = {}
 	local secondVods = {}
 	if Logic.isNotEmpty(match.links.vod2) then
@@ -53,11 +52,11 @@ function CustomMatchSummary.addToFooter(match, footer)
 		end
 	end
 
-	if not Table.isEmpty(vods) or not Table.isEmpty(match.links) or not Logic.isEmpty(match.vod) then
+	if Table.isNotEmpty(vods) or Table.isNotEmpty(match.links) or Logic.isNotEmpty(match.vod) then
 		return CustomMatchSummary._createFooter(match, vods, secondVods)
 	end
 
-	return footer
+	return MatchSummary.createDefaultFooter(match)
 end
 
 ---@param match MatchGroupUtilMatch
@@ -87,10 +86,9 @@ end
 ---@param match MatchGroupUtilMatch
 ---@param vods table<integer, string>
 ---@param secondVods table<integer, table>
----@return MatchSummaryFooter
+---@return Renderable
 function CustomMatchSummary._createFooter(match, vods, secondVods)
-	local footer = MatchSummary.Footer()
-
+	local elements = {}
 	local separator = '<b>·</b>'
 
 	local function addFooterLink(icon, iconDark, url, label, index)
@@ -101,7 +99,7 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 			label = label .. ' for Game ' .. index
 		end
 
-		footer:addLink(url, icon, iconDark, label)
+		table.insert(elements, MatchSummary.makeLinkDisplay(url, icon, iconDark, label))
 	end
 
 	local function addVodLink(gamenum, vod, part)
@@ -115,7 +113,7 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 					htext = 'Watch VOD (part ' .. part .. ')'
 				end
 			end
-			footer:addElement(VodLink.display{
+			table.insert(elements, VodLink.display{
 				gamenum = gamenum,
 				vod = vod,
 				htext = htext
@@ -127,8 +125,8 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 	if Table.isNotEmpty(secondVods[0]) then
 		addVodLink(nil, match.vod, 1)
 		Array.forEach(secondVods[0], function(vodlink, vodindex)
-				addVodLink(nil, vodlink, vodindex + 1)
-			end)
+			addVodLink(nil, vodlink, vodindex + 1)
+		end)
 	else
 		addVodLink(nil, match.vod, nil)
 	end
@@ -145,12 +143,12 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 		end
 	end
 
-	if Table.isNotEmpty(match.links) then
-		if Logic.isNotEmpty(vods) or match.vod then
-			footer:addElement(separator)
-		end
-	else
-		return footer
+	if Table.isEmpty(match.links) then
+		return MatchSummaryWidgets.Footer{children = elements}
+	end
+
+	if Table.isNotEmpty(elements) then
+		table.insert(elements, separator)
 	end
 
 	--- Platforms is used to keep the order of the links in footer
@@ -160,41 +158,43 @@ function CustomMatchSummary._createFooter(match, vods, secondVods)
 	local insertDotNext = false
 	local iconsInserted = 0
 
-	for _, platform in ipairs(platforms) do
-		if Logic.isNotEmpty(platform) then
-			local link = links[platform.name]
-			if link then
-				if insertDotNext then
-					insertDotNext = false
-					iconsInserted = 0
-					footer:addElement(separator)
-				end
+	Array.forEach(platforms, function(platform)
+		if Logic.isEmpty(platform) then
+			insertDotNext = iconsInserted > 0 and true or false
+			return
+		end
+		local link = links[platform.name]
+		if not link then
+			return
+		end
 
-				local icon = platform.icon
-				local iconDark = platform.iconDark
-				local label = platform.label
-				local addGameLabel = platform.isMapStats and match.bestof and match.bestof > 1
+		if insertDotNext then
+			insertDotNext = false
+			iconsInserted = 0
+			table.insert(elements, separator)
+		end
 
-				for _, val in ipairs(link) do
-					addFooterLink(icon, iconDark, val[1], label, addGameLabel and val[2] or 0)
-					iconsInserted = iconsInserted + 1
-				end
+		local icon = platform.icon
+		local iconDark = platform.iconDark
+		local label = platform.label
+		local addGameLabel = platform.isMapStats and match.bestof and match.bestof > 1
 
-				if platform.stats then
-					for _, site in ipairs(platform.stats) do
-						if links[site] then
-							footer:addElement(separator)
-							break
-						end
-					end
+		Array.forEach(link, function(val)
+			addFooterLink(icon, iconDark, val[1], label, addGameLabel and val[2] or 0)
+			iconsInserted = iconsInserted + 1
+		end)
+
+		if platform.stats then
+			for _, site in ipairs(platform.stats) do
+				if links[site] then
+					table.insert(elements, separator)
+					break
 				end
 			end
-		else
-			insertDotNext = iconsInserted > 0 and true or false
 		end
-	end
+	end)
 
-	return footer
+	return MatchSummaryWidgets.Footer{children = elements}
 end
 
 ---@param props MatchSummaryGameRowProps


### PR DESCRIPTION
## Summary

Removes the final Match Summary Class style. 

Rewrites the footer implentations on Chess and CS, as they were expecting a mixure of standard and custom footer pathways.

## How did you test this change?
dev on Chess,CS and R6