### PR TITLE
refactor(match2): remove unused customization points

### DIFF
--- a/lua/wikis/commons/MatchSummary/Base.lua
+++ b/lua/wikis/commons/MatchSummary/Base.lua
@@ -30,11 +30,9 @@ local MATCH_LINK_PRIORITY = Lua.import('Module:Links/MatchPriorityGroups', {load
 local TBD = Abbreviation.make{text = 'TBD', title = 'To Be Determined'}
 
 ---@class CustomMatchSummaryInterface
----@field createHeader? fun(match: MatchGroupUtilMatch, options: {teamStyle: teamStyle?}?): Renderable
 ---@field createBody? fun(match: MatchGroupUtilMatch): Renderable|Renderable[]
 ---@field createGame? fun(date: string, game: table, gameIndex: integer): Renderable|Renderable[]
 ---@field createFooter? fun(match: MatchGroupUtilMatch): Renderable|Renderable[]
----@field createMatch? fun(matchData: MatchGroupUtilMatch): VNode?
 
 ---@class MatchSummary
 local MatchSummary = {}
@@ -43,7 +41,7 @@ local MatchSummary = {}
 ---@param match MatchGroupUtilMatch
 ---@param options {teamStyle: teamStyle?}?
 ---@return VNode
-function MatchSummary.createDefaultHeader(match, options)
+function MatchSummary.createHeader(match, options)
 	options = options or {}
 
 	return Html.Fragment{
@@ -176,12 +174,11 @@ function MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 		return
 	end
 
-	local createHeader = CustomMatchSummary.createHeader or MatchSummary.createDefaultHeader
 	local createBody = CustomMatchSummary.createBody or MatchSummary.createDefaultBody
 	local createFooter = CustomMatchSummary.createFooter or MatchSummary.createDefaultFooter
 
 	return Html.Fragment{children = WidgetUtil.collect(
-		createHeader(matchData, options),
+		MatchSummary.createHeader(matchData, options),
 		MatchSummaryWidgets.Body{
 			children = WidgetUtil.collect(
 				createBody(matchData, CustomMatchSummary.createGame),
@@ -230,7 +227,7 @@ function MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, options)
 	return MatchSummaryWidgets.Container{
 		classes = args.classes,
 		width = width,
-		createMatch = CustomMatchSummary.createMatch or function(matchData)
+		createMatch = function(matchData)
 			return MatchSummary.createMatch(matchData, CustomMatchSummary, options)
 		end,
 		match = match,

--- a/lua/wikis/hearthstone/MatchSummary.lua
+++ b/lua/wikis/hearthstone/MatchSummary.lua
@@ -21,13 +21,13 @@ local Opponent = Lua.import('Module:Opponent/Custom')
 local CustomMatchSummary = {}
 
 ---@param args table
----@return Widget
+---@return Renderable
 function CustomMatchSummary.getByMatchId(args)
 	return MatchSummary.defaultGetByMatchId(CustomMatchSummary, args, {width = '350px', teamStyle = 'bracket'})
 end
 
 ---@param match HearthstoneMatchGroupUtilMatch
----@return Widget[]
+---@return Renderable[]
 function CustomMatchSummary.createBody(match)
 	local submatches
 	if match.isTeamMatch then
@@ -41,7 +41,7 @@ function CustomMatchSummary.createBody(match)
 end
 
 ---@param submatch HearthstoneMatchGroupUtilSubmatch
----@return MatchSummaryRow
+---@return Renderable
 function CustomMatchSummary.TeamSubmatch(submatch)
 	local hasDetails = CustomMatchSummary._submatchHasDetails(submatch)
 	return MatchSummaryWidgets.Row{
@@ -72,7 +72,7 @@ function CustomMatchSummary._submatchHasDetails(submatch)
 end
 
 ---@param submatch HearthstoneMatchGroupUtilSubmatch
----@return Widget
+---@return Renderable
 function CustomMatchSummary.TeamSubMatchOpponentRow(submatch)
 	local opponents = submatch.opponents or {{}, {}}
 	Array.forEach(opponents, function (opponent, opponentIndex)
@@ -85,13 +85,13 @@ function CustomMatchSummary.TeamSubMatchOpponentRow(submatch)
 		opponent.players = players
 	end)
 
-	return MatchSummary.createDefaultHeader({opponents = opponents})
+	return MatchSummary.createHeader({opponents = opponents})
 end
 
 ---@param options {isPartOfSubMatch: boolean?}
 ---@param game MatchGroupUtilGame
 ---@param gameIndex number
----@return Widget
+---@return Renderable
 function CustomMatchSummary.Game(options, game, gameIndex)
 	local rowWidget = options.isPartOfSubMatch and Html.Div or MatchSummaryWidgets.Row
 
@@ -117,7 +117,7 @@ end
 
 ---@param opponent {players: table[], score: number?, status: string?}
 ---@param flip boolean?
----@return Widget?
+---@return Renderable?
 function CustomMatchSummary.DisplayClass(opponent, flip)
 	local player = Array.find(opponent.players or {}, function (player)
 		return Logic.isNotEmpty(player.class)

--- a/lua/wikis/hearthstone/MatchSummary.lua
+++ b/lua/wikis/hearthstone/MatchSummary.lua
@@ -85,6 +85,7 @@ function CustomMatchSummary.TeamSubMatchOpponentRow(submatch)
 		opponent.players = players
 	end)
 
+---@diagnostic disable-next-line: missing-fields
 	return MatchSummary.createHeader({opponents = opponents})
 end
 


### PR DESCRIPTION
## Summary
Remove the `createMatch` and `createHeader` customization points in match summary.

## How did you test this change?
trivial