### PR TITLE
chore: Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Lua-Modules
+
+## Running repository commands
+
+The toolchain lives in the devcontainer, not on the host: Lua 5.1, busted,
+luacheck, lua-language-server, ruff, and the Playwright browsers the visual
+snapshot tests need. Run repository commands there so results match CI.
+
+When the shell is already inside the container, which you can tell from the
+workspace being under `/workspaces/`, run commands directly:
+
+```
+npm run lua-test
+```
+
+From the host, go through the devcontainer CLI, starting the container first if
+it is not already up:
+
+```
+npx --yes @devcontainers/cli up --workspace-folder .
+npx --yes @devcontainers/cli exec --workspace-folder . npm run lua-test
+```
+
+This needs Docker running. If Docker is not available, say so rather than
+falling back to whatever is installed on the host — a host may have a different
+Lua version, or no busted at all, and a result from it does not tell you what CI
+will do.
+
+## Commands
+
+- `npm run lua-test` — busted suite, builds the CSS first
+- `luacheck lua --config lua/.luacheckrc` — Lua lint
+- `npm run lint:scss` — SCSS lint
+- `npm run lint:js` — JS lint, note that it runs `eslint --fix` and edits files
+- `ruff check scripts/` and `ruff format --check scripts/` — Python
+- `npm run build` — CSS and JS bundles
+
+## Visual snapshots
+
+Do not update snapshots locally. CI regenerates them and commits them back to
+the branch, and reviewing that diff is part of reviewing the pull request.
+Rendering is not identical across CPU architectures, so a local update can
+produce changed files that are not real changes.
+
+## Deploying to the wiki
+
+`scripts/deploy.py` writes to liquipedia.net. Set `LUA_DEV_ENV_NAME` so it
+targets sandbox pages, and keep `DRY_RUN=1` unless the intent is a live write.
+With neither set, running it with no arguments resyncs every module to the live
+wiki.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,35 +2,39 @@
 
 ## Running repository commands
 
-The toolchain lives in the devcontainer, not on the host: Lua 5.1, busted,
-luacheck, lua-language-server, ruff, and the Playwright browsers the visual
-snapshot tests need. Run repository commands there so results match CI.
+The toolchain can be installed natively or come from the devcontainer, and both
+are supported — see Setup in the README. Use whichever the machine already has
+rather than assuming one; a native setup is common on Linux, while the
+devcontainer saves a fight with Lua 5.1 on macOS.
 
-When the shell is already inside the container, which you can tell from the
-workspace being under `/workspaces/`, run commands directly:
+Check before running rather than guessing: `command -v busted luacheck ruff`,
+and `lua -v`, which needs to report 5.1. Anything newer is unsupported here, so
+its results do not mean much.
+
+With a native toolchain, or from a shell already inside the devcontainer, which
+you can tell from the workspace being under `/workspaces/`, run commands
+directly:
 
 ```
 npm run lua-test
 ```
 
-From the host, go through the devcontainer CLI, starting the container first if
-it is not already up:
+From the host with only the devcontainer set up, go through its CLI, starting
+the container first if it is not already up:
 
 ```
 npx --yes @devcontainers/cli up --workspace-folder .
 npx --yes @devcontainers/cli exec --workspace-folder . npm run lua-test
 ```
 
-If Docker is not running, or the devcontainer is not set up, fall back to the
-host toolchain. Two conditions on that:
+If neither is available, say so instead of skipping a check or calling it
+passed. Installing the Lua tools natively is `luarocks install --lua-version=5.1
+busted`, and the same for `luacheck`; the devcontainer route needs Docker
+running.
 
-- Check the tool is actually installed first, `command -v busted`, rather than
-  discovering it from a confusing error. If it is missing, say so instead of
-  skipping the check or calling it passed. Installing the Lua ones is
-  `luarocks install --lua-version=5.1 busted` and the same for `luacheck`.
-- Say which environment a result came from. A host may have a different Lua
-  version or an older ruff, so a host result is weaker evidence about CI than a
-  container one, and whoever reads the result should know which they got.
+Say which of the two produced a result when it is not obvious. A native setup
+can differ from CI in Lua patch version or ruff version, and whoever reads the
+result should know which they got.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,16 @@ npx --yes @devcontainers/cli up --workspace-folder .
 npx --yes @devcontainers/cli exec --workspace-folder . npm run lua-test
 ```
 
-This needs Docker running. If Docker is not available, say so rather than
-falling back to whatever is installed on the host — a host may have a different
-Lua version, or no busted at all, and a result from it does not tell you what CI
-will do.
+If Docker is not running, or the devcontainer is not set up, fall back to the
+host toolchain. Two conditions on that:
+
+- Check the tool is actually installed first, `command -v busted`, rather than
+  discovering it from a confusing error. If it is missing, say so instead of
+  skipping the check or calling it passed. Installing the Lua ones is
+  `luarocks install --lua-version=5.1 busted` and the same for `luacheck`.
+- Say which environment a result came from. A host may have a different Lua
+  version or an older ruff, so a host result is weaker evidence about CI than a
+  container one, and whoever reads the result should know which they got.
 
 ## Commands
 


### PR DESCRIPTION
## What

Adds a `CLAUDE.md` so Claude Code sessions check what a machine actually has before running repository commands, rather than assuming a toolchain is present. A native setup and the devcontainer are treated as equals — contributors install natively too, which is straightforward on Linux, where the devcontainer mostly earns its keep on macOS.

If neither is available it is told to say so, rather than skip a check or report it as passing, and to name which setup produced a result when that is not obvious.

Also records a few things that are easy to get wrong from the outside: `lint:js` runs `eslint --fix` and edits files, snapshots are CI's to update, and `deploy.py` writes to the live wiki when `LUA_DEV_ENV_NAME` is unset.

## How it was tested

Not executable, so nothing to run. The commands it lists are the ones exercised in #7955: `npm run lua-test`, `luacheck`, `npm run lint:scss`, `npm run lint:js`, `ruff check`/`format --check`, and `npm run build`, all verified inside the container there.