### PR TITLE
refactor(match2): use ErrorBoundary in matchlists

### DIFF
--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -39,7 +39,7 @@ local MatchlistDisplay = {propTypes = {}, types = {}}
 ---@field width number?
 
 ---@class MatchlistDisplayMatchProps
----@field MatchSummaryContainer? fun(props: table): Renderable
+---@field MatchSummaryContainer fun(props: table): Renderable
 ---@field Opponent Component<MatchListOpponentProps>
 ---@field Score Component<MatchListScoreProps>
 ---@field match MatchGroupUtilMatch

--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -10,7 +10,6 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Countdown = Lua.import('Module:Countdown')
 local DateExt = Lua.import('Module:Date/Ext')
-local DisplayUtil = Lua.import('Module:DisplayUtil')
 local Logic = Lua.import('Module:Logic')
 local Table = Lua.import('Module:Table')
 
@@ -18,6 +17,8 @@ local DisplayHelper = Lua.import('Module:MatchGroup/Display/Helper')
 local MatchGroupUtil = Lua.import('Module:MatchGroup/Util/Custom')
 local WikiSpecific = Lua.import('Module:Brkts/WikiSpecific')
 
+local Builder = Lua.import('Module:Widget/Builder')
+local ErrorBoundary = Lua.import('Module:Widget/ErrorBoundary')
 local GeneralCollapsible = Lua.import('Module:Widget/GeneralCollapsible/Default')
 local MatchInfoIcon = Lua.import('Module:Widget/Match/InfoIcon')
 local MatchListHeader = Lua.import('Module:Widget/Match/List/Header')
@@ -136,11 +137,16 @@ function MatchlistDisplay.Match(props)
 	if props.matchHasDetails(match) then
 		matchInfoIconNode = MatchInfoIcon{}
 		local bracketId = MatchGroupUtil.splitMatchId(props.match.matchId)
-		matchSummaryNode = DisplayUtil.TryPureComponent(props.MatchSummaryContainer, {
-			classes = {'brkts-match-info-popup'},
-			bracketId = bracketId,
-			matchId = props.match.matchId,
-		}, Lua.import('Module:Error/Display').ErrorDetails)
+		matchSummaryNode = ErrorBoundary{
+			children = Builder{builder = function ()
+				return props.MatchSummaryContainer{
+					classes = {'brkts-match-info-popup'},
+					bracketId = bracketId,
+					matchId = props.match.matchId,
+				}
+			end},
+			fallback = Lua.import('Module:Error/Display').ErrorDetails
+		}
 	else
 		matchInfoIconNode = Html.Div{
 			classes = {'brkts-matchlist-placeholder-cell'}

--- a/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Matchlist.lua
@@ -30,20 +30,20 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local MatchlistDisplay = {propTypes = {}, types = {}}
 
 ---@class MatchlistConfigOptions
----@field MatchSummaryContainer function?
+---@field MatchSummaryContainer? fun(props: table): Renderable
 ---@field Opponent Component<MatchListOpponentProps>?
 ---@field Score Component<MatchListScoreProps>?
 ---@field attached boolean?
 ---@field collapsed boolean?
----@field matchHasDetails function?
+---@field matchHasDetails? fun(match: MatchGroupUtilMatch): boolean
 ---@field width number?
 
 ---@class MatchlistDisplayMatchProps
----@field MatchSummaryContainer function
+---@field MatchSummaryContainer? fun(props: table): Renderable
 ---@field Opponent Component<MatchListOpponentProps>
 ---@field Score Component<MatchListScoreProps>
 ---@field match MatchGroupUtilMatch
----@field matchHasDetails function
+---@field matchHasDetails fun(match: MatchGroupUtilMatch): boolean
 
 ---@param args table
 ---@return table


### PR DESCRIPTION
## Summary

This PR replaces `DisplayUtil.TryPureComponent` with the `ErrorBoundary` component.

## How did you test this change?

trivial