### PR TITLE
docs: adjust documentation for reference tag component

### DIFF
--- a/lua/wikis/commons/Widget/ReferenceTag.lua
+++ b/lua/wikis/commons/Widget/ReferenceTag.lua
@@ -40,7 +40,7 @@ local function ReferenceTag(props, context)
 		'ref',
 		--[[
 		Because Frame:extensionTag expects string argument for content, we cannot directly
-		pass children in its raw form. Thus, we manually call Renderer.render here instead
+		pass children in their raw form. Thus, we manually call Renderer.render here instead
 		of letting it be called after processing the parent component.
 		]]
 		Renderer.render(props.children, context),

--- a/lua/wikis/commons/Widget/ReferenceTag.lua
+++ b/lua/wikis/commons/Widget/ReferenceTag.lua
@@ -11,7 +11,7 @@ local Component = Lua.import('Module:Widget/Component')
 local Renderer = Lua.import('Module:Widget/Renderer')
 
 --[[
-Widget component that is roughly equivalent to <ref> tags in MediaWiki.
+Widget component that is roughly equivalent to `<ref>` tags in MediaWiki.
 
 For example, the following Lua code snippet:
 


### PR DESCRIPTION
## Summary

tiny follow-up for #7981
not putting `<ref>` inside a code block makes markdown unhappy and `<ref>` does not get displayed properly
while at it fixes small grammar error in comment too