### PR TITLE
feat(i18n): "MainPage/WantToHelp" widget integration.

### DIFF
--- a/lua/wikis/commons/I18n/Data.lua
+++ b/lua/wikis/commons/I18n/Data.lua
@@ -140,6 +140,28 @@ return {
 		['mainpage-block-matches-title'] = 'Matches',
 		['mainpage-block-tournaments-title'] = 'Tournaments',
 		['mainpage-block-rankings-title'] = 'Liquipedia Rankings',
+		
+		-- Widget: MainPage/WantToHelp
+		['wantToHelp-mainText'] = 'Create your free account ' ..
+					'and join the community to start making a difference by ' ..
+					'sharing your knowledge and insights ' ..
+					'with fellow ${wikiType} fans!',
+		['wantToHelp-checkA'] = 'Join our community and grow the scene(s) you care about.',
+		['wantToHelp-checkB'] = 'Be a hero for fans worldwide by keeping the site updated.',
+		['wantToHelp-checkC'] = 'Develop valuable skills in research, writing, and collaboration.',
+		['wantToHelp-button-create-tooltip'] = 'Click here to create an account',
+		['wantToHelp-button-create-title'] = ' Create Account',
+		['wantToHelp-button-logIn-tooltip'] = 'Click here to log in',
+		['wantToHelp-button-logIn-title'] = ' Log In',
+		['wantToHelp-button-logIn-link'] = 'Special:UserLogin',
+		['wantToHelp-button-discord-tooltip'] = 'Click here to join our discord server',
+		['wantToHelp-button-discord-title'] = ' Join Our Discord',
+		['wantToHelp-helpArticles-tooltip'] = 'Click Here to Read our Help Articles',
+		['wantToHelp-helpArticles-title'] = ' Help Articles',
+		['wantToHelp-helpArticles-link'] = 'Help:Contents',
+		['wantToHelp-articleCount-preLink'] = 'In total there are ',
+		['wantToHelp-articleCount-pages'] = ' pages',
+		['wantToHelp-articleCount-postLink'] = ' listed needing help.',
 
 		-- dota2: MainPage
 		['dota2-mainpage-title'] = 'The Dota 2 Wiki',
@@ -311,6 +333,29 @@ return {
 		['mainpage-block-matches-title'] = 'Матчи',
 		['mainpage-block-tournaments-title'] = 'Турниры',
 		['mainpage-block-rankings-title'] = 'Рейтинги Liquipedia',
+		
+		-- Widget: MainPage/WantToHelp
+		['wantToHelp-mainText'] = 'Создайте учётную запись ' ..
+					'и присоединитесь к сообществу редакторов, ' ..
+					'вносящих неоценимый вклад в сохранение и ' ..
+					'обновление информации о ${wikiType}!',
+		['wantToHelp-checkA'] = 'Присоединяйтесь к сообществу и ' ..
+					'улучшайте осведомлённость игроков!',
+		['wantToHelp-checkB'] = 'Будьте героем, поддерживая актуальность информации об игре!',
+		['wantToHelp-checkC'] = 'Улучшайте свои навыки исследования, письма и работы в команде!',
+		['wantToHelp-button-create-tooltip'] = 'Нажмите, чтобы зарегистрироваться.',
+		['wantToHelp-button-create-title'] = ' Создать аккаунт',
+		['wantToHelp-button-logIn-tooltip'] = 'Нажмите, чтобы войти.',
+		['wantToHelp-button-logIn-title'] = ' Войти',
+		['wantToHelp-button-logIn-link'] = 'Служебная:Вход',
+		['wantToHelp-button-discord-tooltip'] = 'Нажмите, чтобы посетить сервер в Discord.',
+		['wantToHelp-button-discord-title'] = ' Наш Discord',
+		['wantToHelp-helpArticles-tooltip'] = 'Нажмите, чтобы просмотреть полезные статьи.',
+		['wantToHelp-helpArticles-title'] = ' Полезные статьи',
+		['wantToHelp-helpArticles-title'] = 'Справка:Содержимое',
+		['wantToHelp-articleCount-preLink'] = 'Всего ',
+		['wantToHelp-articleCount-pages'] = ' статей',
+		['wantToHelp-articleCount-postLink'] = ' нуждаются в помощи.',
 
 		-- dota2: MainPage / dota2: Заглавная
 		['dota2-mainpage-title'] = 'Dota 2 Вики',

--- a/lua/wikis/commons/I18n/Data.lua
+++ b/lua/wikis/commons/I18n/Data.lua
@@ -140,7 +140,7 @@ return {
 		['mainpage-block-matches-title'] = 'Matches',
 		['mainpage-block-tournaments-title'] = 'Tournaments',
 		['mainpage-block-rankings-title'] = 'Liquipedia Rankings',
-		
+
 		-- Widget: MainPage/WantToHelp
 		['wantToHelp-mainText'] = 'Create your free account ' ..
 					'and join the community to start making a difference by ' ..
@@ -333,7 +333,7 @@ return {
 		['mainpage-block-matches-title'] = 'Матчи',
 		['mainpage-block-tournaments-title'] = 'Турниры',
 		['mainpage-block-rankings-title'] = 'Рейтинги Liquipedia',
-		
+
 		-- Widget: MainPage/WantToHelp
 		['wantToHelp-mainText'] = 'Создайте учётную запись ' ..
 					'и присоединитесь к сообществу редакторов, ' ..
@@ -352,7 +352,7 @@ return {
 		['wantToHelp-button-discord-title'] = ' Наш Discord',
 		['wantToHelp-helpArticles-tooltip'] = 'Нажмите, чтобы просмотреть полезные статьи.',
 		['wantToHelp-helpArticles-title'] = ' Полезные статьи',
-		['wantToHelp-helpArticles-title'] = 'Справка:Содержимое',
+		['wantToHelp-helpArticles-link'] = 'Справка:Содержимое',
 		['wantToHelp-articleCount-preLink'] = 'Всего ',
 		['wantToHelp-articleCount-pages'] = ' статей',
 		['wantToHelp-articleCount-postLink'] = ' нуждаются в помощи.',

--- a/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
+++ b/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
@@ -53,7 +53,7 @@ local function buildFontAwesomeList(icon, entries, listCss)
 end
 
 ---@return string
-local function getWikiType()
+local function getWikiName()
 	if Info.wikiName == 'formula1' then
 		return 'F1'
 	end
@@ -77,7 +77,7 @@ local function WantToHelp()
 			children = I18n.translate(
 				'wantToHelp-mainText',
 				{
-					wikiType = getWikiType(),
+					wikiType = getWikiName(),
 				}
 			)
 		},

--- a/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
+++ b/lua/wikis/commons/Widget/MainPage/WantToHelp.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Page = Lua.import('Module:Page')
 local Variables = Lua.import('Module:Variables')
+local I18n = Lua.import('Module:I18n')
 
 local Info = Lua.import('Module:Info', {loadData = true})
 
@@ -56,7 +57,7 @@ local function getWikiType()
 	if Info.wikiName == 'formula1' then
 		return 'F1'
 	end
-	return 'esports'
+	return Info.name
 end
 
 ---@param content Renderable|Renderable[]?
@@ -73,16 +74,19 @@ local function WantToHelp()
 	return {
 		Div{
 			css = {['padding-bottom'] = '0.7em'},
-			children = 'Create your free account and join the community to start making a difference by ' ..
-					'sharing your knowledge and insights with fellow ' .. getWikiType() ..
-					' fans!'
+			children = I18n.translate(
+				'wantToHelp-mainText',
+				{
+					wikiType = getWikiType(),
+				}
+			)
 		},
 		buildFontAwesomeList(
 			GREEN_CHECK_CIRCLE,
 			{
-				{'Join our community and grow the scene(s) you care about.'},
-				{'Be a hero for fans worldwide by keeping the site updated.'},
-				{'Develop valuable skills in research, writing, and collaboration.'},
+				{I18n.translate('wantToHelp-checkA')},
+				{I18n.translate('wantToHelp-checkB')},
+				{I18n.translate('wantToHelp-checkC')},
 			},
 			{
 				margin = '0 0 0 2.5rem',
@@ -101,39 +105,39 @@ local function WantToHelp()
 					link = 'https://tl.net/mytlnet/register?utm_source=Liquipedia&utm_medium=Website' ..
 						'&utm_campaign=Want+to+Help+' .. mw.uri.encode(mw.site.siteName) .. '&utm_id=Want+to+Help',
 					linktype = 'external',
-					title = 'Click here to create an account',
+					title = I18n.translate('wantToHelp-button-create-tooltip'),
 					variant = 'secondary',
 					children = {
 						IconFa{iconName = 'createaccount'},
-						' Create Account'
+						I18n.translate('wantToHelp-button-create-title')
 					}
 				}),
 				showWhenLoggedOut(Button{
-					link = 'Special:UserLogin',
-					title = 'Click here to log in',
+					link = I18n.translate('wantToHelp-button-logIn-link'),
+					title = I18n.translate('wantToHelp-button-logIn-tooltip'),
 					variant = 'secondary',
 					children = {
 						IconFa{iconName = 'login'},
-						' Log In'
+						I18n.translate('wantToHelp-button-logIn-title')
 					}
 				}),
 				Button{
 					link = 'https://discord.gg/liquipedia',
 					linktype = 'external',
-					title = 'Click here to join our discord server',
+					title = I18n.translate('wantToHelp-button-discord-tooltip'),
 					variant = 'secondary',
 					children = {
 						IconFa{iconName = 'discord'},
-						' Join Our Discord'
+						I18n.translate('wantToHelp-button-discord-title')
 					}
 				},
-				Page.exists('Help:Contents') and Button{
-					link = 'Help:Contents',
-					title = 'Click Here to Read our Help Articles',
+				Page.exists(I18n.translate('wantToHelp-helpArticles-link')) and Button{
+					link = I18n.translate('wantToHelp-helpArticles-link'),
+					title = I18n.translate('wantToHelp-helpArticles-tooltip'),
 					variant = 'secondary',
 					children = {
 						IconFa{iconName = 'helparticles'},
-						' Help Articles'
+						I18n.translate('wantToHelp-helpArticles-title')
 					}
 				} or nil
 			)
@@ -149,14 +153,14 @@ local function WantToHelp()
 			children = {'\n', WantToHelpList{}}
 		},
 		Html.Br{},
-		'In total there are ',
+		I18n.translate('wantToHelp-articleCount-preLink'),
 		Builder{builder = function () -- need the builder so the var is available when accessing it
 			return Link{
 				link = 'Liquipedia:Want to help/All',
-				children = {Variables.varDefault('total_number_of_todos', 0) .. ' pages'}
+				children = {Variables.varDefault('total_number_of_todos', 0) .. I18n.translate('wantToHelp-articleCount-pages')}
 			}
 		end},
-		' listed needing help.'
+		I18n.translate('wantToHelp-articleCount-postLink')
 	}
 end
 


### PR DESCRIPTION
## Summary
Stage 1.1 of the i18n integration: Main page, "Want to Help?" widget.
Added English and Russian strings and replaced all raw text with the i18n calls.

## How did you test this change?
English main page test: https://liquipedia.net/dota2/User:Le_Mur/Template:SandboxModule
English module: https://liquipedia.net/dota2/Module:Sandbox/Le_Mur/WantToHelp

Russian main page test: https://liquipedia.net/dota2gameru/User:Le_Mur/Шаблон:SandboxModule
Russian module (same as English): https://liquipedia.net/dota2gameru/Module:Sandbox/Le_Mur/WantToHelp
_Note: it says "Commons" on Russian test page because /dota2gameru lacks its own Info.lua at this time._ 