### PR TITLE
fix(match2): links do not automatically wrap to fit match summary width

### DIFF
--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -812,6 +812,10 @@ div.brkts-popup-body-element-thumbs {
 
 	.brkts-popup-footer & {
 		flex-wrap: wrap;
+
+		> a {
+			display: contents;
+		}
 	}
 }
 
@@ -820,10 +824,6 @@ div.brkts-popup-body-element-thumbs {
 	line-height: 17px;
 	margin-left: 1%;
 	margin-right: 1%;
-}
-
-.brkts-popup-footer .brkts-popup-spaced > a {
-	display: contents;
 }
 
 .brkts-popup-spaced.brkts-popup-spaced-map-skip > a {

--- a/stylesheets/commons/Brackets.scss
+++ b/stylesheets/commons/Brackets.scss
@@ -809,6 +809,10 @@ div.brkts-popup-body-element-thumbs {
 	justify-content: center;
 	gap: 4px;
 	text-align: center;
+
+	.brkts-popup-footer & {
+		flex-wrap: wrap;
+	}
 }
 
 .brkts-popup-winloss-icon {


### PR DESCRIPTION
## Summary

Fixes #7988

## How did you test this change?

browser dev tools