### PR TITLE
feat: add fragnet to links priority groups

### DIFF
--- a/lua/wikis/commons/Links/PriorityGroups.lua
+++ b/lua/wikis/commons/Links/PriorityGroups.lua
@@ -44,6 +44,7 @@ return {
 		'csgo-fastcup',
 		'cs2-fastcup',
 		'fide',
+		'fragnet',
 		'gamersclub',
 		'geoguessr',
 		'halodatahive',


### PR DESCRIPTION
## Summary

Add Fragnet to the group of other league icons

## How did you test this change?

trivial, follow-up of this PR https://github.com/Liquipedia/Lua-Modules/pull/7989
