### PR TITLE
fix(EmptyPagePreview): warning shown even if no content is generated

### DIFF
--- a/lua/wikis/commons/Widget/EmptyPagePreview.lua
+++ b/lua/wikis/commons/Widget/EmptyPagePreview.lua
@@ -8,6 +8,7 @@
 local Lua = require('Module:Lua')
 
 local Namespace = Lua.import('Module:Namespace')
+local Logic = Lua.import('Module:Logic')
 local TeamTemplate = Lua.import('Module:TeamTemplate')
 
 local AmBox = Lua.import('Module:Widget/ArticleMessageBox')
@@ -42,9 +43,14 @@ local EmptyPagePreview = function(props)
 		}
 	end
 
+	local personPagePreview = tostring(EmptyPersonPagePreview(props))
+	if Logic.isEmpty(personPagePreview) then
+		return
+	end
+
 	return {
 		previewWarning,
-		EmptyPersonPagePreview(props)
+		personPagePreview
 	}
 end
 


### PR DESCRIPTION
## Summary
reported on discord: https://discord.com/channels/93055209017729024/372075546231832576/1539939658086092931

## How did you test this change?
live