### PR TITLE
feat(match2): add dev environment support for br

### DIFF
--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -378,7 +378,7 @@ liquipedia.battleRoyale = {
 		const games = Object.keys( this.battleRoyaleMap[ battleRoyaleId ].gamePanels[ matchContentId ] ).length - 1;
 		let wikitext = '';
 		for ( let i = 1; i <= games; i++ ) {
-			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }|dev=${ dev }}`;
+			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }|dev=${ dev }}}`;
 		}
 
 		const element =

--- a/javascript/commons/BattleRoyale.js
+++ b/javascript/commons/BattleRoyale.js
@@ -328,7 +328,7 @@ liquipedia.battleRoyale = {
 
 				// Trigger countdown initialization since we have new dates
 				liquipedia.countdown.init();
-			} );
+			}, this.battleRoyaleMap[ battleRoyaleId ].dev );
 		} else {
 			this.updateGameTabDisplay( battleRoyaleId, matchContentId, gameTab );
 		}
@@ -362,7 +362,7 @@ liquipedia.battleRoyale = {
 		this.recheckNavigationStates( battleRoyaleId );
 	},
 
-	callTemplate: function( battleRoyaleId, matchId, gameId, matchContentId, callback ) {
+	callTemplate: function( battleRoyaleId, matchId, gameId, matchContentId, callback, dev ) {
 		// Create a new object for the match if it doesn't exist
 		if ( !this.isLoading[ battleRoyaleId ] ) {
 			this.isLoading[ battleRoyaleId ] = {};
@@ -378,7 +378,7 @@ liquipedia.battleRoyale = {
 		const games = Object.keys( this.battleRoyaleMap[ battleRoyaleId ].gamePanels[ matchContentId ] ).length - 1;
 		let wikitext = '';
 		for ( let i = 1; i <= games; i++ ) {
-			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }}}`;
+			wikitext += `{{ShowSingleGame|id=${ battleRoyaleId }|matchid=${ matchId }|gameidx=${ i }|dev=${ dev }}`;
 		}
 
 		const element =
@@ -450,7 +450,8 @@ liquipedia.battleRoyale = {
 					.querySelectorAll( '[data-js-battle-royale-content-id]' ) ),
 			gameTabs: {},
 			gamePanels: {},
-			collapsibles: []
+			collapsibles: [],
+			dev: this.battleRoyaleInstances[ battleRoyaleId ].dataset.jsBattleRoyaleDev
 		};
 
 		this.battleRoyaleMap[ battleRoyaleId ].matchContents.forEach( ( content ) => {

--- a/lua/wikis/commons/FeatureFlag.lua
+++ b/lua/wikis/commons/FeatureFlag.lua
@@ -41,7 +41,7 @@ local cachedFlags = {}
 ---Retrieves the boolean value of a feature flag. If the flag has not been
 ---previously set, this returns the configured default value of the flag.
 ---@param flag string
----@return boolean
+---@return string|boolean
 function FeatureFlag.get(flag)
 	if cachedFlags[flag] == nil then
 		cachedFlags[flag] = FeatureFlag._get(flag)
@@ -50,7 +50,7 @@ function FeatureFlag.get(flag)
 end
 
 ---@param flag string
----@return boolean|string
+---@return string|boolean
 function FeatureFlag._get(flag)
 	local config = FeatureFlag.getConfig(flag)
 	return Logic.nilOr(

--- a/lua/wikis/commons/MatchGroup/Display/Horizontallist.lua
+++ b/lua/wikis/commons/MatchGroup/Display/Horizontallist.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local Array = Lua.import('Module:Array')
 local Date = Lua.import('Module:Date/Ext')
+local FeatureFlag = Lua.import('Module:FeatureFlag')
 local FnUtil = Lua.import('Module:FnUtil')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
@@ -119,6 +120,7 @@ function HorizontallistDisplay.Bracket(props)
 		attributes = {
 			['data-js-battle-royale-id'] = props.bracketId,
 			['data-js-battle-royale-init-tab'] = selectedMatchIdx - 1, -- Convert to 0-index
+			['data-js-battle-royale-dev'] = tostring(FeatureFlag.get('dev')),
 		},
 		children = {
 			bracketNode,


### PR DESCRIPTION
## Summary

Match2 BR/FFA did not support directly applying dev environment arguments to game tabs as they were loaded via javascript due to performance reasons.
This PR exports the dev flag to the generated matchgroup display html code, allowing it to be picked up by javascript.

## How did you test this change?

dev in pubg + dev proxy