### PR TITLE
feat(filterbuttons): add 2026 regions mapping in rocketleague

### DIFF
--- a/lua/wikis/rocketleague/FilterButtons/Config.lua
+++ b/lua/wikis/rocketleague/FilterButtons/Config.lua
@@ -17,6 +17,7 @@ local REGION_TO_SUPERREGION = {
 	['Europe'] = 'EU',
 	['Turkey'] = 'EU',
 	['North America'] = 'NA',
+	['Central America'] = 'NA',
 	['Oceania'] = 'OCE',
 	['Latin America North'] = 'SAM',
 	['Latin America South'] = 'SAM',
@@ -26,8 +27,11 @@ local REGION_TO_SUPERREGION = {
 	['MENA'] = 'MENA',
 	['Asia'] = 'APAC',
 	['Asia-Pacific'] = 'APAC',
+	['East Asia'] = 'APAC',
+	['Japan'] = 'APAC',
 	['Africa'] = 'SSA',
 	['Other'] = 'Other',
+	['World'] = 'Other',
 }
 
 local REGIONS_IN_SUPERREGION = Table.mapValues(Table.groupBy(REGION_TO_SUPERREGION, function(region, superRegion)


### PR DESCRIPTION
## Summary

Tournaments whose region isn't in `REGION_TO_SUPERREGION` are dropped from the match and tournament tickers even with every region button active. 

Map the region values used by 2026 events that were missing:

* East Asia 🠒 **APAC**: [FIFAe Nations League Asia East & Oceania events](https://liquipedia.net/rocketleague/FIFAe_World_Cup/Nations_League/2026/Asia_East_and_Oceania/Points)
* Japan 🠒 **APAC**: [α-LEAGUE 2026](https://liquipedia.net/rocketleague/%CE%91-Gaming/%CE%B1-LEAGUE/2026/Main_Event)
* Central America 🠒 **NA**: [FIFAe North and Central America events](https://liquipedia.net/rocketleague/FIFAe_World_Cup/Continental_Championships/2026/North_and_Central_America)
* World 🠒 **Other**: a few online/low-tier events without boundaries

## How did you test this change?

* [dev env](https://liquipedia.net/rocketleague/Module:FilterButtons/Config/dev/Dyl_m)
* [User page for preview](https://liquipedia.net/rocketleague/User:Dyl_m/Main_Page_Test): the α-LEAGUE 2026 is appearing.