### PR TITLE
refactor: Use partial date parsing in DateRange for wikicode usage

### DIFF
--- a/lua/wikis/commons/Date/Ext.lua
+++ b/lua/wikis/commons/Date/Ext.lua
@@ -274,4 +274,33 @@ function DateExt.daysToSeconds(days)
 	return days * SECONDS_PER_DAY
 end
 
+---@class DateRecord
+---@field year integer
+---@field month integer?
+---@field day integer?
+---@field timestamp integer?
+
+--- This function parses fuzzy dates into a structured format.
+---@param dateRecord string? # date in the format of `YYYY-MM-DD`, with `-MM-DD` optional.
+---@return DateRecord?
+function DateExt.parseDateRecord(dateRecord)
+	if not dateRecord then
+		return nil
+	end
+	if dateRecord == DateExt.defaultDate then
+		return nil
+	end
+	local year, month, day = dateRecord:match('^(%d%d%d%d)%-?(%d?%d?)%-?(%d?%d?)')
+	year, month, day = tonumber(year), tonumber(month), tonumber(day)
+
+	if not year then
+		return
+	end
+
+	local dt = {year = year, month = month or 12, day = day or 31, hour = 0}
+	local timestamp = os.time(dt)
+
+	return {year = year, month = month, day = day, timestamp = timestamp}
+end
+
 return DateExt

--- a/lua/wikis/commons/Tournament.lua
+++ b/lua/wikis/commons/Tournament.lua
@@ -160,8 +160,8 @@ end
 ---@return StandardTournament
 function Tournament.tournamentFromRecord(record)
 	local extradata = record.extradata or {}
-	local startDate = Tournament.parseDateRecord(Logic.nilOr(extradata.startdatetext, record.startdate))
-	local endDate = Tournament.parseDateRecord(Logic.nilOr(extradata.enddatetext, record.sortdate, record.enddate))
+	local startDate = DateExt.parseDateRecord(Logic.nilOr(extradata.startdatetext, record.startdate))
+	local endDate = DateExt.parseDateRecord(Logic.nilOr(extradata.enddatetext, record.sortdate, record.enddate))
 	local tier, tierType, tierOptions = Tier.parseFromQueryData(record)
 
 	local tournament = {
@@ -216,35 +216,6 @@ function Tournament.calculatePhase(tournament)
 		return TOURNAMENT_PHASE.ONGOING
 	end
 	return TOURNAMENT_PHASE.FINISHED
-end
-
----@class DateRecord
----@field year integer
----@field month integer?
----@field day integer?
----@field timestamp integer?
-
---- This function parses fuzzy dates into a structured format.
----@param dateRecord string? # date in the format of `YYYY-MM-DD`, with `-MM-DD` optional.
----@return DateRecord?
-function Tournament.parseDateRecord(dateRecord)
-	if not dateRecord then
-		return nil
-	end
-	if dateRecord == DateExt.defaultDate then
-		return nil
-	end
-	local year, month, day = dateRecord:match('^(%d%d%d%d)%-?(%d?%d?)%-?(%d?%d?)')
-	year, month, day = tonumber(year), tonumber(month), tonumber(day)
-
-	if not year then
-		return
-	end
-
-	local dt = {year = year, month = month or 12, day = day or 31, hour = 0}
-	local timestamp = os.time(dt)
-
-	return {year = year, month = month, day = day, timestamp = timestamp}
 end
 
 --- Determines if a tournament is featured.

--- a/lua/wikis/commons/Widget/Misc/DateRange.lua
+++ b/lua/wikis/commons/Widget/Misc/DateRange.lua
@@ -94,10 +94,10 @@ end
 local function DateRange(props)
 	local startDate, endDate = props.startDate, props.endDate
 	if type(startDate) ~= 'table' then
-		startDate = DateExt.parseIsoDate(startDate --[[ @as string? ]])
+		startDate = DateExt.parseDateRecord(startDate --[[ @as string? ]])
 	end
 	if type(endDate) ~= 'table' then
-		endDate = DateExt.parseIsoDate(endDate --[[ @as string? ]])
+		endDate = DateExt.parseDateRecord(endDate --[[ @as string? ]])
 	end
 
 	---@type osdateparam?

--- a/lua/wikis/commons/Widget/Misc/DateRange.lua
+++ b/lua/wikis/commons/Widget/Misc/DateRange.lua
@@ -89,7 +89,7 @@ local function determineTranslateString(startDate, endDate, showYear)
 	end
 end
 
----@param props {startDate: string|osdateparam?, endDate: string|osdateparam?, showYear: boolean?}
+---@param props {startDate: string|DateRecord|osdateparam?, endDate: string|DateRecord|osdateparam?, showYear: boolean?}
 ---@return string
 local function DateRange(props)
 	local startDate, endDate = props.startDate, props.endDate


### PR DESCRIPTION
## Summary
To be able to properly use Widget/Misc/DateRange from wikicode, use the daterecord parsing that allows partial dates.
<!--
 Explain the **motivation** for making this change. What problems are you solving with this pull request? How are you improving the current situation?

 Please also consider the diff size. If you have changed more than 100 lines, chances are your pull request will be almost impossible to review. Are there any ways to
 split up your pull request further? Does the collection of changes semantically make sense?
-->

## How did you test this change?
dev on https://liquipedia.net/commons/Template:DateRange/doc
<!--
  Demonstrate the code is solid. Example: The exact pages you used to test this change, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.

  Things to be particularly aware of:

  - Does this break LPDB on any of the wikis?
  - Are all needed page variables still set?
-->
