### PR TITLE
feat(TeamParticipants): store role data to LPDB

### DIFF
--- a/lua/wikis/commons/MatchGroup/Util.lua
+++ b/lua/wikis/commons/MatchGroup/Util.lua
@@ -152,6 +152,7 @@ MatchGroupUtil.types.BracketData = TypeUtil.union(
 ---@field extradata table?
 ---@field pageIsResolved boolean?
 ---@field faction string?
+---@field roles string[]?
 ---@field apiId string?
 
 MatchGroupUtil.types.Player = TypeUtil.struct({

--- a/lua/wikis/commons/Opponent.lua
+++ b/lua/wikis/commons/Opponent.lua
@@ -595,6 +595,11 @@ function Opponent.toLpdbStruct(opponent, options)
 				nil
 			players[prefix .. 'template'] = player.team
 			players[prefix .. 'faction'] = Logic.nilIfEmpty(player.faction)
+			if player.roles then
+				Array.forEach(player.roles, function (role, roleIndex)
+					players[prefix .. 'role' .. roleIndex] = role
+				end)
+			end
 			players[prefix .. 'id'] = Logic.nilIfEmpty(player.apiId)
 		end
 		storageStruct.opponentplayers = players
@@ -668,6 +673,9 @@ function Opponent._personFromLpdbStruct(roleIndicator, players, playerIndex)
 		team = players[prefix .. 'template'] or players[prefix .. 'team'],
 		faction = Logic.nilIfEmpty(players[prefix .. 'faction']),
 		apiId = Logic.nilIfEmpty(players[prefix .. 'id']),
+		roles = Logic.nilIfEmpty(Array.mapIndexes(function (roleIndex)
+			return players[prefix .. 'role' .. roleIndex]
+		end))
 	}
 end
 

--- a/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
+++ b/lua/wikis/commons/TeamParticipants/Parse/Wiki.lua
@@ -11,6 +11,7 @@ local Array = Lua.import('Module:Array')
 local DateExt = Lua.import('Module:Date/Ext')
 local Info = Lua.import('Module:Info', {loadData = true})
 local Logic = Lua.import('Module:Logic')
+local Operator = Lua.import('Module:Operator')
 local Opponent = Lua.import('Module:Opponent/Custom')
 local Placement = Lua.import('Module:Placement')
 local RoleUtil = Lua.import('Module:Role/Util')
@@ -243,6 +244,8 @@ function TeamParticipantsWikiParser.parsePlayer(playerInput)
 	else
 		playerType = 'player'
 	end
+
+	player.roles = Array.map(roles, Operator.property('key'))
 
 	player.extradata = {
 		roles = roles,


### PR DESCRIPTION
## Summary

This PR adds support for storing player roles to `placement.opponentplayers` from `TeamParticipants`.

## How did you test this change?

preview with dev