### PR TITLE
feat(match2): handle clutches with time expire in valorant matchpages

### DIFF
--- a/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
@@ -10,6 +10,7 @@ local Lua = require('Module:Lua')
 local Array = Lua.import('Module:Array')
 local Logic = Lua.import('Module:Logic')
 local Operator = Lua.import('Module:Operator')
+local Set = Lua.import('Module:Set')
 local Table = Lua.import('Module:Table')
 
 local MapData = mw.loadJsonData('MediaWiki:Valorantdb-maps.json')
@@ -231,6 +232,16 @@ function CustomMatchGroupInputMatchPage.getRounds(map)
 		if ceremony == 'Clutch' then
 			if Logic.isNotEmpty(round.bomb_defuser) then
 				return round.bomb_defuser
+			elseif mapResultCodes(round.round_result_code) == 'time' then
+				---@type Set<string>
+				local players = Set(map.teams[winningTeam].puuids)
+				Array.forEach(roundKills, function (roundKill)
+					players:remove(roundKill.victim)
+				end)
+				if players:size() ~= 1 then
+					return
+				end
+				return players:toArray()[1]
 			end
 			local killsFromWinningTeam = Array.filter(
 				roundKills,

--- a/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
+++ b/lua/wikis/valorant/MatchGroup/Input/Custom/MatchPage.lua
@@ -234,14 +234,14 @@ function CustomMatchGroupInputMatchPage.getRounds(map)
 				return round.bomb_defuser
 			elseif mapResultCodes(round.round_result_code) == 'time' then
 				---@type Set<string>
-				local players = Set(map.teams[winningTeam].puuids)
+				local alivePlayersOnWinningTeam = Set(map.teams[winningTeam].puuids)
 				Array.forEach(roundKills, function (roundKill)
-					players:remove(roundKill.victim)
+					alivePlayersOnWinningTeam:remove(roundKill.victim)
 				end)
-				if players:size() ~= 1 then
+				if alivePlayersOnWinningTeam:size() ~= 1 then
 					return
 				end
-				return players:toArray()[1]
+				return alivePlayersOnWinningTeam:toArray()[1]
 			end
 			local killsFromWinningTeam = Array.filter(
 				roundKills,


### PR DESCRIPTION
## Summary

A defending team could clutch a round if the team has only one player left standing but still manage to stop the attacking team from planting (e.g., <https://youtu.be/5b5x2btGmQw?t=6h27m58s>). This PR adds handling for this specific edge case.

## How did you test this change?

preview with dev