### PR TITLE
chore(infobox): change type name for player infobox

### DIFF
--- a/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/ageofempires/Infobox/Person/Player/Custom.lua
@@ -37,7 +37,7 @@ local Comparator = Condition.Comparator
 local BooleanOperator = Condition.BooleanOperator
 local ColumnName = Condition.ColumnName
 
----@class AgeofempiresInfoboxPlayer: Person
+---@class AgeofempiresInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): AgeofempiresInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/arenafps/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/arenafps/Infobox/Person/Player/Custom.lua
@@ -19,7 +19,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class ArenafpsInfoboxPlayer: Person
+---@class ArenafpsInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
@@ -21,7 +21,12 @@ local Injector = Lua.import('Module:Widget/Injector')
 local Cell = Widgets.Cell
 
 ---@class BrawlhallaInfoboxPlayer: InfoboxPerson
+---@operator call(Frame): BrawlhallaInfoboxPlayer
 local CustomPlayer = Class.new(Player)
+
+---@class BrawlhallaInfoboxPlayerWidgetInjector: WidgetInjector
+---@operator call(BrawlhallaInfoboxPlayer): BrawlhallaInfoboxPlayerWidgetInjector
+---@field caller BrawlhallaInfoboxPlayer
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame

--- a/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
@@ -20,7 +20,7 @@ local Widgets = Lua.import('Module:Widget/All')
 local Injector = Lua.import('Module:Widget/Injector')
 local Cell = Widgets.Cell
 
----@class BrawlhallaInfoboxPlayer: Person
+---@class BrawlhallaInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/brawlhalla/Infobox/Person/Player/Custom.lua
@@ -9,12 +9,13 @@ local Lua = require('Module:Lua')
 
 local ActiveYears = Lua.import('Module:YearsActive')
 local Class = Lua.import('Module:Class')
+local DateExt = Lua.import('Module:Date/Ext')
 local Math = Lua.import('Module:MathUtil')
 local PlayersSignatureLegends = Lua.import('Module:PlayersSignatureLegends')
 
 local Player = Lua.import('Module:Infobox/Person')
 
-local CURRENT_YEAR = tonumber(os.date('%Y'))
+local CURRENT_YEAR = DateExt.getYearOf()
 
 local Widgets = Lua.import('Module:Widget/All')
 local Injector = Lua.import('Module:Widget/Injector')
@@ -49,13 +50,14 @@ function CustomInjector:parse(id, widgets)
 		local yearsActive = ActiveYears.display{player = caller.pagename}
 
 		local currentYearEarnings = caller.earningsPerYear[CURRENT_YEAR]
+		local currentYearEarningsDisplay
 		if currentYearEarnings then
 			currentYearEarnings = Math.round(currentYearEarnings)
-			currentYearEarnings = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
+			currentYearEarningsDisplay = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
 		end
 
 		return {
-			Cell{name = 'Approx. Winnings ' .. CURRENT_YEAR, children = {currentYearEarnings}},
+			Cell{name = 'Approx. Winnings ' .. CURRENT_YEAR, children = {currentYearEarningsDisplay}},
 			Cell{name = 'Years active', children = {yearsActive}},
 			Cell{name = 'Main Legends', children = {PlayersSignatureLegends.get{player = caller.pagename}}},
 		}

--- a/lua/wikis/brawlstars/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/brawlstars/Infobox/Person/Player/Custom.lua
@@ -25,7 +25,7 @@ local Html = Lua.import('Module:Widget/Html')
 local Cell = Widgets.Cell
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
----@class BrawlstarsInfoboxPlayer: Person
+---@class BrawlstarsInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): BrawlstarsInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/chess/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/chess/Infobox/Person/Player/Custom.lua
@@ -18,7 +18,7 @@ local Widgets = require('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
----@class ChessInfoboxPlayer: Person
+---@class ChessInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/commons/Infobox/Person.lua
+++ b/lua/wikis/commons/Infobox/Person.lua
@@ -203,7 +203,7 @@ function Person:createInfobox()
 	return self:build(widgets, 'Person')
 end
 
----@return Widget?
+---@return Renderable?
 function Person:_createUpcomingMatches()
 	if not self:shouldStoreData(self.args) then
 		return nil

--- a/lua/wikis/commons/Infobox/Person.lua
+++ b/lua/wikis/commons/Infobox/Person.lua
@@ -44,8 +44,8 @@ local Customizable = Widgets.Customizable
 local TeamHistoryWidget = Lua.import('Module:Widget/Infobox/TeamHistory')
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
----@class Person: BasicInfobox
----@operator call(Frame): Person
+---@class InfoboxPerson: BasicInfobox
+---@operator call(Frame): InfoboxPerson
 ---@field locations string[]
 ---@field roles RoleData[]
 local Person = Class.new(BasicInfobox)

--- a/lua/wikis/commons/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/commons/Infobox/Person/Player/Custom.lua
@@ -11,7 +11,7 @@ local Class = Lua.import('Module:Class')
 
 local Player = Lua.import('Module:Infobox/Person')
 
----@class CustomInfoboxPlayer: Person
+---@class CustomInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): CustomInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/commons/Infobox/Person/User.lua
+++ b/lua/wikis/commons/Infobox/Person/User.lua
@@ -13,7 +13,7 @@ local OpponentDisplay = Lua.import('Module:OpponentDisplay/Custom')
 
 local Person = Lua.import('Module:Infobox/Person')
 
----@class InfoboxUser: Person
+---@class InfoboxUser: InfoboxPerson
 ---@operator call(Frame): InfoboxUser
 local User = Class.new(Person)
 

--- a/lua/wikis/criticalops/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/criticalops/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class COPSInfoboxPlayer: Person
+---@class COPSInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/crossfire/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/crossfire/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class CrossfireInfoboxPlayer: Person
+---@class CrossfireInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/dota2/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/dota2/Infobox/Person/Player/Custom.lua
@@ -35,7 +35,7 @@ local BANNED = Lua.import('Module:Banned', {loadData = true})
 local SIZE_HERO = '44x25px'
 local CONVERSION_PLAYER_ID_TO_STEAM = 61197960265728
 
----@class Dota2InfoboxPlayer: Person
+---@class Dota2InfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): Dota2InfoboxPlayer
 ---@field basePageName string
 local CustomPlayer = Class.new(Player)

--- a/lua/wikis/easportsfc/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/easportsfc/Infobox/Person/Player/Custom.lua
@@ -16,7 +16,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class EafcInfoboxPlayer: Person
+---@class EafcInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/fighters/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/fighters/Infobox/Person/Player/Custom.lua
@@ -18,7 +18,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class FightersInfoboxPlayer: Person
+---@class FightersInfoboxPlayer: InfoboxPerson
 ---@field games string[]
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)

--- a/lua/wikis/formula1/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/formula1/Infobox/Person/Player/Custom.lua
@@ -18,7 +18,7 @@ local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
----@class Formula1InfoboxPlayer: Person
+---@class Formula1InfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
@@ -21,7 +21,7 @@ local Cell = Widgets.Cell
 
 local CURRENT_YEAR = tonumber(os.date('%Y'))
 
----@class HearthstoneInfoboxPlayer: Person
+---@class HearthstoneInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
@@ -9,6 +9,7 @@ local Lua = require('Module:Lua')
 
 local ActiveYears = Lua.import('Module:YearsActive')
 local Class = Lua.import('Module:Class')
+local DateExt = Lua.import('Module:Date/Ext')
 local Region = Lua.import('Module:Region')
 local Math = Lua.import('Module:MathUtil')
 local String = Lua.import('Module:StringUtils')
@@ -19,7 +20,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
-local CURRENT_YEAR = tonumber(os.date('%Y'))
+local CURRENT_YEAR = DateExt.getYearOf()
 
 ---@class HearthstoneInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): HearthstoneInfoboxPlayer
@@ -49,13 +50,14 @@ function CustomInjector:parse(id, widgets)
 		local yearsActive = ActiveYears.display{player = caller.pagename}
 
 		local currentYearEarnings = caller.earningsPerYear[CURRENT_YEAR]
+		local currentYearEarningsDisplay
 		if currentYearEarnings then
 			currentYearEarnings = Math.round(currentYearEarnings)
-			currentYearEarnings = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
+			currentYearEarningsDisplay = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
 		end
 
 		return {
-			Cell{name = 'Approx. Winnings ' .. CURRENT_YEAR, children = {currentYearEarnings}},
+			Cell{name = 'Approx. Winnings ' .. CURRENT_YEAR, children = {currentYearEarningsDisplay}},
 			Cell{name = 'Years active', children = {yearsActive}},
 		}
 	elseif id == 'region' then return {}

--- a/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/hearthstone/Infobox/Person/Player/Custom.lua
@@ -22,7 +22,12 @@ local Cell = Widgets.Cell
 local CURRENT_YEAR = tonumber(os.date('%Y'))
 
 ---@class HearthstoneInfoboxPlayer: InfoboxPerson
+---@operator call(Frame): HearthstoneInfoboxPlayer
 local CustomPlayer = Class.new(Player)
+
+---@class HearthstoneInfoboxPlayerWidgetInjector: WidgetInjector
+---@operator call(HearthstoneInfoboxPlayer): HearthstoneInfoboxPlayerWidgetInjector
+---@field caller HearthstoneInfoboxPlayer
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame

--- a/lua/wikis/heroes/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/heroes/Infobox/Person/Player/Custom.lua
@@ -20,7 +20,7 @@ local Cell = Widgets.Cell
 
 local SIZE_HERO = '28x28px'
 
----@class HeroesInfoboxPlayer: Person
+---@class HeroesInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/leagueoflegends/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/leagueoflegends/Infobox/Person/Player/Custom.lua
@@ -25,7 +25,7 @@ local Html = Lua.import('Module:Widget/Html')
 local Cell = Widgets.Cell
 local WidgetUtil = Lua.import('Module:Widget/Util')
 
----@class LeagueoflegendsInfoboxPlayer: Person
+---@class LeagueoflegendsInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): LeagueoflegendsInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/marvelrivals/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/marvelrivals/Infobox/Person/Player/Custom.lua
@@ -29,7 +29,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 local SIZE_HERO = '25x25px'
 local MAX_NUMBER_OF_SIGNATURE_HEROES = 3
 
----@class MarvelRivalsInfoboxPlayer: Person
+---@class MarvelRivalsInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): MarvelRivalsInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/naraka/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/naraka/Infobox/Person/Player/Custom.lua
@@ -25,7 +25,12 @@ local Cell = Widgets.Cell
 local SIZE_HERO = '25x25px'
 
 ---@class NarakaInfoboxPlayer: InfoboxPerson
+---@operator call(Frame): NarakaInfoboxPlayer
 local CustomPlayer = Class.new(Player)
+
+---@class NarakaInfoboxPlayerWidgetInjector: WidgetInjector
+---@operator call(NarakaInfoboxPlayer): NarakaInfoboxPlayerWidgetInjector
+---@field caller NarakaInfoboxPlayer
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
@@ -80,7 +85,7 @@ function CustomPlayer:adjustLPDB(lpdbData, args, personType)
 	return lpdbData
 end
 
----@return Widget?
+---@return VNode?
 function CustomPlayer:createBottomContent()
 	if not self:shouldStoreData(self.args) or String.isEmpty(self.args.team) then
 		return

--- a/lua/wikis/naraka/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/naraka/Infobox/Person/Player/Custom.lua
@@ -24,7 +24,7 @@ local Cell = Widgets.Cell
 
 local SIZE_HERO = '25x25px'
 
----@class NarakaInfoboxPlayer: Person
+---@class NarakaInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/omegastrikers/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/omegastrikers/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class OmegaStrikersInfoboxPlayer: Person
+---@class OmegaStrikersInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/osu/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/osu/Infobox/Person/Player/Custom.lua
@@ -16,7 +16,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class OsuInfoboxPlayer: Person
+---@class OsuInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 ---@class OsuPersonInfoboxInjector: WidgetInjector
 ---@field caller OsuInfoboxPlayer

--- a/lua/wikis/overwatch/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/overwatch/Infobox/Person/Player/Custom.lua
@@ -30,7 +30,7 @@ local Center = Widgets.Center
 local SIZE_HERO = '25x25px'
 local MAX_NUMBER_OF_SIGNATURE_HEROES = 3
 
----@class OverwatchInfoboxPlayer: Person
+---@class OverwatchInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): OverwatchInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/pubgmobile/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/pubgmobile/Infobox/Person/Player/Custom.lua
@@ -19,7 +19,7 @@ local UpcomingTournaments = Lua.import('Module:Infobox/Extension/UpcomingTournam
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class PubgmobileInfoboxPlayer: Person
+---@class PubgmobileInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 
 ---@class PubgmobileInfoboxPlayerWidgetInjector: WidgetInjector

--- a/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rainbowsix/Infobox/Person/Player/Custom.lua
@@ -46,7 +46,7 @@ local BANNED = Lua.import('Module:Banned', {loadData = true})
 
 local SIZE_OPERATOR = '25x25px'
 
----@class RainbowsixInfoboxPlayer: Person
+---@class RainbowsixInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): RainbowsixInfoboxPlayer
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/rocketleague/Infobox/Person/Player/Custom.lua
@@ -32,7 +32,7 @@ local BANNED = Lua.import('Module:Banned', {loadData = true})
 
 local NOT_APPLICABLE = 'N/A'
 
----@class RocketleagueInfoboxPlayer: Person
+---@class RocketleagueInfoboxPlayer: InfoboxPerson
 ---@operator call(Frame): RocketleagueInfoboxPlayer
 ---@field basePageName string
 local CustomPlayer = Class.new(Player)

--- a/lua/wikis/simracing/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/simracing/Infobox/Person/Player/Custom.lua
@@ -16,7 +16,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class SimracingInfoboxPlayer: Person
+---@class SimracingInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/smash/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/smash/Infobox/Person/Player/Custom.lua
@@ -24,7 +24,7 @@ local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 local Title = Widgets.Title
 
----@class SmashInfoboxPlayer: Person
+---@class SmashInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/splatoon/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/splatoon/Infobox/Person/Player/Custom.lua
@@ -22,7 +22,7 @@ local Cell = Widgets.Cell
 
 local SIZE_WEAPON = '25x25px'
 
----@class SplatoonInfoboxPlayer: Person
+---@class SplatoonInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
@@ -136,15 +136,16 @@ function CustomPlayer:_addCustomCells(args)
 		and Namespace.isMain() and self:_getMatchupData() or nil
 
 	local currentYearEarnings = self.earningsPerYear[CURRENT_YEAR]
+	local currentYearEarningsDisplay
 	if currentYearEarnings then
 		currentYearEarnings = Math.round(currentYearEarnings)
-		currentYearEarnings = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
+		currentYearEarningsDisplay = '$' .. mw.getContentLanguage():formatNum(currentYearEarnings)
 	end
 
 	return {
 		Cell{
 			name = 'Approx. Winnings ' .. CURRENT_YEAR,
-			children = {currentYearEarnings}
+			children = {currentYearEarningsDisplay}
 		},
 		Cell{name = 'Years active', children = {yearsActive}}
 	}

--- a/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
@@ -52,7 +52,7 @@ local BOT_INFORMATION_TYPE = 'Bot'
 -- race stuff
 local AVAILABLE_RACES = Array.append(Faction.knownFactions, 'total')
 
----@class StarcraftInfoboxPlayer: Person
+---@class StarcraftInfoboxPlayer: InfoboxPerson
 ---@field achievements placement[]
 ---@field awardAchievements placement[]
 local CustomPlayer = Class.new(Player)

--- a/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/starcraft/Infobox/Person/Player/Custom.lua
@@ -53,9 +53,14 @@ local BOT_INFORMATION_TYPE = 'Bot'
 local AVAILABLE_RACES = Array.append(Faction.knownFactions, 'total')
 
 ---@class StarcraftInfoboxPlayer: InfoboxPerson
+---@operator call(Frame): StarcraftInfoboxPlayer
 ---@field achievements placement[]
 ---@field awardAchievements placement[]
 local CustomPlayer = Class.new(Player)
+
+---@class StarcraftInfoboxPlayerWidgetInjector: WidgetInjector
+---@operator call(StarcraftInfoboxPlayer): StarcraftInfoboxPlayerWidgetInjector
+---@field caller StarcraftInfoboxPlayer
 local CustomInjector = Class.new(Injector)
 
 ---@param frame Frame
@@ -109,7 +114,7 @@ function CustomInjector:parse(id, widgets)
 end
 
 ---@param args table
----@return Widget[]
+---@return VNode[]
 function CustomPlayer:_addCustomCells(args)
 	if args.informationType == BOT_INFORMATION_TYPE then
 		return {

--- a/lua/wikis/starcraft2/Infobox/Person/Custom.lua
+++ b/lua/wikis/starcraft2/Infobox/Person/Custom.lua
@@ -35,7 +35,7 @@ MILITARY_DATA.pending = MILITARY_DATA.starting
 MILITARY_DATA.started = MILITARY_DATA.ongoing
 MILITARY_DATA.ending = MILITARY_DATA.ongoing
 
----@class SC2CustomPerson: Person
+---@class SC2CustomPerson: InfoboxPerson
 local CustomPerson = Class.new(Person)
 
 ---@param args table

--- a/lua/wikis/stormgate/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/stormgate/Infobox/Person/Player/Custom.lua
@@ -28,7 +28,7 @@ local Cell = Widgets.Cell
 local Title = Widgets.Title
 local Center = Widgets.Center
 
----@class StormgateInfoboxPlayer: Person
+---@class StormgateInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/teamfortress/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/teamfortress/Infobox/Person/Player/Custom.lua
@@ -16,7 +16,7 @@ local Cell = Widgets.Cell
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class TeamfortressInfoboxPlayer: Person
+---@class TeamfortressInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/tetris/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/tetris/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class TetrisInfoboxPlayer: Person
+---@class TetrisInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/tft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/tft/Infobox/Person/Player/Custom.lua
@@ -15,7 +15,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class TftInfoboxPlayer: Person
+---@class TftInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/trackmania/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/trackmania/Infobox/Person/Player/Custom.lua
@@ -16,7 +16,7 @@ local Player = Lua.import('Module:Infobox/Person')
 local Widgets = Lua.import('Module:Widget/All')
 local Cell = Widgets.Cell
 
----@class TrackmaniaInfoboxPlayer: Person
+---@class TrackmaniaInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/valorant/Infobox/Person/Player/Custom.lua
@@ -30,7 +30,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local SIZE_AGENT = '20px'
 
----@class ValorantPlayerInfobox: Person
+---@class ValorantPlayerInfobox: InfoboxPerson
 ---@operator call(Frame): ValorantPlayerInfobox
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/warcraft/Infobox/Person/Player/Custom.lua
@@ -22,7 +22,7 @@ local Cell = Widgets.Cell
 local CURRENT_YEAR = tonumber(os.date('%Y'))
 local NON_BREAKING_SPACE = '&nbsp;'
 
----@class WarcraftInfoboxPlayer: Person
+---@class WarcraftInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 

--- a/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/wildrift/Infobox/Person/Player/Custom.lua
@@ -30,7 +30,7 @@ local WidgetUtil = Lua.import('Module:Widget/Util')
 
 local SIZE_CHAMPION = '25x25px'
 
----@class WildriftPlayerInfobox: Person
+---@class WildriftPlayerInfobox: InfoboxPerson
 ---@operator call(Frame): WildriftPlayerInfobox
 local CustomPlayer = Class.new(Player)
 

--- a/lua/wikis/worldofwarcraft/Infobox/Person/Player/Custom.lua
+++ b/lua/wikis/worldofwarcraft/Infobox/Person/Player/Custom.lua
@@ -12,7 +12,7 @@ local Class = Lua.import('Module:Class')
 local Injector = Lua.import('Module:Widget/Injector')
 local Player = Lua.import('Module:Infobox/Person')
 
----@class WorldofwarcraftInfoboxPlayer: Person
+---@class WorldofwarcraftInfoboxPlayer: InfoboxPerson
 local CustomPlayer = Class.new(Player)
 local CustomInjector = Class.new(Injector)
 


### PR DESCRIPTION
## Summary

The base player infobox was given the type name of `Person` - this is problematic for several reasons:
- all infobox type names include `Infobox` (consistency)
- `Person` could be misunderstood as parsed wikicode input (e.g., from `{{Person}}`)

Thus, this PR renames `Person` type to `InfoboxPerson` for more clarity.

## How did you test this change?

trivial