### PR TITLE
refactor(infobox): move column width handling to stylesheets

### DIFF
--- a/lua/wikis/commons/Widget/Infobox/Cell.lua
+++ b/lua/wikis/commons/Widget/Infobox/Cell.lua
@@ -82,7 +82,6 @@ end
 ---@return Widget
 function Cell._buildChildrenContainer(mappedChildren, options)
 	local widgetProps = {
-		css = {width = (100 * (options.columns - 1) / options.columns) .. '%'}, -- 66.66% for col = 3
 		children = Array.interleave(mappedChildren, options.separator)
 	}
 

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -182,7 +182,7 @@ $infobox-padding: 10px;
 	}
 
 	div.infobox-cell-3 {
-		width: 33.3333%;
+		width: calc( 100% / 3 );
 	}
 
 	div.infobox-cell-4 {
@@ -190,7 +190,7 @@ $infobox-padding: 10px;
 	}
 
 	div.infobox-cell-4-5 {
-		width: 22.2222%;
+		width: calc( 100% / 4.5 );
 	}
 
 	div.infobox-cell-5 {
@@ -198,11 +198,11 @@ $infobox-padding: 10px;
 	}
 
 	div.infobox-cell-6 {
-		width: 16.6666%;
+		width: calc( 100% / 6 );
 	}
 
 	div.infobox-cell-7 {
-		width: 14.2857%;
+		width: calc( 100% / 7 );
 	}
 
 	div.infobox-cell-8 {
@@ -210,7 +210,7 @@ $infobox-padding: 10px;
 	}
 
 	div.infobox-cell-9 {
-		width: 11.1111%;
+		width: calc( 100% / 9 );
 	}
 
 	div.infobox-cell-10 {
@@ -218,11 +218,11 @@ $infobox-padding: 10px;
 	}
 
 	div.infobox-cell-11 {
-		width: 9.0909%;
+		width: calc( 100% / 11 );
 	}
 
 	div.infobox-cell-12 {
-		width: 8.3333%;
+		width: calc( 100% / 12 );
 	}
 
 	div.infobox-description {

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -157,11 +157,11 @@ $infobox-padding: 10px;
 		display: table;
 		width: 100%;
 
-		&:nth-child( 2n+1 ) {
+		&:nth-child( odd ) {
 			background-color: var( --clr-surface-2, #eeeeee );
 		}
 
-		&:nth-child( 2n ) {
+		&:nth-child( even ) {
 			background-color: var( --clr-surface-1, #f5f5f5 );
 		}
 

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -148,14 +148,18 @@ $infobox-padding: 10px;
 	padding-bottom: $infobox-padding;
 	border-top: 2px solid var( --infobox-header-background-color, var( --wiki-color-light ) );
 	border-bottom: 2px solid var( --infobox-header-background-color, var( --wiki-color-light ) );
+	display: grid;
+	grid-row: 1fr;
+	grid-auto-flow: column;
 
 	@media ( max-width: 600px ) {
 		width: 100%;
 	}
 
 	> div {
-		display: table;
-		width: 100%;
+		display: grid;
+		grid-column: 1 / -1;
+		grid-template-columns: subgrid;
 
 		&:nth-child( odd ) {
 			background-color: var( --clr-surface-2, #eeeeee );
@@ -169,60 +173,67 @@ $infobox-padding: 10px;
 			clear: both;
 		}
 
+		&:has( > :only-child ) {
+			display: contents;
+
+			> :only-child {
+				grid-column: 1 / -1;
+			}
+		}
+
 		> div {
-			width: 100%;
 			float: left;
 			height: inherit;
 			padding: 5px;
 		}
-	}
 
-	div.infobox-cell-2 {
-		width: 50%;
-	}
+		&:has( > .infobox-cell-2 ) {
+			grid-template-columns: repeat( 2, 1fr );
+		}
 
-	div.infobox-cell-3 {
-		width: calc( 100% / 3 );
-	}
+		&:has( > .infobox-cell-3 ) {
+			grid-template-columns: 1fr 2fr;
+		}
 
-	div.infobox-cell-4 {
-		width: 25%;
-	}
+		&:has( > .infobox-cell-4 ) {
+			grid-template-columns: 1fr 3fr;
+		}
 
-	div.infobox-cell-4-5 {
-		width: calc( 100% / 4.5 );
-	}
+		&:has( > .infobox-cell-4-5 ) {
+			grid-template-columns: 2fr 7fr;
+		}
 
-	div.infobox-cell-5 {
-		width: 20%;
-	}
+		&:has( > .infobox-cell-5 ) {
+			grid-template-columns: 1fr 4fr;
+		}
 
-	div.infobox-cell-6 {
-		width: calc( 100% / 6 );
-	}
+		&:has( > .infobox-cell-6 ) {
+			grid-template-columns: 1fr 5fr;
+		}
 
-	div.infobox-cell-7 {
-		width: calc( 100% / 7 );
-	}
+		&:has( > .infobox-cell-7 ) {
+			grid-template-columns: 1fr 6fr;
+		}
 
-	div.infobox-cell-8 {
-		width: 12.5%;
-	}
+		&:has( > .infobox-cell-8 ) {
+			grid-template-columns: 1fr 7fr;
+		}
 
-	div.infobox-cell-9 {
-		width: calc( 100% / 9 );
-	}
+		&:has( > .infobox-cell-9 ) {
+			grid-template-columns: 1fr 8fr;
+		}
 
-	div.infobox-cell-10 {
-		width: 10%;
-	}
+		&:has( > .infobox-cell-10 ) {
+			grid-template-columns: 1fr 9fr;
+		}
 
-	div.infobox-cell-11 {
-		width: calc( 100% / 11 );
-	}
+		&:has( > .infobox-cell-11 ) {
+			grid-template-columns: 1fr 10fr;
+		}
 
-	div.infobox-cell-12 {
-		width: calc( 100% / 12 );
+		&:has( > .infobox-cell-12 ) {
+			grid-template-columns: 1fr 11fr;
+		}
 	}
 
 	div.infobox-description {

--- a/stylesheets/commons/Infobox.scss
+++ b/stylesheets/commons/Infobox.scss
@@ -148,9 +148,8 @@ $infobox-padding: 10px;
 	padding-bottom: $infobox-padding;
 	border-top: 2px solid var( --infobox-header-background-color, var( --wiki-color-light ) );
 	border-bottom: 2px solid var( --infobox-header-background-color, var( --wiki-color-light ) );
-	display: grid;
-	grid-row: 1fr;
-	grid-auto-flow: column;
+	display: flex;
+	flex-flow: column nowrap;
 
 	@media ( max-width: 600px ) {
 		width: 100%;
@@ -158,8 +157,7 @@ $infobox-padding: 10px;
 
 	> div {
 		display: grid;
-		grid-column: 1 / -1;
-		grid-template-columns: subgrid;
+		width: 100%;
 
 		&:nth-child( odd ) {
 			background-color: var( --clr-surface-2, #eeeeee );
@@ -177,7 +175,7 @@ $infobox-padding: 10px;
 			display: contents;
 
 			> :only-child {
-				grid-column: 1 / -1;
+				width: 100%;
 			}
 		}
 
@@ -187,52 +185,14 @@ $infobox-padding: 10px;
 			padding: 5px;
 		}
 
-		&:has( > .infobox-cell-2 ) {
-			grid-template-columns: repeat( 2, 1fr );
-		}
-
-		&:has( > .infobox-cell-3 ) {
-			grid-template-columns: 1fr 2fr;
-		}
-
-		&:has( > .infobox-cell-4 ) {
-			grid-template-columns: 1fr 3fr;
+		@for $i from 2 through 12 {
+			&:has( > .infobox-cell-#{$i} ) {
+				grid-template-columns: 1fr #{$i - 1}fr;
+			}
 		}
 
 		&:has( > .infobox-cell-4-5 ) {
 			grid-template-columns: 2fr 7fr;
-		}
-
-		&:has( > .infobox-cell-5 ) {
-			grid-template-columns: 1fr 4fr;
-		}
-
-		&:has( > .infobox-cell-6 ) {
-			grid-template-columns: 1fr 5fr;
-		}
-
-		&:has( > .infobox-cell-7 ) {
-			grid-template-columns: 1fr 6fr;
-		}
-
-		&:has( > .infobox-cell-8 ) {
-			grid-template-columns: 1fr 7fr;
-		}
-
-		&:has( > .infobox-cell-9 ) {
-			grid-template-columns: 1fr 8fr;
-		}
-
-		&:has( > .infobox-cell-10 ) {
-			grid-template-columns: 1fr 9fr;
-		}
-
-		&:has( > .infobox-cell-11 ) {
-			grid-template-columns: 1fr 10fr;
-		}
-
-		&:has( > .infobox-cell-12 ) {
-			grid-template-columns: 1fr 11fr;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Currently infobox cells have to do their own calculation for determining column widths. This PR removes those calculations, replacing with css queries.

## How did you test this change?

browser dev tools