### PR TITLE
chore(links): Remove dead chinese live stream links

### DIFF
--- a/lua/wikis/commons/Links.lua
+++ b/lua/wikis/commons/Links.lua
@@ -375,7 +375,6 @@ local PREFIXES = {
 	yandexefir = {'https://yandex.ru/efir?stream_channel='},
 	youtube = {'https://www.youtube.com/'},
 	zhangyutv = {'http://www.zhangyu.tv/'},
-	zhanqitv = {'https://www.zhanqi.tv/'},
 }
 
 PREFIXES = Table.merge(PREFIXES, CustomData.prefixes or {})
@@ -415,7 +414,6 @@ local ALIASES = {
 	rules = {'rulebook'},
 	['start-gg'] = {'startgg', 'smashgg'},
 	yandexefir = {'yandex'},
-	zhanqitv = {'zhanqi'},
 }
 
 local ICON_KEYS_TO_RENAME = {

--- a/lua/wikis/commons/Links/PriorityGroups.lua
+++ b/lua/wikis/commons/Links/PriorityGroups.lua
@@ -115,7 +115,6 @@ return {
 		'openrec',
 		'steamtv',
 		'yandexefir',
-		'zhanqitv',
 		'rooter',
 	},
 }

--- a/stylesheets/commons/Icons.scss
+++ b/stylesheets/commons/Icons.scss
@@ -241,7 +241,6 @@ https://liquipedia.net/commons/Infobox_Icons
 	@include icon-make-image( youku, "//liquipedia.net/commons/images/8/8e/InfoboxIcon_Youku.png" );
 	@include icon-make-image( youtube, "//liquipedia.net/commons/images/6/6c/InfoboxIcon_YouTube.png" );
 	@include icon-make-image( zhangyutv, "//liquipedia.net/commons/images/c/cf/InfoboxIcon_ZhangyuTV.png" );
-	@include icon-make-image( zhanqitv, "//liquipedia.net/commons/images/b/b0/InfoboxIcon_ZhanqiTV.png" );
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary

The chinese live stream platform https://www.zhanqi.tv/ does not seem to work anymore and is just showing old VODs of 2019 on repeat. Personal pages that are linked in _Infobox player_  only lead to an empty page with a link to the mainpage without further information. 

Keeping this in draft until a chinese editor can confirm for sure, see discord https://discord.com/channels/93055209017729024/1209065403955806270/1544384493706809364

There's also doubts about https://cc.163.com, but that redirects automatically to https://ds.163.com now (since 31.08.2026 according to a random contributor who tried to remove several of those links), unsure if its always a redirect to the same channel or if its suddenly linking to someone else. Havent touched this yet

## How did you test this change?

seems trivial
