### PR TITLE
fix: devcontainer node_modules permissions

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "==> Installing npm dependencies"
-# node_modules is a named volume, which docker creates owned by root
-sudo chown "$(id -u):$(id -g)" node_modules
+# node_modules is a named volume, which docker creates owned by root. Recursive
+# because a volume that outlives a rebuild keeps whatever uid wrote it, and the
+# user we run as has not always had the same one: fixing only the mount point
+# leaves npm unable to rename anything inside it
+sudo mkdir -p node_modules
+sudo chown -R "$(id -u):$(id -g)" node_modules
 npm install
 
 echo "==> Installing python dependencies"


### PR DESCRIPTION
## What

`post-create.sh` chowned only the `node_modules` mount point, not its contents. The volume outlives a rebuild and keeps whatever uid wrote it, and the user we run as has not always had the same one — containers built before #7955's uid fix wrote it as 1002, and since that fix we are 1000. So on rebuild every file inside stayed owned by the old uid and `npm install` died:

```
npm error EACCES: permission denied, rename '/workspaces/Lua-Modules/node_modules/.bin/playwright' -> '.../.playwright-em54emh1'
```

It only worked initially because the volume was empty. This affects anyone who used the devcontainer before the uid fix and rebuilds after it.

## How it was tested

Reproduced on a volume seeded to match: contents owned by 1002, mount point 1000. As uid 1000, the old line then fails the same way —

```
mv: cannot move '/nm/.bin/playwright' to '/nm/.bin/.playwright-tmp': Permission denied
```

— and with `chown -R` the rename succeeds. On a real populated volume (456 entries) the recursive chown takes 0.7s.