### PR TITLE
perf: replace html2canvas with snapdom for image export

### DIFF
--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -597,26 +597,27 @@ class ExportLayoutFrame {
 		const iframe = await this.prepare();
 		const frameDocument = iframe.contentDocument;
 
-		iframe.style.height = `${ this.getLayoutHeight() }px`;
-		this.copyRootAttributes( frameDocument );
-
-		const target = this.replaceContent( frameDocument, element );
-		options.prepareDocument( frameDocument );
-		this.pruneHiddenContent( target );
-		target.style.background = options.backgroundColor;
-
-		await this.waitForFonts( frameDocument );
-
-		this.pinSubgridTracks( target );
-
-		const bounds = target.getBoundingClientRect();
-		if ( bounds.width === 0 || bounds.height === 0 ) {
-			throw new Error( 'Canvas capture resulted in zero dimensions' );
-		}
-
-		const scale = this.getEffectiveScale( bounds, options.scale );
-
+		// A run that throws part way leaves the frame just as dirty as one that
+		// finishes, so every exit recycles.
 		try {
+			iframe.style.height = `${ this.getLayoutHeight() }px`;
+			this.copyRootAttributes( frameDocument );
+
+			const target = this.replaceContent( frameDocument, element );
+			options.prepareDocument( frameDocument );
+			this.pruneHiddenContent( target );
+			target.style.background = options.backgroundColor;
+
+			await this.waitForFonts( frameDocument );
+
+			this.pinSubgridTracks( target );
+
+			const bounds = target.getBoundingClientRect();
+			if ( bounds.width === 0 || bounds.height === 0 ) {
+				throw new Error( 'Canvas capture resulted in zero dimensions' );
+			}
+
+			const scale = this.getEffectiveScale( bounds, options.scale );
 			const canvas = await snapdom.toCanvas( target, {
 				scale: scale,
 				// The fixed scale must not be multiplied by the reader's ratio.

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -47,10 +47,11 @@ const EXPORT_IMAGE_CONFIG = {
 		LAYOUT_WIDTH: 1440,
 		// snapdom clamps its SVG raster to this many pixels per side.
 		MAX_RASTER_SIDE: 16384,
-		// A wrapped title grows the header past HEADER_HEIGHT, so the raster
-		// budget reserves the tallest one it can produce: six lines of 18 plus
-		// vertical padding.
-		MAX_HEADER_HEIGHT: 120,
+		// Browsers cap total canvas area well below MAX_RASTER_SIDE squared, so
+		// a near-square export can fail on a side length that looks safe. This is
+		// the largest square Firefox will allocate, the tightest of the desktop
+		// browsers; drop it if an iOS export ever comes back blank.
+		MAX_RASTER_AREA: 11180 * 11180,
 		// Fixed so exports match on every display. Two keeps text crisp and leaves
 		// the most headroom under the raster limit.
 		SCALE: 2,
@@ -188,6 +189,18 @@ class CanvasComposer {
 		);
 
 		return canvas;
+	}
+
+	// The chrome the capture has to share the canvas with. Wrapping depends on
+	// the ratio of text width to available width, and both scale together, so
+	// measuring at scale 1 gives the same line count as the real composition.
+	measureChrome( contentWidth, sectionTitle ) {
+		const dims = this.getScaledDimensions( 1 );
+		const fonts = this.getScaledFonts( 1 );
+		const canvasWidth = Math.max( contentWidth + ( dims.PADDING * 2 ), dims.MIN_WIDTH );
+		const header = this.calculateHeaderLayout( canvasWidth, sectionTitle, 1, fonts, dims );
+
+		return ( dims.PADDING * 4 ) + header.height + dims.FOOTER_HEIGHT;
 	}
 
 	getScaledDimensions( scale ) {
@@ -596,6 +609,7 @@ class ExportLayoutFrame {
 	 * @param {number} options.scale requested raster scale
 	 * @param {string} options.backgroundColor page background
 	 * @param {Function} options.prepareDocument applies export fixes to the frame document
+	 * @param {Function} options.measureChrome composed chrome height for a content width
 	 * @return {Promise<{canvas: HTMLCanvasElement, scale: number}>}
 	 */
 	async render( element, options ) {
@@ -625,7 +639,9 @@ class ExportLayoutFrame {
 				throw new Error( 'Canvas capture resulted in zero dimensions' );
 			}
 
-			const scale = this.getEffectiveScale( bounds, options.scale );
+			const scale = this.getEffectiveScale(
+				bounds, options.scale, options.measureChrome( bounds.width )
+			);
 			const canvas = await snapdom.toCanvas( target, {
 				scale: scale,
 				// The fixed scale must not be multiplied by the reader's ratio.
@@ -863,15 +879,21 @@ class ExportLayoutFrame {
 		] );
 	}
 
-	// The composed chrome shares the raster budget, and losing resolution beats
-	// losing the image, so the scale drops as far as it has to.
-	getEffectiveScale( bounds, requestedScale ) {
+	// The chrome composed around the capture shares the canvas, so the limits
+	// apply to the finished size rather than the capture's. Losing resolution
+	// beats losing the image, so the scale drops as far as it has to.
+	getEffectiveScale( bounds, requestedScale, chromeHeight ) {
 		const dimensions = EXPORT_IMAGE_CONFIG.DIMENSIONS;
 		const capture = EXPORT_IMAGE_CONFIG.CAPTURE;
-		const composed = ( dimensions.PADDING * 4 ) + capture.MAX_HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
-		const longestSide = Math.max( bounds.width, bounds.height, 1 ) + composed;
+		const width = Math.max( bounds.width + ( dimensions.PADDING * 2 ), dimensions.MIN_WIDTH );
+		const height = Math.max( bounds.height, 1 ) + chromeHeight;
 
-		return Math.min( requestedScale, capture.MAX_RASTER_SIDE / longestSide );
+		return Math.min(
+			requestedScale,
+			capture.MAX_RASTER_SIDE / width,
+			capture.MAX_RASTER_SIDE / height,
+			Math.sqrt( capture.MAX_RASTER_AREA / ( width * height ) )
+		);
 	}
 
 	dispose() {
@@ -965,7 +987,8 @@ class ExportService {
 		const capture = await this.layoutFrame.render( element, {
 			scale: EXPORT_IMAGE_CONFIG.CAPTURE.SCALE,
 			backgroundColor: backgroundColor,
-			prepareDocument: ( frameDocument ) => this.applyExportFixes( frameDocument )
+			prepareDocument: ( frameDocument ) => this.applyExportFixes( frameDocument ),
+			measureChrome: ( contentWidth ) => this.canvasComposer.measureChrome( contentWidth, title )
 		} );
 
 		if ( capture.canvas.width === 0 || capture.canvas.height === 0 ) {

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -396,11 +396,6 @@ class CanvasComposer {
 	wrapText( context, text, maxWidth, font ) {
 		context.font = font;
 		const words = text.split( ' ' );
-
-		if ( words.length === 0 ) {
-			return [];
-		}
-
 		const lines = [];
 		let currentLine = words[ 0 ];
 
@@ -768,6 +763,8 @@ class ExportLayoutFrame {
 			const liveNode = liveNodes[ index ];
 			const clonedNode = clonedNodes[ index ];
 
+			// A mismatch means the two lists have drifted out of step, so the
+			// pairing is meaningless from here on, not just for this node.
 			if ( liveNode.tagName !== clonedNode.tagName ) {
 				return;
 			}
@@ -1074,6 +1071,11 @@ class ExportImageDOMUtils {
 			return false;
 		}
 
+		// `closest` walks to the root on its own, so one check covers every ancestor.
+		if ( element.parentElement?.closest( '.tabs-content > div:not(.active)' ) ) {
+			return false;
+		}
+
 		let parent = element.parentElement;
 		while ( parent && parent !== document.body ) {
 			const parentStyle = window.getComputedStyle( parent );
@@ -1085,10 +1087,6 @@ class ExportImageDOMUtils {
 			if ( parent.classList.contains( 'collapsed' ) ||
 				parent.classList.contains( 'is--collapsed' ) ||
 				parent.dataset.collapsibleState === 'collapsed' ) {
-				return false;
-			}
-
-			if ( parent.closest( '.tabs-content > div:not(.active)' ) ) {
 				return false;
 			}
 
@@ -1161,9 +1159,8 @@ class ExportImageDOMUtils {
  * Creates and manages dropdown UI components
  */
 class DropdownWidget {
-	constructor( exportService, zoomManager ) {
+	constructor( exportService ) {
 		this.exportService = exportService;
-		this.zoomManager = zoomManager;
 		this.eventCleanupFunctions = new WeakMap();
 	}
 
@@ -1179,12 +1176,6 @@ class DropdownWidget {
 
 			if ( !menuElement.contains( loadingElement ) ) {
 				menuElement.appendChild( loadingElement );
-			}
-
-			if ( this.zoomManager.hasZoomed ) {
-				const refreshItem = this.createRefreshMenuItem();
-				menuElement.insertBefore( refreshItem, loadingElement );
-				return;
 			}
 
 			const visibleElements = elements.filter( ( item ) => ExportImageDOMUtils.isElementVisible( item.element )
@@ -1241,19 +1232,6 @@ class DropdownWidget {
 		this.setupEventListeners( wrapper, menuElement, toggleButton );
 
 		return wrapper;
-	}
-
-	createRefreshMenuItem() {
-		const item = this.createElement( 'div', {
-			class: 'dropdown-widget__item',
-			tabindex: '0',
-			role: 'menuitem',
-			style: { fontWeight: 'bold' }
-		}, '<i class="fas fa-fw fa-sync-alt"></i> Refresh the page to export images' );
-
-		item.addEventListener( 'click', () => window.location.reload() );
-
-		return item;
 	}
 
 	createDisabledMenuItem( buttonText ) {
@@ -1578,40 +1556,6 @@ class DropdownWidget {
 }
 
 /**
- * Manages zoom detection
- */
-class ZoomManager {
-	constructor() {
-		this.initialZoom = this.getZoomLevel();
-		this.hasZoomed = false;
-		this.resizeTimeout = null;
-		this.setupZoomListener();
-	}
-
-	getZoomLevel() {
-		return window.devicePixelRatio || 1;
-	}
-
-	setupZoomListener() {
-		window.addEventListener( 'resize', () => {
-			clearTimeout( this.resizeTimeout );
-			this.resizeTimeout = setTimeout( () => {
-				this.handleZoomChange();
-			}, 250 );
-		} );
-	}
-
-	handleZoomChange() {
-		const newZoom = this.getZoomLevel();
-		const ZOOM_THRESHOLD = 0.01;
-
-		if ( Math.abs( newZoom - this.initialZoom ) > ZOOM_THRESHOLD ) {
-			this.hasZoomed = true;
-		}
-	}
-}
-
-/**
  * Main module class that coordinates all components
  */
 class ExportImageModule {
@@ -1619,8 +1563,7 @@ class ExportImageModule {
 		this.imageCache = new ImageCache();
 		this.canvasComposer = new CanvasComposer( this.imageCache );
 		this.exportService = new ExportService( this.canvasComposer );
-		this.zoomManager = new ZoomManager();
-		this.dropdownWidget = new DropdownWidget( this.exportService, this.zoomManager );
+		this.dropdownWidget = new DropdownWidget( this.exportService );
 	}
 
 	init() {

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -47,6 +47,10 @@ const EXPORT_IMAGE_CONFIG = {
 		LAYOUT_WIDTH: 1440,
 		// snapdom clamps its SVG raster to this many pixels per side.
 		MAX_RASTER_SIDE: 16384,
+		// A wrapped title grows the header past HEADER_HEIGHT, so the raster
+		// budget reserves the tallest one it can produce: six lines of 18 plus
+		// vertical padding.
+		MAX_HEADER_HEIGHT: 120,
 		// Fixed so exports match on every display. Two keeps text crisp and leaves
 		// the most headroom under the raster limit.
 		SCALE: 2,
@@ -863,10 +867,11 @@ class ExportLayoutFrame {
 	// losing the image, so the scale drops as far as it has to.
 	getEffectiveScale( bounds, requestedScale ) {
 		const dimensions = EXPORT_IMAGE_CONFIG.DIMENSIONS;
-		const composed = ( dimensions.PADDING * 4 ) + dimensions.HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
+		const capture = EXPORT_IMAGE_CONFIG.CAPTURE;
+		const composed = ( dimensions.PADDING * 4 ) + capture.MAX_HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
 		const longestSide = Math.max( bounds.width, bounds.height, 1 ) + composed;
 
-		return Math.min( requestedScale, EXPORT_IMAGE_CONFIG.CAPTURE.MAX_RASTER_SIDE / longestSide );
+		return Math.min( requestedScale, capture.MAX_RASTER_SIDE / longestSide );
 	}
 
 	dispose() {

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -846,6 +846,9 @@ class ExportLayoutFrame {
 	// an image still loading measures zero and can collapse the capture.
 	waitForImages( element ) {
 		const pending = Array.from( element.querySelectorAll( 'img' ), ( image ) => {
+			// Cloned lazy images may be outside the frame's viewport.
+			image.setAttribute( 'loading', 'eager' );
+
 			if ( image.complete ) {
 				return Promise.resolve();
 			}
@@ -915,10 +918,20 @@ class ExportService {
 	}
 
 	applyExportFixes( frameDocument ) {
-		this.suppressShadows( frameDocument );
+		if ( this.needsShadowSuppression() ) {
+			this.suppressShadows( frameDocument );
+		}
 		this.hideInfoIcons( frameDocument );
 		this.removeExportControls( frameDocument );
 		this.expandPrizepoolTables( frameDocument );
+	}
+
+	// Every iOS browser uses WebKit; desktop Blink also reports AppleWebKit.
+	needsShadowSuppression() {
+		const userAgent = navigator.userAgent;
+		return /AppleWebKit/i.test( userAgent ) &&
+			!/(?:Chrome|Chromium|Edg|OPR)\//i.test( userAgent ) &&
+			!/Android/i.test( userAgent );
 	}
 
 	// One pixel shadow sends Safari and iOS down snapdom's fallback path, which

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -2,8 +2,8 @@
 
 /*******************************************************************************
  * Description: Adds export functionality to Liquipedia pages, enabling users
- *              to copy or download group tables, crosstables, brackets, and
- *              match lists as images.
+ *              to copy or download brackets, group tables, prize pools,
+ *              standings, participant lists and other tables as images.
  ******************************************************************************/
 
 const EXPORT_IMAGE_CONFIG = {
@@ -46,8 +46,9 @@ const EXPORT_IMAGE_CONFIG = {
 		LAYOUT_WIDTH: 1440,
 		// snapdom clamps its SVG raster to this many pixels per side.
 		MAX_RASTER_SIDE: 16384,
-		MIN_SCALE: 2,
-		MAX_SCALE: 3,
+		// Fixed so exports match on every display. Two keeps text crisp and leaves
+		// the most headroom under the raster limit.
+		SCALE: 2,
 		TARGET_ATTRIBUTE: 'data-export-target'
 	},
 	COLORS: {
@@ -115,9 +116,6 @@ const EXPORT_IMAGE_CONFIG = {
 	]
 };
 
-/**
- * Manages image caching and loading
- */
 class ImageCache {
 	constructor() {
 		this.cache = new Map();
@@ -159,9 +157,6 @@ class ImageCache {
 	}
 }
 
-/**
- * Handles canvas composition and rendering
- */
 class CanvasComposer {
 	constructor( imageCache ) {
 		this.imageCache = imageCache;
@@ -464,10 +459,9 @@ class CanvasComposer {
 }
 
 /**
- * Renders exportable content in an offscreen document of a fixed width.
- *
- * A capture reproduces whatever the browser already laid out, and a viewport
- * width cannot be changed in the live document, so an iframe provides one.
+ * Renders exportable content in an offscreen document of a fixed width. A
+ * capture reproduces the browser's existing layout, and only an iframe can
+ * give it a viewport width other than the reader's.
  */
 class ExportLayoutFrame {
 	constructor() {
@@ -476,7 +470,7 @@ class ExportLayoutFrame {
 	}
 
 	/**
-	 * Reuses pending or completed setup; called on menu open and before capture.
+	 * Builds the frame once, however many callers ask for it.
 	 *
 	 * @return {Promise<HTMLIFrameElement>}
 	 */
@@ -525,7 +519,7 @@ class ExportLayoutFrame {
 		return iframe;
 	}
 
-	// Rebuild between exports to prevent snapdom's cached image sizes affecting later captures.
+	// Rebuild between exports; snapdom's cached image sizes would corrupt the next.
 	recycle() {
 		if ( !this.iframe ) {
 			return;
@@ -536,9 +530,8 @@ class ExportLayoutFrame {
 		this.preparePromise.catch( () => this.dispose() );
 	}
 
-	// The frame needs the page's own stylesheets, since a copied computed style
-	// would carry the live viewport's media query results. Returns each copied
-	// link with whether the page itself has it loaded.
+	// Copy the page's stylesheet nodes, not computed styles, which would carry
+	// the live viewport's media query results.
 	copyStyles( frameDocument ) {
 		// The frame document has no URL, so relative paths need a base.
 		const base = frameDocument.createElement( 'base' );
@@ -560,8 +553,7 @@ class ExportLayoutFrame {
 		return copiedLinks;
 	}
 
-	// Reject errors or timeouts only for stylesheets already loaded in the page;
-	// tolerate other failures.
+	// Only fail on a stylesheet the page itself has loaded.
 	waitForStylesheets( copiedLinks ) {
 		return Promise.all( copiedLinks.map( ( { link, loadedInPage } ) => new Promise( ( resolve, reject ) => {
 			if ( link.sheet ) {
@@ -586,7 +578,7 @@ class ExportLayoutFrame {
 		} ) ) );
 	}
 
-	// Preserve the previous capture height: the live document's scroll height.
+	// Tall enough not to constrain the clone.
 	getLayoutHeight() {
 		return document.documentElement.scrollHeight;
 	}
@@ -627,11 +619,12 @@ class ExportLayoutFrame {
 		try {
 			const canvas = await snapdom.toCanvas( target, {
 				scale: scale,
-				// scale already accounts for the device pixel ratio.
+				// The fixed scale must not be multiplied by the reader's ratio.
 				dpr: 1,
-				// Embed fonts in the isolated SVG.
 				embedFonts: true,
-				cache: 'auto'
+				// Anything looser keeps stale style maps, which re-render
+				// container-constrained images at their intrinsic size.
+				cache: 'soft'
 			} );
 
 			return { canvas: canvas, scale: scale };
@@ -763,8 +756,8 @@ class ExportLayoutFrame {
 			const liveNode = liveNodes[ index ];
 			const clonedNode = clonedNodes[ index ];
 
-			// A mismatch means the two lists have drifted out of step, so the
-			// pairing is meaningless from here on, not just for this node.
+			// The lists have drifted out of step, so no later pairing can be
+			// trusted either.
 			if ( liveNode.tagName !== clonedNode.tagName ) {
 				return;
 			}
@@ -795,8 +788,7 @@ class ExportLayoutFrame {
 		}
 	}
 
-	// Theme and wiki classes live on the root, runtime custom properties in its
-	// inline style.
+	// Theme classes live on the root, runtime custom properties in its style.
 	copyRootAttributes( frameDocument ) {
 		const liveRoot = document.documentElement;
 		const frameRoot = frameDocument.documentElement;
@@ -807,7 +799,7 @@ class ExportLayoutFrame {
 		frameRoot.setAttribute( 'style', liveRoot.getAttribute( 'style' ) || '' );
 	}
 
-	// Wait for font metrics, but fall back on timeout rather than block the export.
+	// Text is measured later, but a slow font must not block the export.
 	waitForFonts( frameDocument ) {
 		if ( !frameDocument.fonts ) {
 			return Promise.resolve();
@@ -821,9 +813,8 @@ class ExportLayoutFrame {
 		] );
 	}
 
-	// Very large content would exceed the raster limit, and the chrome composed
-	// around the capture shares the budget. Losing resolution beats losing the
-	// image, so the scale drops as far as it has to.
+	// The composed chrome shares the raster budget, and losing resolution beats
+	// losing the image, so the scale drops as far as it has to.
 	getEffectiveScale( bounds, requestedScale ) {
 		const dimensions = EXPORT_IMAGE_CONFIG.DIMENSIONS;
 		const composed = ( dimensions.PADDING * 4 ) + dimensions.HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
@@ -842,9 +833,6 @@ class ExportLayoutFrame {
 	}
 }
 
-/**
- * Handles export operations (canvas capture, download, clipboard)
- */
 class ExportService {
 	constructor( canvasComposer ) {
 		this.canvasComposer = canvasComposer;
@@ -854,9 +842,20 @@ class ExportService {
 	}
 
 	applyExportFixes( frameDocument ) {
+		this.suppressShadows( frameDocument );
 		this.hideInfoIcons( frameDocument );
 		this.removeExportControls( frameDocument );
 		this.expandPrizepoolTables( frameDocument );
+	}
+
+	// One pixel shadow sends Safari and iOS down snapdom's fallback path, which
+	// rasterises at natural size and upscales, softening the whole image.
+	suppressShadows( frameDocument ) {
+		const style = frameDocument.createElement( 'style' );
+
+		style.textContent = '*, *::before, *::after { box-shadow: none !important; ' +
+			'text-shadow: none !important; }';
+		frameDocument.head.appendChild( style );
 	}
 
 	hideInfoIcons( frameDocument ) {
@@ -913,7 +912,7 @@ class ExportService {
 		const backgroundColor = this.getBackgroundColor();
 
 		const capture = await this.layoutFrame.render( element, {
-			scale: this.getScale(),
+			scale: EXPORT_IMAGE_CONFIG.CAPTURE.SCALE,
 			backgroundColor: backgroundColor,
 			prepareDocument: ( frameDocument ) => this.applyExportFixes( frameDocument )
 		} );
@@ -939,13 +938,6 @@ class ExportService {
 				}
 			}, 'image/png' );
 		} );
-	}
-
-	// At least 2 so text stays crisp, never above 3 so files stay a sane size.
-	getScale() {
-		const { MIN_SCALE, MAX_SCALE } = EXPORT_IMAGE_CONFIG.CAPTURE;
-
-		return Math.min( Math.max( window.devicePixelRatio || 1, MIN_SCALE ), MAX_SCALE );
 	}
 
 	async copyToClipboard( element, title ) {
@@ -980,8 +972,7 @@ class ExportService {
 		}, EXPORT_IMAGE_CONFIG.TIMEOUTS.URL_REVOKE_DELAY );
 	}
 
-	// Called on menu open so the setup cost lands before anyone picks an option,
-	// and again before each export as a guard.
+	// Called on menu open so setup lands before anyone picks an option.
 	prewarm() {
 		return Promise.all( [ this.ensureSnapdomLoaded(), this.layoutFrame.prepare() ] );
 	}
@@ -1034,9 +1025,6 @@ class ExportService {
 	}
 }
 
-/**
- * Utilities for finding elements and headings in the DOM
- */
 class ExportImageDOMUtils {
 	static findPreviousHeading( startElement ) {
 		const walker = document.createTreeWalker(
@@ -1155,9 +1143,6 @@ class ExportImageDOMUtils {
 	}
 }
 
-/**
- * Creates and manages dropdown UI components
- */
 class DropdownWidget {
 	constructor( exportService ) {
 		this.exportService = exportService;
@@ -1309,7 +1294,7 @@ class DropdownWidget {
 
 		button.addEventListener( 'click', () => {
 			if ( menuElement.style.display === 'none' ) {
-				// Log warmup failures; exports retry setup and report failures.
+				// Exports retry setup and report properly, so only log here.
 				this.exportService.prewarm().catch( ( error ) => {
 					// eslint-disable-next-line no-console
 					console.warn( 'Export prewarm failed:', error );
@@ -1555,9 +1540,6 @@ class DropdownWidget {
 	}
 }
 
-/**
- * Main module class that coordinates all components
- */
 class ExportImageModule {
 	constructor() {
 		this.imageCache = new ImageCache();

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -41,10 +41,8 @@ const EXPORT_IMAGE_CONFIG = {
 		FONT_READY: 5000
 	},
 	CAPTURE: {
-		// Exports are rendered in a window of this width so that they look the same
-		// on a phone as on a desktop, and stay independent of the reader's window
-		// size. Responsive layout here is driven by viewport media queries, which
-		// cannot be re-evaluated in the live document, hence the offscreen frame.
+		// Responsive layout is driven by viewport media queries, so exports are
+		// rendered in a frame of this width instead of the reader's window.
 		LAYOUT_WIDTH: 1440,
 		// snapdom clamps its SVG raster to this many pixels per side.
 		MAX_RASTER_SIDE: 16384,
@@ -126,7 +124,6 @@ class ImageCache {
 	}
 
 	async load( url, key, timeout = EXPORT_IMAGE_CONFIG.TIMEOUTS.IMAGE_LOAD ) {
-		// Return cached image if available
 		if ( this.cache.has( key ) ) {
 			return this.cache.get( key );
 		}
@@ -237,7 +234,6 @@ class CanvasComposer {
 	}
 
 	drawHeader( context, canvasWidth, theme, headerLayout, fonts, dims ) {
-		// Draw header background with gradient
 		const gradient = context.createLinearGradient( dims.PADDING, 0, canvasWidth - dims.PADDING, 0 );
 		gradient.addColorStop( 0, theme.HEADER_START );
 		gradient.addColorStop( 1, theme.HEADER_END );
@@ -253,7 +249,6 @@ class CanvasComposer {
 		);
 		context.fill();
 
-		// Draw header text
 		context.fillStyle = '#ffffff';
 		context.textBaseline = 'middle';
 
@@ -307,8 +302,7 @@ class CanvasComposer {
 		const x = dims.PADDING;
 		const y = dims.PADDING + headerHeight + dims.PADDING;
 
-		// The capture leaves uncovered pixels transparent, so paint the page
-		// background under it rather than letting the frame colour show through.
+		// Fill transparent capture pixels with the page background, not the surrounding frame.
 		if ( contentBackground ) {
 			context.fillStyle = contentBackground;
 			context.fillRect( x, y, sourceCanvas.width, sourceCanvas.height );
@@ -320,7 +314,6 @@ class CanvasComposer {
 	async drawFooter( context, canvasWidth, sourceHeight, theme, isDarkTheme, headerHeight, fonts, dims ) {
 		const footerY = dims.PADDING + headerHeight + dims.PADDING + sourceHeight + dims.PADDING;
 
-		// Draw footer background
 		const gradient = context.createLinearGradient( dims.PADDING, 0, canvasWidth - dims.PADDING, 0 );
 		gradient.addColorStop( 0, theme.FOOTER_START );
 		gradient.addColorStop( 1, theme.FOOTER_END );
@@ -336,7 +329,6 @@ class CanvasComposer {
 		);
 		context.fill();
 
-		// Draw footer text
 		context.fillStyle = theme.TEXT;
 		context.font = fonts.FOOTER;
 		context.textAlign = 'left';
@@ -350,7 +342,7 @@ class CanvasComposer {
 			EXPORT_IMAGE_CONFIG.SPACING.LETTER_SPACING * ( dims.LOGO_WIDTH / 22 )
 		);
 
-		// Draw logo (non-critical, catch errors silently)
+		// A missing logo must not prevent the export.
 		try {
 			await this.drawLogo( context, footerY, isDarkTheme, dims );
 		} catch ( error ) {
@@ -365,7 +357,6 @@ class CanvasComposer {
 
 		const context = this.getOffscreenContext();
 
-		// Measure text widths
 		context.font = fonts.HEADER;
 		const mainTitleWidth = context.measureText( mainTitle ).width;
 
@@ -375,7 +366,6 @@ class CanvasComposer {
 		const totalTextWidth = mainTitleWidth + sectionTitleWidth + ( dims.HEADER_TEXT_OFFSET * 2 );
 		const sideBySideAvailableWidth = canvasWidth - ( dims.PADDING * 2 ) - dims.TEXT_OFFSET_X;
 
-		// Check if text fits side-by-side
 		if ( totalTextWidth <= sideBySideAvailableWidth ) {
 			return {
 				height: dims.HEADER_HEIGHT,
@@ -385,7 +375,6 @@ class CanvasComposer {
 			};
 		}
 
-		// Calculate stacked layout
 		const mainTitleLines = this.wrapText( context, mainTitle, availableWidth, fonts.HEADER );
 		const sectionTitleLines = this.wrapText( context, sectionTitle, availableWidth, fonts.SUBHEADER );
 
@@ -482,11 +471,8 @@ class CanvasComposer {
 /**
  * Renders exportable content in an offscreen document of a fixed width.
  *
- * snapdom captures whatever the browser has already laid out, so the content has
- * to be laid out at export width before it is captured. A viewport width cannot
- * be changed in the live document, so an offscreen iframe provides one. Its
- * document is rebuilt after every capture (see `recycle`), which keeps the
- * stylesheet parse between exports rather than inside one.
+ * A capture reproduces whatever the browser already laid out, and a viewport
+ * width cannot be changed in the live document, so an iframe provides one.
  */
 class ExportLayoutFrame {
 	constructor() {
@@ -495,15 +481,14 @@ class ExportLayoutFrame {
 	}
 
 	/**
-	 * Builds the frame if needed. Safe to call repeatedly; used both to warm up
-	 * when the share menu opens and as a guard before each capture.
+	 * Reuses pending or completed setup; called on menu open and before capture.
 	 *
 	 * @return {Promise<HTMLIFrameElement>}
 	 */
 	prepare() {
 		if ( !this.preparePromise ) {
 			this.preparePromise = this.build().catch( ( error ) => {
-				// Start from scratch next time rather than keeping a half-built frame.
+				// Start over rather than keep a half-built frame.
 				this.dispose();
 				throw error;
 			} );
@@ -545,36 +530,22 @@ class ExportLayoutFrame {
 		return iframe;
 	}
 
-	/**
-	 * Gives the next export a document that has not been captured from before.
-	 *
-	 * snapdom keeps caches keyed to the document it read, and reusing that document
-	 * makes every capture after the first lay out CSS-constrained images at their
-	 * intrinsic size, so team logos come out oversized. Rebuilding right after a
-	 * capture puts that cost between exports rather than inside one.
-	 */
+	// Rebuild between exports to prevent snapdom's cached image sizes affecting later captures.
 	recycle() {
 		if ( !this.iframe ) {
 			return;
 		}
 
+		// Discard failed rebuilds so the next export can retry.
 		this.preparePromise = this.resetDocument( this.iframe );
-		// Nobody awaits the rebuild itself; start clean if it fails, and let the
-		// next export report the failure.
 		this.preparePromise.catch( () => this.dispose() );
 	}
 
-	/**
-	 * The frame needs the page's own stylesheets: layout, theme colours and fonts
-	 * all come from them, and a copied computed style would carry the live
-	 * viewport's media query results instead of the export width's.
-	 *
-	 * @param {Document} frameDocument
-	 * @return {Array} the copied links, and whether the page has each one loaded
-	 */
+	// The frame needs the page's own stylesheets, since a copied computed style
+	// would carry the live viewport's media query results. Returns each copied
+	// link with whether the page itself has it loaded.
 	copyStyles( frameDocument ) {
-		// The frame document has no URL of its own, so relative paths in the
-		// cloned content would not resolve without a base.
+		// The frame document has no URL, so relative paths need a base.
 		const base = frameDocument.createElement( 'base' );
 		base.href = document.baseURI;
 		frameDocument.head.appendChild( base );
@@ -594,18 +565,8 @@ class ExportLayoutFrame {
 		return copiedLinks;
 	}
 
-	/**
-	 * Holds the frame back until its stylesheets have settled.
-	 *
-	 * A stylesheet the page itself never loaded is expected to fail here too, and
-	 * the export should look like the page, so that resolves. One the page has but
-	 * the frame cannot get would silently change the layout, and one still in
-	 * flight could change it again mid-capture, so those reject and the frame is
-	 * rebuilt for the next attempt.
-	 *
-	 * @param {Array} copiedLinks from copyStyles
-	 * @return {Promise}
-	 */
+	// Reject errors or timeouts only for stylesheets already loaded in the page;
+	// tolerate other failures.
 	waitForStylesheets( copiedLinks ) {
 		return Promise.all( copiedLinks.map( ( { link, loadedInPage } ) => new Promise( ( resolve, reject ) => {
 			if ( link.sheet ) {
@@ -630,8 +591,7 @@ class ExportLayoutFrame {
 		} ) ) );
 	}
 
-	// Follows the height of the page so that viewport-relative units inside the
-	// frame resolve to the same values they do while reading it.
+	// Preserve the previous capture height: the live document's scroll height.
 	getLayoutHeight() {
 		return document.documentElement.scrollHeight;
 	}
@@ -640,8 +600,10 @@ class ExportLayoutFrame {
 	 * Captures an element as it would look at export width.
 	 *
 	 * @param {HTMLElement} element element in the live document
-	 * @param {Object} options scale, backgroundColor and a prepareDocument hook
-	 *                         that may adjust the frame before it is captured
+	 * @param {Object} options required capture settings
+	 * @param {number} options.scale requested raster scale
+	 * @param {string} options.backgroundColor page background
+	 * @param {Function} options.prepareDocument applies export fixes to the frame document
 	 * @return {Promise<{canvas: HTMLCanvasElement, scale: number}>}
 	 */
 	async render( element, options ) {
@@ -652,22 +614,10 @@ class ExportLayoutFrame {
 		this.copyRootAttributes( frameDocument );
 
 		const target = this.replaceContent( frameDocument, element );
-		if ( !target ) {
-			throw new Error( 'Could not find the element inside the export frame' );
-		}
-
-		if ( options.prepareDocument ) {
-			options.prepareDocument( frameDocument );
-		}
-
+		options.prepareDocument( frameDocument );
 		this.pruneHiddenContent( target );
+		target.style.background = options.backgroundColor;
 
-		if ( options.backgroundColor ) {
-			target.style.background = options.backgroundColor;
-		}
-
-		// Measure once the fonts the content uses have loaded, since text metrics
-		// decide the size of most of what gets exported.
 		await this.waitForFonts( frameDocument );
 
 		this.pinSubgridTracks( target );
@@ -678,38 +628,24 @@ class ExportLayoutFrame {
 		}
 
 		const scale = this.getEffectiveScale( bounds, options.scale );
-		let canvas;
 
 		try {
-			canvas = await snapdom.toCanvas( target, {
+			const canvas = await snapdom.toCanvas( target, {
 				scale: scale,
-				// snapdom multiplies scale by the device pixel ratio; the requested
-				// scale already accounts for it.
+				// scale already accounts for the device pixel ratio.
 				dpr: 1,
-				// The frame is serialised into an isolated SVG document, so the fonts
-				// it uses have to travel with it.
+				// Embed fonts in the isolated SVG.
 				embedFonts: true,
 				cache: 'auto'
 			} );
+
+			return { canvas: canvas, scale: scale };
 		} finally {
 			this.recycle();
 		}
-
-		return { canvas: canvas, scale: scale };
 	}
 
-	/**
-	 * Replaces `subgrid` on the captured element with the tracks its parent
-	 * resolved.
-	 *
-	 * A capture is re-laid out on its own, where the root has no parent grid to
-	 * take tracks from, so `subgrid` falls back to `none` and every cell drops
-	 * into a single column. Match lists are laid out exactly that way: the
-	 * collapse area is a subgrid of the five columns declared on
-	 * `.brkts-matchlist`.
-	 *
-	 * @param {HTMLElement} element root of the subtree about to be captured
-	 */
+	// Pin inherited tracks because the captured root loses its parent grid.
 	pinSubgridTracks( element ) {
 		const parent = element.parentElement;
 		if ( !parent ) {
@@ -735,8 +671,6 @@ class ExportLayoutFrame {
 				continue;
 			}
 
-			// The element covers a range of the parent's tracks, usually all of
-			// them, and inherits only those.
 			const from = Math.max( parseInt( style[ axis.start ], 10 ) || 1, 1 ) - 1;
 			const end = parseInt( style[ axis.end ], 10 );
 			const to = end > 0 ? Math.max( end - 1, from + 1 ) : tracks.length;
@@ -745,13 +679,8 @@ class ExportLayoutFrame {
 		}
 	}
 
-	/**
-	 * Splits a resolved track list into tracks, keeping line names and functional
-	 * notation intact: `[a] 10px [b c] minmax( 2px, 1fr )` gives two entries.
-	 *
-	 * @param {string} value resolved grid-template-columns or -rows
-	 * @return {string[]}
-	 */
+	// Splits a resolved track list, keeping line names and functional notation
+	// intact: `[a] 10px [b c] minmax( 2px, 1fr )` gives two entries.
 	parseTrackList( value ) {
 		if ( !value || value === 'none' || value.startsWith( 'subgrid' ) ) {
 			return [];
@@ -780,25 +709,12 @@ class ExportLayoutFrame {
 		return tracks;
 	}
 
-	/**
-	 * Drops content the browser does not paint.
-	 *
-	 * A capture reads the whole subtree, including collapsed match rows and
-	 * closed detail popups, and inlines every image it finds there. A collapsed
-	 * match list can hide hundreds of team logos behind a box a few lines tall,
-	 * which costs seconds to embed and cannot show up in the result anyway,
-	 * because `display: none` paints nothing.
-	 *
-	 * Runs after the export fixes, so anything they reveal is kept.
-	 *
-	 * @param {HTMLElement} element root of the subtree about to be captured
-	 */
+	// Prune hidden subtrees after export fixes so snapdom skips their images.
 	pruneHiddenContent( element ) {
 		const view = element.ownerDocument.defaultView;
 		const hidden = [];
 
-		// Collect before removing: a removal invalidates style, which would make
-		// every following style read recompute it.
+		// Collect first: removing invalidates style, forcing a recalc per read.
 		const collect = ( node ) => {
 			for ( let child = node.firstElementChild; child; child = child.nextElementSibling ) {
 				if ( view.getComputedStyle( child ).display === 'none' ) {
@@ -816,7 +732,6 @@ class ExportLayoutFrame {
 		}
 	}
 
-	// Copies the live body into the frame and returns the copy of `element`.
 	replaceContent( frameDocument, element ) {
 		const marker = EXPORT_IMAGE_CONFIG.CAPTURE.TARGET_ATTRIBUTE;
 
@@ -826,12 +741,11 @@ class ExportLayoutFrame {
 
 		const target = bodyClone.querySelector( `[${ marker }]` );
 		if ( !target ) {
-			return null;
+			throw new Error( 'Could not find the element inside the export frame' );
 		}
 		target.removeAttribute( marker );
 
-		// Cloned scripts never execute, but frames and embeds would load their
-		// content for nothing. Nothing exportable lives inside one.
+		// Cloned scripts never run, but frames and embeds would load for nothing.
 		for ( const node of bodyClone.querySelectorAll( 'script, noscript, iframe, object, embed' ) ) {
 			node.remove();
 		}
@@ -844,8 +758,7 @@ class ExportLayoutFrame {
 		return target;
 	}
 
-	// Cloning markup loses state that only exists in the DOM. Only the captured
-	// subtree matters, so this stays cheap.
+	// Cloning markup loses state that only exists in the DOM.
 	copyDynamicState( liveElement, clonedElement ) {
 		const selector = 'input, textarea, select, canvas';
 		const liveNodes = liveElement.querySelectorAll( selector );
@@ -862,8 +775,7 @@ class ExportLayoutFrame {
 			if ( liveNode.tagName === 'CANVAS' ) {
 				this.copyCanvas( liveNode, clonedNode );
 			} else if ( liveNode.type !== 'file' ) {
-				// A file input rejects an assigned value, and nothing else here can
-				// fail, but a throw would cost the whole export.
+				// A file input would throw on an assigned value.
 				clonedNode.value = liveNode.value;
 
 				if ( liveNode.tagName === 'INPUT' ) {
@@ -886,8 +798,8 @@ class ExportLayoutFrame {
 		}
 	}
 
-	// Theme and wiki classes live on the root element, and custom properties set at
-	// runtime live in its inline style.
+	// Theme and wiki classes live on the root, runtime custom properties in its
+	// inline style.
 	copyRootAttributes( frameDocument ) {
 		const liveRoot = document.documentElement;
 		const frameRoot = frameDocument.documentElement;
@@ -898,14 +810,7 @@ class ExportLayoutFrame {
 		frameRoot.setAttribute( 'style', liveRoot.getAttribute( 'style' ) || '' );
 	}
 
-	/**
-	 * Waits for the fonts the content uses, but not forever: a request that never
-	 * settles would otherwise leave the export spinning with no way out. Falling
-	 * back to whatever is loaded costs some text metrics, not the export.
-	 *
-	 * @param {Document} frameDocument
-	 * @return {Promise}
-	 */
+	// Wait for font metrics, but fall back on timeout rather than block the export.
 	waitForFonts( frameDocument ) {
 		if ( !frameDocument.fonts ) {
 			return Promise.resolve();
@@ -919,16 +824,9 @@ class ExportLayoutFrame {
 		] );
 	}
 
-	/**
-	 * Very large content would exceed the raster limit. Losing resolution beats
-	 * losing the image, so the scale drops as far as it needs to, and the header,
-	 * footer and padding composed around the capture have to fit in the same
-	 * budget.
-	 *
-	 * @param {DOMRect} bounds captured element's box
-	 * @param {number} requestedScale
-	 * @return {number}
-	 */
+	// Very large content would exceed the raster limit, and the chrome composed
+	// around the capture shares the budget. Losing resolution beats losing the
+	// image, so the scale drops as far as it has to.
 	getEffectiveScale( bounds, requestedScale ) {
 		const dimensions = EXPORT_IMAGE_CONFIG.DIMENSIONS;
 		const composed = ( dimensions.PADDING * 4 ) + dimensions.HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
@@ -955,17 +853,15 @@ class ExportService {
 		this.canvasComposer = canvasComposer;
 		this.layoutFrame = new ExportLayoutFrame();
 		this.snapdomPromise = null;
-		this.activeExports = new Set();
+		this.exportInProgress = false;
 	}
 
 	applyExportFixes( frameDocument ) {
 		this.hideInfoIcons( frameDocument );
-		this.removeContentSwitchers( frameDocument );
-		this.removePrizepoolToggles( frameDocument );
+		this.removeExportControls( frameDocument );
 		this.expandPrizepoolTables( frameDocument );
 	}
 
-	// Hides info icons that shouldn't appear in exports
 	hideInfoIcons( frameDocument ) {
 		const infoIcons = frameDocument.querySelectorAll( '.brkts-match-info-icon' );
 		for ( const icon of infoIcons ) {
@@ -973,24 +869,13 @@ class ExportService {
 		}
 	}
 
-	// Remove toggle switches
-	removeContentSwitchers( frameDocument ) {
-		const contentSwitches = frameDocument.querySelectorAll( '.switch-pill-container' );
-
-		for ( const contentSwitch of contentSwitches ) {
-			contentSwitch.remove();
-		}
-	}
-
-	removePrizepoolToggles( frameDocument ) {
-		// The legacy in-table toggle and the redesigned table's footer (now inside the
-		// captured wrapper) shouldn't appear in a static export.
-		const prizepoolToggles = frameDocument.querySelectorAll(
-			'.prizepooltabletoggle, .prizepool-table-wrapper .table2__footer'
+	removeExportControls( frameDocument ) {
+		const controls = frameDocument.querySelectorAll(
+			'.switch-pill-container, .prizepooltabletoggle, .prizepool-table-wrapper .table2__footer'
 		);
 
-		for ( const prizepoolToggle of prizepoolToggles ) {
-			prizepoolToggle.remove();
+		for ( const control of controls ) {
+			control.remove();
 		}
 	}
 
@@ -1004,13 +889,11 @@ class ExportService {
 	}
 
 	async export( element, title, mode ) {
-		// Prevent concurrent exports
-		if ( this.activeExports.size > 0 ) {
+		if ( this.exportInProgress ) {
 			throw new Error( 'An export is already in progress' );
 		}
 
-		const exportId = Symbol( 'export' );
-		this.activeExports.add( exportId );
+		this.exportInProgress = true;
 
 		try {
 			await this.prewarm();
@@ -1024,7 +907,7 @@ class ExportService {
 				throw new Error( `Unknown export mode: ${ mode }` );
 			}
 		} finally {
-			this.activeExports.delete( exportId );
+			this.exportInProgress = false;
 		}
 	}
 
@@ -1069,7 +952,6 @@ class ExportService {
 	}
 
 	async copyToClipboard( element, title ) {
-		// Check browser support
 		if ( !window.ClipboardItem || !navigator.clipboard || !navigator.clipboard.write ) {
 			mw.notify( 'This browser does not support copying images to the clipboard.', { type: 'error' } );
 			return;
@@ -1096,19 +978,13 @@ class ExportService {
 		link.href = url;
 		link.click();
 
-		// Clean up object URL after short delay
 		setTimeout( () => {
 			URL.revokeObjectURL( url );
 		}, EXPORT_IMAGE_CONFIG.TIMEOUTS.URL_REVOKE_DELAY );
 	}
 
-	/**
-	 * Loads the library and builds the layout frame. Called when the share menu
-	 * opens so that the setup cost lands before anyone picks an option, and again
-	 * before each export as a guard.
-	 *
-	 * @return {Promise}
-	 */
+	// Called on menu open so the setup cost lands before anyone picks an option,
+	// and again before each export as a guard.
 	prewarm() {
 		return Promise.all( [ this.ensureSnapdomLoaded(), this.layoutFrame.prepare() ] );
 	}
@@ -1116,8 +992,7 @@ class ExportService {
 	ensureSnapdomLoaded() {
 		if ( !this.snapdomPromise ) {
 			this.snapdomPromise = Promise.resolve( mw.loader.using( 'snapdom' ) ).catch( ( error ) => {
-				// Let the next export load it again instead of reusing the failure
-				// for the rest of the page's life.
+				// Let the next export retry instead of reusing the failure.
 				this.snapdomPromise = null;
 				throw error;
 			} );
@@ -1158,7 +1033,7 @@ class ExportService {
 	}
 
 	isExporting() {
-		return this.activeExports.size > 0;
+		return this.exportInProgress;
 	}
 }
 
@@ -1312,7 +1187,6 @@ class DropdownWidget {
 				return;
 			}
 
-			// Filter visible elements
 			const visibleElements = elements.filter( ( item ) => ExportImageDOMUtils.isElementVisible( item.element )
 			);
 			const hasSingleElement = visibleElements.length === 1;
@@ -1457,7 +1331,7 @@ class DropdownWidget {
 
 		button.addEventListener( 'click', () => {
 			if ( menuElement.style.display === 'none' ) {
-				// Failures are surfaced when an export is actually requested.
+				// Log warmup failures; exports retry setup and report failures.
 				this.exportService.prewarm().catch( ( error ) => {
 					// eslint-disable-next-line no-console
 					console.warn( 'Export prewarm failed:', error );
@@ -1759,12 +1633,10 @@ class ExportImageModule {
 		for ( const data of headingsToElements.values() ) {
 			let targetNode = data.headingNode;
 
-			// Use parent if it's a heading wrapper
 			if ( targetNode.parentNode && targetNode.parentNode.classList.contains( 'mw-heading' ) ) {
 				targetNode = targetNode.parentNode;
 			}
 
-			// Avoid duplicate dropdowns
 			if ( !targetNode.querySelector( '.dropdown-widget' ) ) {
 				const dropdown = this.dropdownWidget.create( data.elements, data.headingText );
 				targetNode.appendChild( dropdown );

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -38,7 +38,8 @@ const EXPORT_IMAGE_CONFIG = {
 		IMAGE_LOAD: 5000,
 		URL_REVOKE_DELAY: 100,
 		STYLESHEET_LOAD: 10000,
-		FONT_READY: 5000
+		FONT_READY: 5000,
+		CLONED_IMAGES: 5000
 	},
 	CAPTURE: {
 		// Responsive layout is driven by viewport media queries, so exports are
@@ -608,7 +609,10 @@ class ExportLayoutFrame {
 			this.pruneHiddenContent( target );
 			target.style.background = options.backgroundColor;
 
-			await this.waitForFonts( frameDocument );
+			await Promise.all( [
+				this.waitForFonts( frameDocument ),
+				this.waitForImages( target )
+			] );
 
 			this.pinSubgridTracks( target );
 
@@ -798,6 +802,29 @@ class ExportLayoutFrame {
 		frameRoot.setAttribute( 'lang', liveRoot.lang || 'en' );
 		frameRoot.setAttribute( 'dir', liveRoot.dir || 'ltr' );
 		frameRoot.setAttribute( 'style', liveRoot.getAttribute( 'style' ) || '' );
+	}
+
+	// A logo is sized by its container with the image itself unconstrained, so
+	// an image still loading measures zero and can collapse the capture.
+	waitForImages( element ) {
+		const pending = Array.from( element.querySelectorAll( 'img' ), ( image ) => {
+			if ( image.complete ) {
+				return Promise.resolve();
+			}
+
+			// A broken image resolves too; it must not hold up the export.
+			return new Promise( ( resolve ) => {
+				image.addEventListener( 'load', resolve, { once: true } );
+				image.addEventListener( 'error', resolve, { once: true } );
+			} );
+		} );
+
+		return Promise.race( [
+			Promise.all( pending ),
+			new Promise( ( resolve ) => {
+				setTimeout( resolve, EXPORT_IMAGE_CONFIG.TIMEOUTS.CLONED_IMAGES );
+			} )
+		] );
 	}
 
 	// Text is measured later, but a slow font must not block the export.

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -606,7 +606,7 @@ class ExportLayoutFrame {
 
 			const target = this.replaceContent( frameDocument, element );
 			options.prepareDocument( frameDocument );
-			this.pruneHiddenContent( target );
+			this.stripHiddenMedia( target );
 			target.style.background = options.backgroundColor;
 
 			await Promise.all( [
@@ -702,12 +702,15 @@ class ExportLayoutFrame {
 		return tracks;
 	}
 
-	// Prune hidden subtrees after export fixes so snapdom skips their images.
-	pruneHiddenContent( element ) {
+	// snapdom leaves hidden subtrees out of the capture but still inlines every
+	// image it can find, and a collapsed match list hides hundreds of logos.
+	// Clearing their sources buys that back without removing the nodes, which
+	// would renumber siblings and break the `:nth-child` rules the page matched.
+	stripHiddenMedia( element ) {
 		const view = element.ownerDocument.defaultView;
 		const hidden = [];
 
-		// Collect first: removing invalidates style, forcing a recalc per read.
+		// Collect first: mutating invalidates style, forcing a recalc per read.
 		const collect = ( node ) => {
 			for ( let child = node.firstElementChild; child; child = child.nextElementSibling ) {
 				if ( view.getComputedStyle( child ).display === 'none' ) {
@@ -721,7 +724,22 @@ class ExportLayoutFrame {
 		collect( element );
 
 		for ( const node of hidden ) {
-			node.remove();
+			this.clearMediaSources( node );
+		}
+	}
+
+	// Nothing inside a hidden subtree is drawn, so nothing here can be missed.
+	clearMediaSources( element ) {
+		for ( const node of [ element, ...element.querySelectorAll( '*' ) ] ) {
+			if ( node.tagName === 'IMG' || node.tagName === 'SOURCE' ) {
+				// Both, since a bare srcset still resolves through currentSrc.
+				node.removeAttribute( 'src' );
+				node.removeAttribute( 'srcset' );
+			}
+
+			if ( node.style ) {
+				node.style.backgroundImage = 'none';
+			}
 		}
 	}
 

--- a/javascript/commons/ExportImage.js
+++ b/javascript/commons/ExportImage.js
@@ -1,4 +1,4 @@
-/* global html2canvas */
+/* global snapdom */
 
 /*******************************************************************************
  * Description: Adds export functionality to Liquipedia pages, enabling users
@@ -36,7 +36,21 @@ const EXPORT_IMAGE_CONFIG = {
 	},
 	TIMEOUTS: {
 		IMAGE_LOAD: 5000,
-		URL_REVOKE_DELAY: 100
+		URL_REVOKE_DELAY: 100,
+		STYLESHEET_LOAD: 10000,
+		FONT_READY: 5000
+	},
+	CAPTURE: {
+		// Exports are rendered in a window of this width so that they look the same
+		// on a phone as on a desktop, and stay independent of the reader's window
+		// size. Responsive layout here is driven by viewport media queries, which
+		// cannot be re-evaluated in the live document, hence the offscreen frame.
+		LAYOUT_WIDTH: 1440,
+		// snapdom clamps its SVG raster to this many pixels per side.
+		MAX_RASTER_SIDE: 16384,
+		MIN_SCALE: 2,
+		MAX_SCALE: 3,
+		TARGET_ATTRIBUTE: 'data-export-target'
 	},
 	COLORS: {
 		DARK: {
@@ -157,7 +171,7 @@ class CanvasComposer {
 		this.offscreenContext = null;
 	}
 
-	async compose( sourceCanvas, sectionTitle, isDarkTheme, scale = 1 ) {
+	async compose( sourceCanvas, sectionTitle, isDarkTheme, scale = 1, contentBackground = null ) {
 		const dims = this.getScaledDimensions( scale );
 		const fonts = this.getScaledFonts( scale );
 
@@ -171,7 +185,7 @@ class CanvasComposer {
 
 		this.drawBackground( context, canvas.width, canvas.height, theme );
 		this.drawHeader( context, canvas.width, theme, headerLayout, fonts, dims );
-		this.drawContent( context, sourceCanvas, headerLayout.height, dims );
+		this.drawContent( context, sourceCanvas, headerLayout.height, dims, contentBackground );
 		await this.drawFooter(
 			context, canvas.width, sourceCanvas.height, theme, isDarkTheme, headerLayout.height, fonts, dims
 		);
@@ -289,12 +303,18 @@ class CanvasComposer {
 		);
 	}
 
-	drawContent( context, sourceCanvas, headerHeight, dims ) {
-		context.drawImage(
-			sourceCanvas,
-			dims.PADDING,
-			dims.PADDING + headerHeight + dims.PADDING
-		);
+	drawContent( context, sourceCanvas, headerHeight, dims, contentBackground ) {
+		const x = dims.PADDING;
+		const y = dims.PADDING + headerHeight + dims.PADDING;
+
+		// The capture leaves uncovered pixels transparent, so paint the page
+		// background under it rather than letting the frame colour show through.
+		if ( contentBackground ) {
+			context.fillStyle = contentBackground;
+			context.fillRect( x, y, sourceCanvas.width, sourceCanvas.height );
+		}
+
+		context.drawImage( sourceCanvas, x, y );
 	}
 
 	async drawFooter( context, canvasWidth, sourceHeight, theme, isDarkTheme, headerHeight, fonts, dims ) {
@@ -460,43 +480,512 @@ class CanvasComposer {
 }
 
 /**
+ * Renders exportable content in an offscreen document of a fixed width.
+ *
+ * snapdom captures whatever the browser has already laid out, so the content has
+ * to be laid out at export width before it is captured. A viewport width cannot
+ * be changed in the live document, so an offscreen iframe provides one. Its
+ * document is rebuilt after every capture (see `recycle`), which keeps the
+ * stylesheet parse between exports rather than inside one.
+ */
+class ExportLayoutFrame {
+	constructor() {
+		this.iframe = null;
+		this.preparePromise = null;
+	}
+
+	/**
+	 * Builds the frame if needed. Safe to call repeatedly; used both to warm up
+	 * when the share menu opens and as a guard before each capture.
+	 *
+	 * @return {Promise<HTMLIFrameElement>}
+	 */
+	prepare() {
+		if ( !this.preparePromise ) {
+			this.preparePromise = this.build().catch( ( error ) => {
+				// Start from scratch next time rather than keeping a half-built frame.
+				this.dispose();
+				throw error;
+			} );
+		}
+
+		return this.preparePromise;
+	}
+
+	async build() {
+		const iframe = document.createElement( 'iframe' );
+
+		iframe.setAttribute( 'aria-hidden', 'true' );
+		iframe.setAttribute( 'tabindex', '-1' );
+		Object.assign( iframe.style, {
+			position: 'fixed',
+			top: '0',
+			left: '-20000px',
+			width: `${ EXPORT_IMAGE_CONFIG.CAPTURE.LAYOUT_WIDTH }px`,
+			height: `${ this.getLayoutHeight() }px`,
+			border: '0',
+			pointerEvents: 'none'
+		} );
+
+		document.body.appendChild( iframe );
+		this.iframe = iframe;
+
+		return this.resetDocument( iframe );
+	}
+
+	async resetDocument( iframe ) {
+		const frameDocument = iframe.contentDocument;
+
+		frameDocument.open();
+		frameDocument.write( '<!DOCTYPE html><html><head></head><body></body></html>' );
+		frameDocument.close();
+
+		await this.waitForStylesheets( this.copyStyles( frameDocument ) );
+
+		return iframe;
+	}
+
+	/**
+	 * Gives the next export a document that has not been captured from before.
+	 *
+	 * snapdom keeps caches keyed to the document it read, and reusing that document
+	 * makes every capture after the first lay out CSS-constrained images at their
+	 * intrinsic size, so team logos come out oversized. Rebuilding right after a
+	 * capture puts that cost between exports rather than inside one.
+	 */
+	recycle() {
+		if ( !this.iframe ) {
+			return;
+		}
+
+		this.preparePromise = this.resetDocument( this.iframe );
+		// Nobody awaits the rebuild itself; start clean if it fails, and let the
+		// next export report the failure.
+		this.preparePromise.catch( () => this.dispose() );
+	}
+
+	/**
+	 * The frame needs the page's own stylesheets: layout, theme colours and fonts
+	 * all come from them, and a copied computed style would carry the live
+	 * viewport's media query results instead of the export width's.
+	 *
+	 * @param {Document} frameDocument
+	 * @return {Array} the copied links, and whether the page has each one loaded
+	 */
+	copyStyles( frameDocument ) {
+		// The frame document has no URL of its own, so relative paths in the
+		// cloned content would not resolve without a base.
+		const base = frameDocument.createElement( 'base' );
+		base.href = document.baseURI;
+		frameDocument.head.appendChild( base );
+
+		const copiedLinks = [];
+		const styleNodes = document.querySelectorAll( 'style, link[rel~="stylesheet"]' );
+
+		for ( const styleNode of styleNodes ) {
+			const copy = frameDocument.importNode( styleNode, true );
+			frameDocument.head.appendChild( copy );
+
+			if ( copy.tagName === 'LINK' ) {
+				copiedLinks.push( { link: copy, loadedInPage: Boolean( styleNode.sheet ) } );
+			}
+		}
+
+		return copiedLinks;
+	}
+
+	/**
+	 * Holds the frame back until its stylesheets have settled.
+	 *
+	 * A stylesheet the page itself never loaded is expected to fail here too, and
+	 * the export should look like the page, so that resolves. One the page has but
+	 * the frame cannot get would silently change the layout, and one still in
+	 * flight could change it again mid-capture, so those reject and the frame is
+	 * rebuilt for the next attempt.
+	 *
+	 * @param {Array} copiedLinks from copyStyles
+	 * @return {Promise}
+	 */
+	waitForStylesheets( copiedLinks ) {
+		return Promise.all( copiedLinks.map( ( { link, loadedInPage } ) => new Promise( ( resolve, reject ) => {
+			if ( link.sheet ) {
+				resolve();
+				return;
+			}
+
+			let timeoutId = null;
+			const settle = ( failed ) => {
+				clearTimeout( timeoutId );
+
+				if ( failed && loadedInPage ) {
+					reject( new Error( `Export frame could not load stylesheet: ${ link.href }` ) );
+				} else {
+					resolve();
+				}
+			};
+
+			timeoutId = setTimeout( () => settle( true ), EXPORT_IMAGE_CONFIG.TIMEOUTS.STYLESHEET_LOAD );
+			link.addEventListener( 'load', () => settle( false ), { once: true } );
+			link.addEventListener( 'error', () => settle( true ), { once: true } );
+		} ) ) );
+	}
+
+	// Follows the height of the page so that viewport-relative units inside the
+	// frame resolve to the same values they do while reading it.
+	getLayoutHeight() {
+		return document.documentElement.scrollHeight;
+	}
+
+	/**
+	 * Captures an element as it would look at export width.
+	 *
+	 * @param {HTMLElement} element element in the live document
+	 * @param {Object} options scale, backgroundColor and a prepareDocument hook
+	 *                         that may adjust the frame before it is captured
+	 * @return {Promise<{canvas: HTMLCanvasElement, scale: number}>}
+	 */
+	async render( element, options ) {
+		const iframe = await this.prepare();
+		const frameDocument = iframe.contentDocument;
+
+		iframe.style.height = `${ this.getLayoutHeight() }px`;
+		this.copyRootAttributes( frameDocument );
+
+		const target = this.replaceContent( frameDocument, element );
+		if ( !target ) {
+			throw new Error( 'Could not find the element inside the export frame' );
+		}
+
+		if ( options.prepareDocument ) {
+			options.prepareDocument( frameDocument );
+		}
+
+		this.pruneHiddenContent( target );
+
+		if ( options.backgroundColor ) {
+			target.style.background = options.backgroundColor;
+		}
+
+		// Measure once the fonts the content uses have loaded, since text metrics
+		// decide the size of most of what gets exported.
+		await this.waitForFonts( frameDocument );
+
+		this.pinSubgridTracks( target );
+
+		const bounds = target.getBoundingClientRect();
+		if ( bounds.width === 0 || bounds.height === 0 ) {
+			throw new Error( 'Canvas capture resulted in zero dimensions' );
+		}
+
+		const scale = this.getEffectiveScale( bounds, options.scale );
+		let canvas;
+
+		try {
+			canvas = await snapdom.toCanvas( target, {
+				scale: scale,
+				// snapdom multiplies scale by the device pixel ratio; the requested
+				// scale already accounts for it.
+				dpr: 1,
+				// The frame is serialised into an isolated SVG document, so the fonts
+				// it uses have to travel with it.
+				embedFonts: true,
+				cache: 'auto'
+			} );
+		} finally {
+			this.recycle();
+		}
+
+		return { canvas: canvas, scale: scale };
+	}
+
+	/**
+	 * Replaces `subgrid` on the captured element with the tracks its parent
+	 * resolved.
+	 *
+	 * A capture is re-laid out on its own, where the root has no parent grid to
+	 * take tracks from, so `subgrid` falls back to `none` and every cell drops
+	 * into a single column. Match lists are laid out exactly that way: the
+	 * collapse area is a subgrid of the five columns declared on
+	 * `.brkts-matchlist`.
+	 *
+	 * @param {HTMLElement} element root of the subtree about to be captured
+	 */
+	pinSubgridTracks( element ) {
+		const parent = element.parentElement;
+		if ( !parent ) {
+			return;
+		}
+
+		const view = element.ownerDocument.defaultView;
+		const style = view.getComputedStyle( element );
+		const parentStyle = view.getComputedStyle( parent );
+
+		const axes = [
+			{ template: 'gridTemplateColumns', start: 'gridColumnStart', end: 'gridColumnEnd' },
+			{ template: 'gridTemplateRows', start: 'gridRowStart', end: 'gridRowEnd' }
+		];
+
+		for ( const axis of axes ) {
+			if ( !style[ axis.template ].startsWith( 'subgrid' ) ) {
+				continue;
+			}
+
+			const tracks = this.parseTrackList( parentStyle[ axis.template ] );
+			if ( !tracks.length ) {
+				continue;
+			}
+
+			// The element covers a range of the parent's tracks, usually all of
+			// them, and inherits only those.
+			const from = Math.max( parseInt( style[ axis.start ], 10 ) || 1, 1 ) - 1;
+			const end = parseInt( style[ axis.end ], 10 );
+			const to = end > 0 ? Math.max( end - 1, from + 1 ) : tracks.length;
+
+			element.style[ axis.template ] = tracks.slice( from, to ).join( ' ' );
+		}
+	}
+
+	/**
+	 * Splits a resolved track list into tracks, keeping line names and functional
+	 * notation intact: `[a] 10px [b c] minmax( 2px, 1fr )` gives two entries.
+	 *
+	 * @param {string} value resolved grid-template-columns or -rows
+	 * @return {string[]}
+	 */
+	parseTrackList( value ) {
+		if ( !value || value === 'none' || value.startsWith( 'subgrid' ) ) {
+			return [];
+		}
+
+		const tracks = [];
+		let pending = '';
+		let depth = 0;
+
+		for ( const token of value.split( /\s+/ ) ) {
+			pending += ( pending ? ' ' : '' ) + token;
+			depth += ( token.match( /[[(]/g ) || [] ).length;
+			depth -= ( token.match( /[\])]/g ) || [] ).length;
+
+			// A group of line names belongs to the track that follows it.
+			if ( depth === 0 && !token.endsWith( ']' ) ) {
+				tracks.push( pending );
+				pending = '';
+			}
+		}
+
+		if ( pending && tracks.length ) {
+			tracks[ tracks.length - 1 ] += ` ${ pending }`;
+		}
+
+		return tracks;
+	}
+
+	/**
+	 * Drops content the browser does not paint.
+	 *
+	 * A capture reads the whole subtree, including collapsed match rows and
+	 * closed detail popups, and inlines every image it finds there. A collapsed
+	 * match list can hide hundreds of team logos behind a box a few lines tall,
+	 * which costs seconds to embed and cannot show up in the result anyway,
+	 * because `display: none` paints nothing.
+	 *
+	 * Runs after the export fixes, so anything they reveal is kept.
+	 *
+	 * @param {HTMLElement} element root of the subtree about to be captured
+	 */
+	pruneHiddenContent( element ) {
+		const view = element.ownerDocument.defaultView;
+		const hidden = [];
+
+		// Collect before removing: a removal invalidates style, which would make
+		// every following style read recompute it.
+		const collect = ( node ) => {
+			for ( let child = node.firstElementChild; child; child = child.nextElementSibling ) {
+				if ( view.getComputedStyle( child ).display === 'none' ) {
+					hidden.push( child );
+				} else {
+					collect( child );
+				}
+			}
+		};
+
+		collect( element );
+
+		for ( const node of hidden ) {
+			node.remove();
+		}
+	}
+
+	// Copies the live body into the frame and returns the copy of `element`.
+	replaceContent( frameDocument, element ) {
+		const marker = EXPORT_IMAGE_CONFIG.CAPTURE.TARGET_ATTRIBUTE;
+
+		element.setAttribute( marker, '' );
+		const bodyClone = document.body.cloneNode( true );
+		element.removeAttribute( marker );
+
+		const target = bodyClone.querySelector( `[${ marker }]` );
+		if ( !target ) {
+			return null;
+		}
+		target.removeAttribute( marker );
+
+		// Cloned scripts never execute, but frames and embeds would load their
+		// content for nothing. Nothing exportable lives inside one.
+		for ( const node of bodyClone.querySelectorAll( 'script, noscript, iframe, object, embed' ) ) {
+			node.remove();
+		}
+
+		this.copyDynamicState( element, target );
+
+		frameDocument.adoptNode( bodyClone );
+		frameDocument.body.replaceWith( bodyClone );
+
+		return target;
+	}
+
+	// Cloning markup loses state that only exists in the DOM. Only the captured
+	// subtree matters, so this stays cheap.
+	copyDynamicState( liveElement, clonedElement ) {
+		const selector = 'input, textarea, select, canvas';
+		const liveNodes = liveElement.querySelectorAll( selector );
+		const clonedNodes = clonedElement.querySelectorAll( selector );
+
+		for ( let index = 0; index < liveNodes.length && index < clonedNodes.length; index++ ) {
+			const liveNode = liveNodes[ index ];
+			const clonedNode = clonedNodes[ index ];
+
+			if ( liveNode.tagName !== clonedNode.tagName ) {
+				return;
+			}
+
+			if ( liveNode.tagName === 'CANVAS' ) {
+				this.copyCanvas( liveNode, clonedNode );
+			} else if ( liveNode.type !== 'file' ) {
+				// A file input rejects an assigned value, and nothing else here can
+				// fail, but a throw would cost the whole export.
+				clonedNode.value = liveNode.value;
+
+				if ( liveNode.tagName === 'INPUT' ) {
+					clonedNode.checked = liveNode.checked;
+					clonedNode.indeterminate = liveNode.indeterminate;
+				}
+			}
+		}
+	}
+
+	copyCanvas( liveCanvas, clonedCanvas ) {
+		if ( liveCanvas.width === 0 || liveCanvas.height === 0 ) {
+			return;
+		}
+
+		try {
+			clonedCanvas.getContext( '2d' ).drawImage( liveCanvas, 0, 0 );
+		} catch {
+			// A tainted canvas cannot be read; leave the copy blank.
+		}
+	}
+
+	// Theme and wiki classes live on the root element, and custom properties set at
+	// runtime live in its inline style.
+	copyRootAttributes( frameDocument ) {
+		const liveRoot = document.documentElement;
+		const frameRoot = frameDocument.documentElement;
+
+		frameRoot.className = liveRoot.className;
+		frameRoot.setAttribute( 'lang', liveRoot.lang || 'en' );
+		frameRoot.setAttribute( 'dir', liveRoot.dir || 'ltr' );
+		frameRoot.setAttribute( 'style', liveRoot.getAttribute( 'style' ) || '' );
+	}
+
+	/**
+	 * Waits for the fonts the content uses, but not forever: a request that never
+	 * settles would otherwise leave the export spinning with no way out. Falling
+	 * back to whatever is loaded costs some text metrics, not the export.
+	 *
+	 * @param {Document} frameDocument
+	 * @return {Promise}
+	 */
+	waitForFonts( frameDocument ) {
+		if ( !frameDocument.fonts ) {
+			return Promise.resolve();
+		}
+
+		return Promise.race( [
+			frameDocument.fonts.ready,
+			new Promise( ( resolve ) => {
+				setTimeout( resolve, EXPORT_IMAGE_CONFIG.TIMEOUTS.FONT_READY );
+			} )
+		] );
+	}
+
+	/**
+	 * Very large content would exceed the raster limit. Losing resolution beats
+	 * losing the image, so the scale drops as far as it needs to, and the header,
+	 * footer and padding composed around the capture have to fit in the same
+	 * budget.
+	 *
+	 * @param {DOMRect} bounds captured element's box
+	 * @param {number} requestedScale
+	 * @return {number}
+	 */
+	getEffectiveScale( bounds, requestedScale ) {
+		const dimensions = EXPORT_IMAGE_CONFIG.DIMENSIONS;
+		const composed = ( dimensions.PADDING * 4 ) + dimensions.HEADER_HEIGHT + dimensions.FOOTER_HEIGHT;
+		const longestSide = Math.max( bounds.width, bounds.height, 1 ) + composed;
+
+		return Math.min( requestedScale, EXPORT_IMAGE_CONFIG.CAPTURE.MAX_RASTER_SIDE / longestSide );
+	}
+
+	dispose() {
+		if ( this.iframe ) {
+			this.iframe.remove();
+			this.iframe = null;
+		}
+
+		this.preparePromise = null;
+	}
+}
+
+/**
  * Handles export operations (canvas capture, download, clipboard)
  */
 class ExportService {
 	constructor( canvasComposer ) {
 		this.canvasComposer = canvasComposer;
-		this.html2canvasLoaded = false;
+		this.layoutFrame = new ExportLayoutFrame();
+		this.snapdomPromise = null;
 		this.activeExports = new Set();
 	}
 
-	applyCloneFixes( clonedDoc ) {
-		this.hideInfoIcons( clonedDoc );
-		this.removeContentSwitchers( clonedDoc );
-		this.removePrizepoolToggles( clonedDoc );
-		this.expandPrizepoolTables( clonedDoc );
+	applyExportFixes( frameDocument ) {
+		this.hideInfoIcons( frameDocument );
+		this.removeContentSwitchers( frameDocument );
+		this.removePrizepoolToggles( frameDocument );
+		this.expandPrizepoolTables( frameDocument );
 	}
 
 	// Hides info icons that shouldn't appear in exports
-	hideInfoIcons( clonedDoc ) {
-		const infoIcons = clonedDoc.querySelectorAll( '.brkts-match-info-icon' );
+	hideInfoIcons( frameDocument ) {
+		const infoIcons = frameDocument.querySelectorAll( '.brkts-match-info-icon' );
 		for ( const icon of infoIcons ) {
 			icon.style.opacity = '0';
 		}
 	}
 
 	// Remove toggle switches
-	removeContentSwitchers( clonedDoc ) {
-		const contentSwitches = clonedDoc.querySelectorAll( '.switch-pill-container' );
+	removeContentSwitchers( frameDocument ) {
+		const contentSwitches = frameDocument.querySelectorAll( '.switch-pill-container' );
 
 		for ( const contentSwitch of contentSwitches ) {
 			contentSwitch.remove();
 		}
 	}
 
-	removePrizepoolToggles( clonedDoc ) {
+	removePrizepoolToggles( frameDocument ) {
 		// The legacy in-table toggle and the redesigned table's footer (now inside the
 		// captured wrapper) shouldn't appear in a static export.
-		const prizepoolToggles = clonedDoc.querySelectorAll(
+		const prizepoolToggles = frameDocument.querySelectorAll(
 			'.prizepooltabletoggle, .prizepool-table-wrapper .table2__footer'
 		);
 
@@ -506,8 +995,8 @@ class ExportService {
 	}
 
 	// Cut placements are hidden by `.collapsed` on the wrapper; expand so they export.
-	expandPrizepoolTables( clonedDoc ) {
-		const collapsedTables = clonedDoc.querySelectorAll( '.prizepool-table-wrapper.collapsed' );
+	expandPrizepoolTables( frameDocument ) {
+		const collapsedTables = frameDocument.querySelectorAll( '.prizepool-table-wrapper.collapsed' );
 
 		for ( const collapsedTable of collapsedTables ) {
 			collapsedTable.classList.remove( 'collapsed' );
@@ -524,7 +1013,7 @@ class ExportService {
 		this.activeExports.add( exportId );
 
 		try {
-			await this.ensureHtml2CanvasLoaded();
+			await this.prewarm();
 
 			if ( mode === 'copy' ) {
 				await this.copyToClipboard( element, title );
@@ -540,48 +1029,43 @@ class ExportService {
 	}
 
 	async generateImageBlob( element, title ) {
-		const originalBackground = element.style.background;
 		const isDarkTheme = document.documentElement.classList.contains( 'theme--dark' );
 		const backgroundColor = this.getBackgroundColor();
-		// This ensures the scale is at least 2, but never higher than 3
-		const scale = Math.min( Math.max( window.devicePixelRatio || 1, 2 ), 3 );
 
-		try {
-			element.style.background = backgroundColor;
+		const capture = await this.layoutFrame.render( element, {
+			scale: this.getScale(),
+			backgroundColor: backgroundColor,
+			prepareDocument: ( frameDocument ) => this.applyExportFixes( frameDocument )
+		} );
 
-			const capturedCanvas = await html2canvas( element, {
-				scale: scale,
-				windowWidth: 1440,
-				windowHeight: document.documentElement.scrollHeight,
-				scrollX: 0,
-				scrollY: 0,
-				backgroundColor: backgroundColor,
-				onclone: ( clonedDoc ) => this.applyCloneFixes( clonedDoc )
-			} );
-
-			if ( capturedCanvas.width === 0 || capturedCanvas.height === 0 ) {
-				throw new Error( 'Canvas capture resulted in zero dimensions' );
-			}
-
-			const composedCanvas = await this.canvasComposer.compose(
-				capturedCanvas,
-				title,
-				isDarkTheme,
-				scale
-			);
-
-			return new Promise( ( resolve, reject ) => {
-				composedCanvas.toBlob( ( blob ) => {
-					if ( blob ) {
-						resolve( blob );
-					} else {
-						reject( new Error( 'Failed to create image blob' ) );
-					}
-				}, 'image/png' );
-			} );
-		} finally {
-			element.style.background = originalBackground;
+		if ( capture.canvas.width === 0 || capture.canvas.height === 0 ) {
+			throw new Error( 'Canvas capture resulted in zero dimensions' );
 		}
+
+		const composedCanvas = await this.canvasComposer.compose(
+			capture.canvas,
+			title,
+			isDarkTheme,
+			capture.scale,
+			backgroundColor
+		);
+
+		return new Promise( ( resolve, reject ) => {
+			composedCanvas.toBlob( ( blob ) => {
+				if ( blob ) {
+					resolve( blob );
+				} else {
+					reject( new Error( 'Failed to create image blob' ) );
+				}
+			}, 'image/png' );
+		} );
+	}
+
+	// At least 2 so text stays crisp, never above 3 so files stay a sane size.
+	getScale() {
+		const { MIN_SCALE, MAX_SCALE } = EXPORT_IMAGE_CONFIG.CAPTURE;
+
+		return Math.min( Math.max( window.devicePixelRatio || 1, MIN_SCALE ), MAX_SCALE );
 	}
 
 	async copyToClipboard( element, title ) {
@@ -618,17 +1102,32 @@ class ExportService {
 		}, EXPORT_IMAGE_CONFIG.TIMEOUTS.URL_REVOKE_DELAY );
 	}
 
-	async ensureHtml2CanvasLoaded() {
-		if ( this.html2canvasLoaded ) {
-			return;
+	/**
+	 * Loads the library and builds the layout frame. Called when the share menu
+	 * opens so that the setup cost lands before anyone picks an option, and again
+	 * before each export as a guard.
+	 *
+	 * @return {Promise}
+	 */
+	prewarm() {
+		return Promise.all( [ this.ensureSnapdomLoaded(), this.layoutFrame.prepare() ] );
+	}
+
+	ensureSnapdomLoaded() {
+		if ( !this.snapdomPromise ) {
+			this.snapdomPromise = Promise.resolve( mw.loader.using( 'snapdom' ) ).catch( ( error ) => {
+				// Let the next export load it again instead of reusing the failure
+				// for the rest of the page's life.
+				this.snapdomPromise = null;
+				throw error;
+			} );
 		}
 
-		return new Promise( ( resolve ) => {
-			mw.loader.using( 'html2canvas', () => {
-				this.html2canvasLoaded = true;
-				resolve();
-			} );
-		} );
+		return this.snapdomPromise;
+	}
+
+	dispose() {
+		this.layoutFrame.dispose();
 	}
 
 	getBackgroundColor() {
@@ -958,7 +1457,11 @@ class DropdownWidget {
 
 		button.addEventListener( 'click', () => {
 			if ( menuElement.style.display === 'none' ) {
-				this.exportService.ensureHtml2CanvasLoaded();
+				// Failures are surfaced when an export is actually requested.
+				this.exportService.prewarm().catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.warn( 'Export prewarm failed:', error );
+				} );
 				if ( onOpen ) {
 					onOpen();
 				}
@@ -1271,6 +1774,7 @@ class ExportImageModule {
 
 	cleanup() {
 		this.imageCache.clear();
+		this.exportService.dispose();
 		const dropdowns = document.querySelectorAll( '.dropdown-widget' );
 		for ( const dropdown of dropdowns ) {
 			this.dropdownWidget.cleanup( dropdown );


### PR DESCRIPTION
## Summary

Replace html2canvas with snapdom for image exports. This is an alternative to #7920, which was put on hold due to issues with its proposed approach.

html2canvas clones the whole document and reparses every stylesheet for each capture, taking 1.2–2.4 seconds regardless of element size. Local measurements across brackets, tables, prize pools, and participant grids found the new capture path approximately 3.4× faster without observed layout drift.

The new implementation:

- renders exports in a reusable offscreen iframe at the existing fixed 1440px layout width;
- copies page styles, root attributes, and dynamic form/canvas state;
- waits for stylesheets, fonts, and cloned images before measuring;
- strips media from hidden subtrees without changing their DOM structure;
- pins resolved subgrid tracks so match lists retain their layout;
- rebuilds the frame after every capture, including failed renders, to avoid stale snapdom state;
- fixes output at scale 2 and DPR 1 so browser zoom and display density do not affect exports;
- measures the composed header and footer exactly, then clamps the complete canvas against per-side and total-area limits.

The browser-zoom lockout is removed because capture layout and resolution no longer depend on the reader's viewport or device pixel ratio.

This remains one change because the iframe lifecycle, snapdom capture, scaling, and canvas composition form a coupled replacement; splitting them would leave broken intermediate export paths.

Known caveat: the fixed area ceiling uses the conservative desktop Firefox limit. Stricter iOS limits could require lowering it if very large iOS exports return blank.

## How did you test this change?

Manually tested image exports on:

- https://liquipedia.net/pubgmobile/PUBG_Mobile_Japan_League/Season_6/Phase_1
- https://liquipedia.net/dota2/BLAST/SLAM/6
- https://liquipedia.net/fighters/Capcom_Pro_Tour/2026/World_Warrior/South_America/West/5

Local checks:

- `./node_modules/.bin/eslint --no-fix javascript/commons/ExportImage.js`
- `npm run test:js -- --runInBand --reporters=default` — 21 tests passed
- `node --check javascript/commons/ExportImage.js`
- `git diff --check`
