### PR TITLE
ci: fix possible race condition in snapshot js

### DIFF
--- a/lua/spec/helpers/template.html
+++ b/lua/spec/helpers/template.html
@@ -7,8 +7,6 @@
 	<!-- The wiki's own styles, fetched by scripts/fetch-remote-css.sh -->
 	<link rel="stylesheet" href="./css/lakeside.css">
 	<link rel="stylesheet" href="./css/main.css">
-	<script src="../../node_modules/jquery/dist/jquery.min.js"></script>
-	<script src="../../javascript/Main.js"></script>
 </head>
 
 <body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-2 ns-subject mw-editable skin-lakesideview action-view wiki-commons logged-in user-is-editor user-is-reviewer user-is-sysop" id="top">
@@ -25,6 +23,8 @@
 			</main>
 		</div>
 	</div>
+	<script src="../../node_modules/jquery/dist/jquery.min.js"></script>
+	<script src="../../javascript/Main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Ensure that the full dom is present before JS is loaded. This MIGHT fix a race condition, that MIGHT be the cause of the flaky dota2 ratings snapshot