### PR TITLE
fix(match2): links that do not use allmode icon create extra gap in matchpage footer

### DIFF
--- a/stylesheets/commons/BigMatch.scss
+++ b/stylesheets/commons/BigMatch.scss
@@ -1069,6 +1069,10 @@ span.slash {
 				border-color: var( --clr-on-surface-dark-primary-8 );
 			}
 
+			&.vodlink > a {
+				display: contents;
+			}
+
 			&:has( > .match-table-wrapper ) {
 				display: contents;
 				padding: unset;


### PR DESCRIPTION
## Summary

<img width="469" height="128" alt="image" src="https://github.com/user-attachments/assets/7b6d76e7-130b-4560-945b-fd4598b206cb" />

Links display in match pages add unintended extra gap between links if the link uses separate files for lightmode and darkmode (i.e., link does not use allmode icon), as shown in the example screenshot above.
This PR adjusts the stylesheet to kick the forementioned extra gap.

## How did you test this change?

browser dev tools