### PR TITLE
feat: moved PlacementStats to module for mobilelegends

### DIFF
--- a/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
@@ -8,9 +8,8 @@
 local Lua = require('Module:Lua')
 
 local Class = Lua.import('Module:Class')
-
-local Team = Lua.import('Module:Infobox/Team')
 local PlacementStats = Lua.import('Module:Infobox/Extension/PlacementStats')
+local Team = Lua.import('Module:Infobox/Team')
 
 ---@class MobileLegendsInfoboxTeam: InfoboxTeam
 ---@operator call(Frame): MobileLegendsInfoboxTeam

--- a/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
@@ -1,0 +1,32 @@
+---
+-- @Liquipedia
+-- page=Module:Infobox/Team/Custom
+--
+-- Please see https://github.com/Liquipedia/Lua-Modules to contribute
+--
+
+local Lua = require('Module:Lua')
+
+local Class = Lua.import('Module:Class')
+
+local Team = Lua.import('Module:Infobox/Team')
+local PlacementStats = Lua.import('Module:Infobox/Extension/PlacementStats')
+
+---@class MobileLegendsInfoboxTeam: InfoboxTeam
+---@operator call(Frame): MobileLegendsInfoboxTeam
+local CustomTeam = Class.new(Team)
+
+---@param frame Frame
+---@return VNode
+function CustomTeam.run(frame)
+	local team = CustomTeam(frame)
+
+	return team:createInfobox()
+end
+
+---@return Html|string
+function CustomTeam:createBottomContent()
+	return PlacementStats.run{}
+end
+
+return CustomTeam

--- a/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
+++ b/lua/wikis/mobilelegends/Infobox/Team/Custom.lua
@@ -24,7 +24,7 @@ function CustomTeam.run(frame)
 	return team:createInfobox()
 end
 
----@return Html|string
+---@return VNode?
 function CustomTeam:createBottomContent()
 	return PlacementStats.run{}
 end


### PR DESCRIPTION
## Summary
Previously, the mobilelegends use the Module:Infobox/Extension/PlacementStats inside of the template, which is put it on the left, not in the bottom of the infobox

## How did you test this change?
dev
https://liquipedia.net/mobilelegends/Module:Infobox/Team/Custom/dev/steve23
