### PR TITLE
refactor(match2): use Array.mapRange in copypaste generators

### DIFF
--- a/lua/wikis/ageofempires/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/ageofempires/GetMatchGroupCopyPaste/wiki.lua
@@ -40,11 +40,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		isFfa and Logic.readBool(args.hasPointsMapping)
 			and (INDENT .. WikiCopyPaste._getPointsMapping(opponents)) or nil,
 		Logic.readBool(args.casters) and (INDENT .. '|caster1= |caster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' ..
 				(isFfa and WikiCopyPaste.getFfaOpponent(mode, bestof) or WikiCopyPaste.getOpponent(mode))
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode, isFfa)
 		end),
 		'}}'
@@ -73,7 +73,7 @@ end
 ---@return string
 function WikiCopyPaste.getFfaOpponent(mode, mapCount)
 	local mapArgs = table.concat(
-		Array.map(Array.range(1, mapCount), function (index)
+		Array.mapRange(1, mapCount, function (index)
 			return '|m' .. index .. '={{MS||civs=}}'
 		end)
 	)
@@ -110,7 +110,7 @@ end
 ---@return string
 function WikiCopyPaste._getPointsMapping(opponents)
 	return table.concat(
-		Array.map(Array.range(1, opponents), function (index)
+		Array.mapRange(1, opponents, function (index)
 			return '|p' .. index .. '='
 		end)
 	)

--- a/lua/wikis/apexlegends/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/apexlegends/GetMatchGroupCopyPaste/wiki.lua
@@ -31,10 +31,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT ..
 		'|p_kill=1 |p1=12 |p2=9 |p3=7 |p4=5 |p5=4 |p6=3 |p7=3 |p8=2 |p9=2 |p10=2 |p11=1 |p12=1 |p13=1 |p14=1 |p15=1',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/arenafps/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/arenafps/GetMatchGroupCopyPaste/wiki.lua
@@ -47,10 +47,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end),
 		'}}'
@@ -70,10 +70,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p1=5|p2=4|p3=3|p4=2|p5=1',
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/artifact/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/artifact/GetMatchGroupCopyPaste/wiki.lua
@@ -30,12 +30,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		showScore and INDENT .. '|finished=' or nil,
 		INDENT .. '|date= |twitch= |youtube= |vod=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex)
 		end),
 		'}}'

--- a/lua/wikis/autochess/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/autochess/GetMatchGroupCopyPaste/wiki.lua
@@ -30,10 +30,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p1=9 |p2=7 |p3=6 |p4=5 |p5=3 |p6=2 |p7=1 |p8=0',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/battalion/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/battalion/GetMatchGroupCopyPaste/wiki.lua
@@ -31,10 +31,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		INDENT .. '|date=|twitch=|finished=',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'

--- a/lua/wikis/brawlhalla/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/brawlhalla/GetMatchGroupCopyPaste/wiki.lua
@@ -33,10 +33,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|bestof=' .. bestof,
 		INDENT .. '|date=',
 		INDENT .. '|twitch=|vod=',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
 		end),
 		'}}'

--- a/lua/wikis/callofduty/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/callofduty/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
@@ -76,10 +76,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 			'|p16_kill=1.2 |p17_kill=1.2 |p18_kill=1.2 |p19_kill=1.2 |p20_kill=1.2 ' ..
 			'|p21_kill=1.2 |p22_kill=1.2 |p23_kill=1.2 |p24_kill=1.2 |p25_kill=1.2 ' ..
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/chess/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/chess/GetMatchGroupCopyPaste/wiki.lua
@@ -34,10 +34,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		showScore and (INDENT .. '|finished=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		Array.map(Array.range(1, bestof), WikiCopyPaste._map),
+		Array.mapRange(1, bestof, WikiCopyPaste._map),
 		INDENT .. '}}'
 	)
 

--- a/lua/wikis/clashofclans/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/clashofclans/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|percent1= |score2=|percent2= |winner=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/clashroyale/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/clashroyale/GetMatchGroupCopyPaste/wiki.lua
@@ -42,11 +42,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		mvps and (INDENT .. '|mvp=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		bans and '|t1bans={{Cards|}}|t2bans={{Cards|}}' or nil,
-		Array.map(Array.range(1, bestof), FnUtil.curry(WikiCopyPaste.getMapCode, mode)),
+		Array.mapRange(1, bestof, FnUtil.curry(WikiCopyPaste.getMapCode, mode)),
 		'}}'
 	)
 

--- a/lua/wikis/counterstrike/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/counterstrike/GetMatchGroupCopyPaste/wiki.lua
@@ -114,7 +114,7 @@ end
 ---@return table
 function WikiCopyPaste.getStart(template, id, modus, args)
 	args.namedMatchParams = false
-	args.headersUpTop = Logic.readBool(Logic.emptyOr(args.headersUpTop, true))
+	args.headersUpTop = Logic.nilOr(Logic.readBoolOrNil(args.headersUpTop), true)
 
 	local start = '{{' .. WikiCopyPaste.getMatchGroupTypeCopyPaste(modus, template) .. '|id=' .. id
 

--- a/lua/wikis/counterstrike/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/counterstrike/GetMatchGroupCopyPaste/wiki.lua
@@ -47,7 +47,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = {
 		'{{Match',
-		INDENT .. table.concat(Array.map(Array.range(1, opponents), function(opponentIndex)
+		INDENT .. table.concat(Array.mapRange(1, opponents, function(opponentIndex)
 			return '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode, showScore)
 		end)),
 		INDENT .. '|date= |finished=',

--- a/lua/wikis/criticalops/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/criticalops/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|youtube=|twitch=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/crossfire/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/crossfire/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|huya=|douyu=|youtube=|twitch=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/deadlock/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/deadlock/GetMatchGroupCopyPaste/wiki.lua
@@ -25,12 +25,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match|bestof=' .. (bestof ~= 0 and bestof or ''),
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date=',
 		INDENT .. '|twitch=|youtube=|vod=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, bans)
 		end),
 		'}}'

--- a/lua/wikis/deltaforce/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/deltaforce/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|team1side=|team2side=|winner=|vod=}}'
 		end) or nil,
 		INDENT .. '}}'
@@ -72,10 +72,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1' ..
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/dota2/GetMatchGroupCopyPaste/wiki.lua
@@ -26,7 +26,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		Logic.readBool(args.hasDate) and {
@@ -34,13 +34,13 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|finished=',
 			INDENT .. '|twitch='
 		} or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|vodgame'.. mapIndex ..'='
 		end),
-		generateMatchPage and {} or Array.map(Array.range(1, bestof), function(mapIndex)
+		generateMatchPage and {} or Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|matchid'.. mapIndex ..'='
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, Logic.readBool(args.bans), generateMatchPage)
 		end),
 		'}}'

--- a/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/easportsfc/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		hasSubmatches and INDENT .. '|hasSubmatches=1' or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|youtube=|twitch='} or {},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '=' .. WikiCopyPaste._getMap(hasSubmatches)
 		end) or nil,
 		'}}'

--- a/lua/wikis/eva/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/eva/GetMatchGroupCopyPaste/wiki.lua
@@ -46,7 +46,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		showScore and (INDENT .. '|finished=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end)
 	)
@@ -65,7 +65,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	if bestof ~= 0 then
-		Array.extendWith(lines, Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.extendWith(lines, Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end))
 	end

--- a/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fighters/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|bestof=' .. bestof,
 		Logic.readBool(args.date) and INDENT .. '|date=' or nil,
 		Logic.readBool(args.vod) and INDENT .. '|twitch=|vod=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Logic.readBool(args.details) and Array.map(Array.range(1, bestof), function(mapIndex)
+		Logic.readBool(args.details) and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
 		end) or nil,
 		'}}'

--- a/lua/wikis/fortnite/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/fortnite/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		{INDENT .. '|date='},
 		{INDENT .. '|twitch=|youtube='},
 		{INDENT .. '|vod='},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'
@@ -81,10 +81,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. defaultScoring,
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'
@@ -97,7 +97,7 @@ end
 ---@param mapCount integer
 ---@return string
 function WikiCopyPaste.getFfaOpponent(mode, mapCount)
-	local mapScores = table.concat(Array.map(Array.range(1, mapCount), function(idx)
+	local mapScores = table.concat(Array.mapRange(1, mapCount, function(idx)
 		return '|m' .. idx .. '={{MS||}}'
 	end))
 

--- a/lua/wikis/freefire/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/freefire/GetMatchGroupCopyPaste/wiki.lua
@@ -47,10 +47,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		{INDENT .. '|date='},
 		{INDENT .. '|twitch=|youtube='},
 		{INDENT .. '|vod='},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'
@@ -70,10 +70,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=12 |p2=9 |p3=8 |p4=7 |p5=6 |p6=5 |p7=4 |p8=3 |p9=2 |p10=1 |p11=0 |p12=0',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/geoguessr/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/geoguessr/GetMatchGroupCopyPaste/wiki.lua
@@ -31,12 +31,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'

--- a/lua/wikis/goals/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/goals/GetMatchGroupCopyPaste/wiki.lua
@@ -31,12 +31,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2=|finished=}}'
 		end),
 		'}}'

--- a/lua/wikis/halo/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/halo/GetMatchGroupCopyPaste/wiki.lua
@@ -47,10 +47,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
 		end),
 		'}}'
@@ -70,10 +70,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=0',
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/hearthstone/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/hearthstone/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		'{{Match|bestof=' .. bestof,
 		INDENT .. '|date=',
 		INDENT .. '|twitch=|vod=',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getStandardMap(mode, opponents)
 		end),
 		'}}'
@@ -73,8 +73,8 @@ function WikiCopyPaste._getStandardMap(mode, opponents)
 	end
 
 	local parts = Array.extend({'={{Map'},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
-			return table.concat(Array.map(Array.range(1, Opponent.partySize(mode) --[[@as integer]]), function(playerIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
+			return table.concat(Array.mapRange(1, Opponent.partySize(mode) --[[@as integer]], function(playerIndex)
 				return '|o' .. opponentIndex .. 'c' .. playerIndex .. '='
 			end))
 		end),
@@ -96,10 +96,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p1=7.1 |p2=6 |p3=5 |p4=4 |p5=3 |p6=2 |p7=1 |p8=0',
 		INDENT .. '|twitch= |youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/heroes/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/heroes/GetMatchGroupCopyPaste/wiki.lua
@@ -41,15 +41,15 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|twitch=',
 		} or nil,
 		casters > 0 and {
-			INDENT .. table.concat(Array.map(Array.range(1, casters), function(casterIndex)
+			INDENT .. table.concat(Array.mapRange(1, casters, function(casterIndex)
 				return '|caster' .. casterIndex .. '='
 			end), ' ')
 		} or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		(veto and bestof > 0) and WikiCopyPaste._getVeto(bestof, vetoBanRounds) or nil,
-		Array.map(Array.range(1, bestof), function (mapIndex)
+		Array.mapRange(1, bestof, function (mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(bans)
 		end),
 		'}}'
@@ -71,7 +71,7 @@ function WikiCopyPaste._getVeto(bestof, vetoRounds)
 		INDENT .. INDENT .. '|format=By turns',
 		INDENT .. INDENT .. '|firstpick=',
 		INDENT .. INDENT .. '|types=' .. preFilledVetoTypes,
-		Array.map(Array.range(1, vetoRounds + bestof), function (round)
+		Array.mapRange(1, vetoRounds + bestof, function (round)
 			return INDENT .. INDENT .. '|t1map' .. round .. '=|t2map' .. round .. '='
 		end),
 		INDENT .. '}}'

--- a/lua/wikis/honorofkings/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/honorofkings/GetMatchGroupCopyPaste/wiki.lua
@@ -33,7 +33,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		Logic.readBool(args.hasDate) and Array.extend(
@@ -42,7 +42,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			Logic.readBool(args.mvp) and INDENT .. '|mvp=' or nil,
 			args.vod == 'series' and (INDENT .. '|vod=') or nil
 		) or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, numberOfBans, args.vod == 'maps')
 		end),
 		'}}'
@@ -61,7 +61,7 @@ function WikiCopyPaste._getMapCode(mapIndex, numberOfBans, showVod)
 		if numberOfBans == 0 then
 			return nil
 		end
-		return INDENT .. INDENT .. table.concat(Array.map(Array.range(1, numberOfBans), function(banIndex)
+		return INDENT .. INDENT .. table.concat(Array.mapRange(1, numberOfBans, function(banIndex)
 				return '|t' .. opponentIndex .. 'b' .. banIndex .. '='
 			end), ' ')
 	end

--- a/lua/wikis/identityv/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/identityv/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), WikiCopyPaste._getMapCode) or nil,
+		bestof ~= 0 and Array.mapRange(1, bestof, WikiCopyPaste._getMapCode) or nil,
 		INDENT .. '}}'
 	)
 
@@ -53,7 +53,7 @@ function WikiCopyPaste._getMapCode(mapIndex)
 	---@param limit integer
 	---@return string
 	local charsCode = function(opponentIndex, charType, limit)
-		local params = Array.map(Array.range(1, limit), function(runIndex)
+		local params = Array.mapRange(1, limit, function(runIndex)
 				return '|t' .. opponentIndex .. charType .. runIndex .. '='
 		end)
 		return table.concat(params)

--- a/lua/wikis/lab/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/lab/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
@@ -72,10 +72,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=12 |p2=9 |p3=7 |p4=5 |p5=4 |p6=3 |p7=3 |p8=2 |p9=2 |p10=2 ' ..
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/leagueoflegends/GetMatchGroupCopyPaste/wiki.lua
@@ -42,7 +42,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		Logic.readBool(args.hasDate) and Array.extend(
@@ -52,11 +52,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|mvp='
 		) or nil,
 		casters > 0 and {
-			INDENT .. table.concat(Array.map(Array.range(1, casters), function(casterIndex)
+			INDENT .. table.concat(Array.mapRange(1, casters, function(casterIndex)
 				return '|caster' .. casterIndex .. '='
 			end), ' ')
 		} or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, args)
 		end),
 		INDENT .. '|patch=',
@@ -85,13 +85,13 @@ function WikiCopyPaste._getMapCode(mapIndex, args)
 		INDENT .. '|map' .. mapIndex .. '={{Map',
 		INDENT .. INDENT .. '|vod=',
 		INDENT .. INDENT .. '|team1side=',
-		detailedPlayerInput and Array.map(Array.range(1, 5), function (index)
+		detailedPlayerInput and Array.mapRange(1, 5, function (index)
 			return INDENT .. INDENT .. '|t1p' .. index .. '={{Json|player= |role=' ..
 					ROLES[index] .. ' |character= |kills= |deaths= |assists=}}'
 		end) or (INDENT .. INDENT .. '|t1c1= |t1c2= |t1c3= |t1c4= |t1c5='),
 		bans and (INDENT .. INDENT .. '|t1b1= |t1b2= |t1b3= |t1b4= |t1b5=') or nil,
 		INDENT .. INDENT .. '|team2side=',
-		detailedPlayerInput and Array.map(Array.range(1, 5), function (index)
+		detailedPlayerInput and Array.mapRange(1, 5, function (index)
 			return INDENT .. INDENT .. '|t2p' .. index .. '={{Json|player= |role=' ..
 					ROLES[index] .. ' |character= |kills= |deaths= |assists=}}'
 		end) or (INDENT .. INDENT .. '|t2c1= |t2c2= |t2c3= |t2c4= |t2c5='),

--- a/lua/wikis/marvelrivals/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/marvelrivals/GetMatchGroupCopyPaste/wiki.lua
@@ -36,10 +36,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		casters and (INDENT .. '|caster1=|caster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		Logic.readBool(args.mvp) and (INDENT .. '|mvp=') or nil,

--- a/lua/wikis/naraka/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/naraka/GetMatchGroupCopyPaste/wiki.lua
@@ -31,10 +31,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|p_kill=1 |p1_kill=1.2',
 		INDENT .. '|p1=4 |p2=2.5 |p3=2 |p4=1.5 |p5=1.5 |p6=1 |p7=1 |p8=0.5 |p9=0.5 |p10=0.5',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/omegastrikers/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/omegastrikers/GetMatchGroupCopyPaste/wiki.lua
@@ -57,10 +57,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|date=',
 			INDENT .. '|twitch='
 		} or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function (mapIndex)
+		Array.mapRange(1, bestof, function (mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '=' .. WikiCopyPaste._getMap(opponents, args.pickBan, args.mapBestof)
 		end),
 		'}}'
@@ -96,8 +96,8 @@ end
 function WikiCopyPaste._pickBanParams(key, numberOfOpponents)
 	local shortKey = PARAM_TO_SHORT[key]
 	local limit = LIMIT_OF_PARAM[key]
-	local display = Array.map(Array.range(1, numberOfOpponents), function (opponentIndex)
-		return INDENT .. INDENT .. table.concat(Array.map(Array.range(1, limit), function (keyIndex)
+	local display = Array.mapRange(1, numberOfOpponents, function (opponentIndex)
+		return INDENT .. INDENT .. table.concat(Array.mapRange(1, limit, function (keyIndex)
 			return '|t' .. opponentIndex .. shortKey .. keyIndex .. '='
 		end))
 	end)

--- a/lua/wikis/osu/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/osu/GetMatchGroupCopyPaste/wiki.lua
@@ -40,11 +40,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Logic.readBool(args.mplinks) and (INDENT .. '|mplink=|mplink2=|mplink3=') or nil,
 		Logic.readBool(args.lazermplinks) and (INDENT .. '|lazermplink=|lazermplink2=|lazermplink3=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. BaseCopyPaste.getOpponent(mode, Logic.readBool(args.score))
 		end),
 		WikiCopyPaste._getVetoes(args, bestof),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|mode=|score1=|score2=|winner=}}'
 		end),
 		'}}'

--- a/lua/wikis/overwatch/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/overwatch/GetMatchGroupCopyPaste/wiki.lua
@@ -40,10 +40,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		casters and (INDENT .. '|caster1=|caster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), FnUtil.curry(WikiCopyPaste._getMapCode, hasBans)) or nil,
+		bestof ~= 0 and Array.mapRange(1, bestof, FnUtil.curry(WikiCopyPaste._getMapCode, hasBans)) or nil,
 		Logic.readBool(args.faceit) and (INDENT .. '|faceit=') or nil,
 		Logic.readBool(args.mvp) and (INDENT .. '|mvp=') or nil,
 		INDENT .. '}}'

--- a/lua/wikis/paladins/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/paladins/GetMatchGroupCopyPaste/wiki.lua
@@ -31,11 +31,11 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.showScore) and INDENT .. '|finished=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |twitch= |youtube= |vod=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex)
 		end),
 		'}}'

--- a/lua/wikis/pokemon/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/pokemon/GetMatchGroupCopyPaste/wiki.lua
@@ -32,7 +32,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		Logic.readBool(args.hasDate) and {
@@ -40,7 +40,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|twitch= |youtube=',
 			INDENT .. '|vod=',
 		} or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, bans)
 		end),
 		'}}'

--- a/lua/wikis/pubg/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/pubg/GetMatchGroupCopyPaste/wiki.lua
@@ -30,10 +30,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=10 |p2=6 |p3=5 |p4=4 |p5=3 |p6=2 |p7=1 |p8=1',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/pubgmobile/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/pubgmobile/GetMatchGroupCopyPaste/wiki.lua
@@ -30,10 +30,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=10 |p2=6 |p3=5 |p4=4 |p5=3 |p6=2 |p7=1 |p8=1',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|map=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/rainbowsix/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rainbowsix/GetMatchGroupCopyPaste/wiki.lua
@@ -74,7 +74,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		buildListLine(matchLinks, 1),
 		casters and (INDENT .. '|caster1=|caster2=') or nil,
 		mvps and (INDENT .. '|mvp=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end)
 	)
@@ -103,7 +103,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	end
 
 	local operatorBanParams = function(opponentIndex)
-		return INDENT .. INDENT .. table.concat(Array.map(Array.range(1, numberOfOperatorBans), function(banIndex)
+		return INDENT .. INDENT .. table.concat(Array.mapRange(1, numberOfOperatorBans, function(banIndex)
 			return '|t' .. opponentIndex .. 'ban' .. banIndex .. '='
 		end))
 	end

--- a/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rematch/GetMatchGroupCopyPaste/wiki.lua
@@ -31,12 +31,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|score1=|score2= |otlength= |finished=}}'
 		end),
 		'}}'

--- a/lua/wikis/rocketleague/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/rocketleague/GetMatchGroupCopyPaste/wiki.lua
@@ -42,10 +42,10 @@ end
 function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste._getOpponent(mode)
 		end),
-		Array.map(Array.range(1, bestof), WikiCopyPaste._getMapCode),
+		Array.mapRange(1, bestof, WikiCopyPaste._getMapCode),
 		INDENT .. '|finished=',
 		INDENT .. '|date=',
 		'}}',

--- a/lua/wikis/sideswipe/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/sideswipe/GetMatchGroupCopyPaste/wiki.lua
@@ -43,12 +43,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|finished=',
 		INDENT .. '|date=',
-		Array.map(Array.range(1, bestof), function (mapIndex)
+		Array.mapRange(1, bestof, function (mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '=' .. WikiCopyPaste._getMap()
 		end),
 		INDENT .. '}}'

--- a/lua/wikis/smash/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/smash/GetMatchGroupCopyPaste/wiki.lua
@@ -33,10 +33,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|bestof=' .. bestof,
 		INDENT .. '|date=',
 		INDENT .. '|twitch=|vod=',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. WikiCopyPaste._getMap(mode)
 		end),
 		'}}'

--- a/lua/wikis/smite/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/smite/GetMatchGroupCopyPaste/wiki.lua
@@ -33,14 +33,14 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match',
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		Logic.readBool(args.hasDate) and Array.extend(
 			INDENT .. '|date= |youtube= |twitch=',
 			args.vod == 'series' and (INDENT .. '|vod=') or nil
 		) or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, showBans, args.vod == 'maps')
 		end),
 		'}}'

--- a/lua/wikis/splatoon/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/splatoon/GetMatchGroupCopyPaste/wiki.lua
@@ -45,7 +45,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, displayScore)
 		end),
 		Logic.readBool(args.hasDate) and {

--- a/lua/wikis/splitgate/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/splitgate/GetMatchGroupCopyPaste/wiki.lua
@@ -33,7 +33,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		index == 1 and (INDENT .. '|bestof=' .. (bestof ~= 0 and bestof or '')) or nil,
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and {INDENT .. '|date=', INDENT .. '|twitch='} or {},
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end)
 	)

--- a/lua/wikis/tarkovarena/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/tarkovarena/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/teamfortress/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/teamfortress/GetMatchGroupCopyPaste/wiki.lua
@@ -32,13 +32,13 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend({},
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
 		stats and (INDENT .. '|etf2l=|rgl=|ozf=|tftv=') or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished= |logstf= |logstfgold=}}'
 		end),
 		'}}'

--- a/lua/wikis/tetris/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/tetris/GetMatchGroupCopyPaste/wiki.lua
@@ -37,7 +37,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 			INDENT .. '|date=',
 			INDENT .. '|youtube=|twitch='
 		} or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		'}}'

--- a/lua/wikis/tft/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/tft/GetMatchGroupCopyPaste/wiki.lua
@@ -50,10 +50,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Logic.readBool(args.casters) and (INDENT .. '|caster1=|caqster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
@@ -73,10 +73,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p1=8|p2=7|p3=6|p4=5|p5=4|p6=3|p7=2|p8=1',
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/thefinals/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/thefinals/GetMatchGroupCopyPaste/wiki.lua
@@ -49,10 +49,10 @@ function WikiCopyPaste.getStandardMatchCode(bestof, mode, index, opponents, args
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'
@@ -72,10 +72,10 @@ function WikiCopyPaste.getFfaMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p_kill=1 |p1=12 |p2=9 |p3=7 |p4=5 |p5=4 |p6=3 |p7=3 |p8=2 |p9=2 |p10=2 ' ..
 		INDENT .. '|twitch=|youtube=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/trackmania/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/trackmania/GetMatchGroupCopyPaste/wiki.lua
@@ -35,10 +35,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and (INDENT .. '|winner=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		bestof ~= 0 and Array.map(Array.range(1, bestof), function(mapIndex)
+		bestof ~= 0 and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/underlords/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/underlords/GetMatchGroupCopyPaste/wiki.lua
@@ -30,10 +30,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		'{{Match|finished=',
 		INDENT .. '|p1=14 |p2=12 |p3=10 |p4=8 |p5=6 |p6=4 |p7=2 |p8=0',
 		{INDENT .. '|twitch=|youtube='},
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|date=|finished=|vod=}}'
 		end),
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getFfaOpponent(mode, bestof)
 		end),
 		'}}'

--- a/lua/wikis/valorant/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/valorant/GetMatchGroupCopyPaste/wiki.lua
@@ -51,7 +51,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		INDENT .. '|date=',
 		streams and (INDENT .. '|twitch=|youtube=|vod=') or nil,
 		Logic.readBool(args.casters) and (INDENT .. '|caster1= |caster2=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end)
 	)
@@ -69,7 +69,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		)
 	end
 
-	Array.extendWith(lines, Array.map(Array.range(1, bestof), FnUtil.curry(WikiCopyPaste._getMap, args)))
+	Array.extendWith(lines, Array.mapRange(1, bestof, FnUtil.curry(WikiCopyPaste._getMap, args)))
 
 	Array.appendWith(lines,'}}')
 

--- a/lua/wikis/warthunder/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/warthunder/GetMatchGroupCopyPaste/wiki.lua
@@ -34,10 +34,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		showScore and (INDENT .. '|finished=') or nil,
 		INDENT .. '|date=',
 		Logic.readBool(args.streams) and (INDENT .. '|twitch=|youtube=|vod=') or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. opponent
 		end),
-		(not showScore) and Array.map(Array.range(1, bestof), function(mapIndex)
+		(not showScore) and Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|winner=}}'
 		end) or nil,
 		INDENT .. '}}'

--- a/lua/wikis/wildrift/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/wildrift/GetMatchGroupCopyPaste/wiki.lua
@@ -36,10 +36,10 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
 		Logic.readBool(args.hasDate) and INDENT .. '|date=' or nil,
 		Logic.readBool(args.hasTwitch) and INDENT .. '|twitch=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex, bans, kda)
 		end),
 		'}}'

--- a/lua/wikis/worldoftanks/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/worldoftanks/GetMatchGroupCopyPaste/wiki.lua
@@ -31,7 +31,7 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = {
 		'{{Match',
-		INDENT .. table.concat(Array.map(Array.range(1, opponents), function(opponentIndex)
+		INDENT .. table.concat(Array.mapRange(1, opponents, function(opponentIndex)
 			return '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end)),
 		INDENT .. '|date= |finished=',

--- a/lua/wikis/worldofwarcraft/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/worldofwarcraft/GetMatchGroupCopyPaste/wiki.lua
@@ -24,12 +24,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 	local lines = Array.extend(
 		'{{Match',
 		Logic.readBool(args.needsWinner) and INDENT .. '|winner=' or nil,
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date=',
 		INDENT .. '|twitch=|youtube=|vod=',
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return WikiCopyPaste._getMapCode(mapIndex)
 		end),
 		'}}'

--- a/lua/wikis/zula/GetMatchGroupCopyPaste/wiki.lua
+++ b/lua/wikis/zula/GetMatchGroupCopyPaste/wiki.lua
@@ -31,12 +31,12 @@ function WikiCopyPaste.getMatchCode(bestof, mode, index, opponents, args)
 
 	local lines = Array.extend(
 		'{{Match',
-		Array.map(Array.range(1, opponents), function(opponentIndex)
+		Array.mapRange(1, opponents, function(opponentIndex)
 			return INDENT .. '|opponent' .. opponentIndex .. '=' .. WikiCopyPaste.getOpponent(mode, showScore)
 		end),
 		INDENT .. '|date= |finished=',
 		streams and (INDENT .. '|twitch=|vod=') or nil,
-		Array.map(Array.range(1, bestof), function(mapIndex)
+		Array.mapRange(1, bestof, function(mapIndex)
 			return INDENT .. '|map' .. mapIndex .. '={{Map|map=|score1=|score2=|finished=}}'
 		end),
 		'}}'


### PR DESCRIPTION
## Summary
well pretty much explain by the title
changed all the usage of ```Array.map(Array.range``` to ```Array.mapRange``` on the GetMatchGroupCopyPaste/Wiki.lua

This pr also fix the luals error
## How did you test this change?
should be trivial enough though? i can try to test it 
